### PR TITLE
refactor: remove unused event_logging/batch endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ export KIROCC_MODEL_MAPPINGS='[{"anthropic":"my-model","kiro":"claude-sonnet-4.5
 | `GET /v1/models`                 | List available models                    |
 | `POST /v1/messages`              | Messages API (streaming / non-streaming) |
 | `POST /v1/messages/count_tokens` | Token count (approximate \*)             |
-| `POST /api/event_logging/batch`  | Event logging (stub, always returns OK)  |
 
 \* `count_tokens` uses the `cl100k_base` encoding from [tiktoken-go](https://github.com/pkoukk/tiktoken-go), which differs from Claude's actual tokenizer. The returned value is an approximation.
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -40,12 +40,3 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 	}
 	_, _ = w.Write([]byte("\n"))
 }
-
-func (s *Server) handleEventLogging(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.MarshalWrite(w, map[string]string{"status": "ok"}); err != nil {
-		slog.ErrorContext(r.Context(), "write event logging response failed", "err", err)
-		return
-	}
-	_, _ = w.Write([]byte("\n"))
-}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,5 +48,4 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /v1/models", s.handleModels)
 	s.mux.HandleFunc("POST /v1/messages/count_tokens", s.messages.HandleCountTokens)
 	s.mux.HandleFunc("POST /v1/messages", s.messages.HandleMessages)
-	s.mux.HandleFunc("POST /api/event_logging/batch", s.handleEventLogging)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -199,20 +199,6 @@ func TestCountTokens_EmptyMessages(t *testing.T) {
 	}
 }
 
-func TestEventLoggingBatch(t *testing.T) {
-	srv := newTestServer(t, "", nil)
-	defer srv.Close()
-
-	resp, err := http.Post(srv.URL+"/api/event_logging/batch", "application/json", strings.NewReader(`[]`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != 200 {
-		t.Fatalf("status = %d", resp.StatusCode)
-	}
-}
-
 func TestAPIKeyAuth_Missing(t *testing.T) {
 	srv := newTestServer(t, "secret", nil)
 	defer srv.Close()


### PR DESCRIPTION
## Summary

- Remove the unused `POST /api/event_logging/batch` stub endpoint
- Delete handler, route registration, test, and README entry

## Test plan

- [x] `make test` — all pass
- [x] `make lint` — 0 issues
- [x] `make build` — success