### PR TITLE
feat: shorten tool names exceeding 64 characters

### DIFF
--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -153,7 +153,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload, err := reqconv.BuildPayload(req, reqconv.BuildOptions{
+	payload, nameMap, err := reqconv.BuildPayload(req, reqconv.BuildOptions{
 		ProfileARN:     creds.ProfileARN,
 		ModelID:        kiroModel,
 		ConversationID: ccSessionID,
@@ -167,8 +167,9 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
 		return
 	}
+	reverseMap := nameMap.ReverseMap()
 
-	retryReason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 1)
+	retryReason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 1, reverseMap)
 	if retryReason == "" {
 		return
 	}
@@ -184,7 +185,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		// Clear IDs to break out of stuck conversation state.
 		payload.ConversationState.ConversationID = ""
 		payload.ConversationState.AgentContinuationID = ""
-		reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2)
+		reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2, reverseMap)
 		if reason == "" {
 			return
 		}
@@ -208,7 +209,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 	)
 	payload.ConversationState.ConversationID = ""
 	payload.ConversationState.AgentContinuationID = ""
-	if reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2); reason != "" {
+	if reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2, reverseMap); reason != "" {
 		WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: "+reason)
 	}
 }
@@ -216,7 +217,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 // callAndHandle calls the Kiro API and handles the response.
 // Returns a non-empty reason string if the request failed with a retryable invalidStateEvent
 // before the stream started (i.e., no bytes written to w yet). Returns "" on success or non-retryable error.
-func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req *anthropic.Request, payload *kiroproto.Payload, creds *auth.Credentials, model string, contextWindowSize int, thinking bool, attempt int) string {
+func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req *anthropic.Request, payload *kiroproto.Payload, creds *auth.Credentials, model string, contextWindowSize int, thinking bool, attempt int, toolNameMap map[string]string) string {
 	_, short := logging.TraceIDs(ctx)
 	capture := newUpstreamAttemptCapture(ctx, payload, model, thinking, req.Stream, attempt)
 
@@ -235,9 +236,9 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req 
 
 	var reason string
 	if req.Stream {
-		reason = s.handleStreamingResponse(ctx, w, apiResp, model, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture)
+		reason = s.handleStreamingResponse(ctx, w, apiResp, model, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture, toolNameMap)
 	} else {
-		reason = s.handleNonStreamingResponse(ctx, w, apiResp, model, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture)
+		reason = s.handleNonStreamingResponse(ctx, w, apiResp, model, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture, toolNameMap)
 	}
 	if reason == retryReasonEmptyVisibleEndTurn {
 		capture.logCapture(ctx, reason)

--- a/internal/app/messages/request.go
+++ b/internal/app/messages/request.go
@@ -36,7 +36,7 @@ func (s *Service) HandleCountTokens(w http.ResponseWriter, r *http.Request) {
 
 	ccSessionID := r.Header.Get(headerCCSessionID)
 
-	payload, err := reqconv.BuildPayload(req, reqconv.BuildOptions{ProfileARN: profileARN, ModelID: kiroModel, ConversationID: ccSessionID, Thinking: thinking, ThinkingBudget: 0, EnvState: s.envState})
+	payload, _, err := reqconv.BuildPayload(req, reqconv.BuildOptions{ProfileARN: profileARN, ModelID: kiroModel, ConversationID: ccSessionID, Thinking: thinking, ThinkingBudget: 0, EnvState: s.envState})
 	if err != nil {
 		WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
 		return

--- a/internal/app/messages/response.go
+++ b/internal/app/messages/response.go
@@ -15,12 +15,13 @@ import (
 
 const retryReasonEmptyVisibleEndTurn = "empty_visible_end_turn"
 
-func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWriter, apiResp *kiroclient.Response, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture) string {
+func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWriter, apiResp *kiroclient.Response, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture, toolNameMap map[string]string) string {
 	traceID, short := logging.TraceIDs(ctx)
 
 	gw := NewGateWriter(w)
 	sw := respconv.NewSSEWriter(ctx, gw, model, contextWindowSize, stopSequences, maxTokens, preCountedInputTokens)
 	sw.OnVisibleOutput = func() { gw.Promote() }
+	sw.SetToolNameMap(toolNameMap)
 
 	var streamErr bool
 	var localStop bool
@@ -118,9 +119,10 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 	return ""
 }
 
-func (s *Service) handleNonStreamingResponse(ctx context.Context, w http.ResponseWriter, apiResp *kiroclient.Response, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture) string {
+func (s *Service) handleNonStreamingResponse(ctx context.Context, w http.ResponseWriter, apiResp *kiroclient.Response, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture, toolNameMap map[string]string) string {
 	traceID, short := logging.TraceIDs(ctx)
 	acc := respconv.NewNonStreamingAccumulator(contextWindowSize, stopSequences, maxTokens, preCountedInputTokens)
+	acc.SetToolNameMap(toolNameMap)
 
 	var invalidReason string
 	var hasError bool

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -42,12 +42,13 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 	var cumulativeInputTokens, cumulativeOutputTokens int
 
 	for round := range maxToolSearchRounds {
-		payload, err := o.buildPayload(msgs)
+		payload, nameMap, err := o.buildPayload(msgs)
 		if err != nil {
 			slog.WarnContext(ctx, "tool search payload build error", "trace_id", short, "err", err)
 			writeStreamingOrJSONError(gw, sw, w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
 			return ""
 		}
+		sw.SetToolNameMap(nameMap.ReverseMap())
 
 		apiResp, err := o.service.client.GenerateAssistantResponse(ctx, o.creds.AccessToken, payload, o.creds.Region)
 		if err != nil {
@@ -141,7 +142,7 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 			sw.WriteToolSearchResult(srvToolUseID, results)
 		}
 
-		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr)
+		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr, nameMap)
 	}
 
 	// Max rounds reached without normal completion.
@@ -165,7 +166,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 	var normalExit bool
 
 	for round := range maxToolSearchRounds {
-		payload, err := o.buildPayload(msgs)
+		payload, nameMap, err := o.buildPayload(msgs)
 		if err != nil {
 			WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
 			return ""
@@ -180,6 +181,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 
 		acc := respconv.NewNonStreamingAccumulator(o.contextWindowSize, o.req.StopSequences, o.req.MaxTokens, 0)
 		acc.SetFilterToolName(toolsearch.KiroToolSearchName)
+		acc.SetToolNameMap(nameMap.ReverseMap())
 
 		var hasError bool
 		var foundToolSearch bool
@@ -260,7 +262,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 			})
 		}
 
-		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr)
+		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr, nameMap)
 	}
 
 	// Max rounds reached without normal completion.
@@ -309,16 +311,20 @@ func (o *toolSearchOrchestrator) executeSearch(ctx context.Context, short string
 
 // appendSearchMessages appends the server_tool_use + tool_result messages to the conversation.
 // On error, the tool_result contains the error message instead of tool references.
-func (o *toolSearchOrchestrator) appendSearchMessages(msgs []anthropic.Message, srvToolUseID string, searchInput map[string]any, results []string, searchErr error) []anthropic.Message {
+// Tool names in the result text are shortened via nameMap so Kiro sees consistent names.
+func (o *toolSearchOrchestrator) appendSearchMessages(msgs []anthropic.Message, srvToolUseID string, searchInput map[string]any, results []string, searchErr error, nameMap *reqconv.ToolNameMap) []anthropic.Message {
 	var resultContent anthropic.MessageContent
 	var isError bool
 	if searchErr != nil {
 		isError = true
 		resultContent = anthropic.MessageContent{Text: "tool search error: " + toolsearch.ErrorCode(searchErr)}
 	} else {
-		// Use text content so Kiro's tool_result conversion preserves the result.
-		// tool_reference blocks would be dropped by extractToolResultContentText.
-		resultContent = anthropic.MessageContent{Text: "Found tools: " + strings.Join(results, ", ")}
+		// Shorten tool names in the result text so Kiro sees names matching the tool schema.
+		shortened := make([]string, len(results))
+		for i, name := range results {
+			shortened[i] = nameMap.Shorten(name)
+		}
+		resultContent = anthropic.MessageContent{Text: "Found tools: " + strings.Join(shortened, ", ")}
 	}
 	return append(msgs,
 		anthropic.Message{
@@ -345,7 +351,7 @@ func buildSearchInput(query string, maxResults int) map[string]any {
 	return input
 }
 
-func (o *toolSearchOrchestrator) buildPayload(msgs []anthropic.Message) (*kiroproto.Payload, error) {
+func (o *toolSearchOrchestrator) buildPayload(msgs []anthropic.Message) (*kiroproto.Payload, *reqconv.ToolNameMap, error) {
 	tmpReq := *o.req
 	tmpReq.Messages = msgs
 	return reqconv.BuildPayload(&tmpReq, o.buildOpts)

--- a/internal/reqconv/build_payload.go
+++ b/internal/reqconv/build_payload.go
@@ -26,12 +26,11 @@ type BuildOptions struct {
 }
 
 // BuildPayload converts an Anthropic request into a Kiro API payload.
-func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payload, error) {
+func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payload, *ToolNameMap, error) {
+	nameMap := NewToolNameMap()
+
 	// 1. Build system prompt and convert tools.
-	systemPrompt, toolEntries, err := buildSystemAndTools(req, options.ToolSearchCtx)
-	if err != nil {
-		return nil, err
-	}
+	systemPrompt, toolEntries := buildSystemAndTools(req, options.ToolSearchCtx, nameMap)
 
 	// 2. Normalize and split messages.
 	hasTools := len(req.Tools) > 0
@@ -42,7 +41,7 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 	historyMsgs, lastMsg := splitMessages(msgs)
 
 	// 3. Build history and place system prompt.
-	history := buildHistory(historyMsgs, options.EnvState)
+	history := buildHistory(historyMsgs, options.EnvState, nameMap)
 	history, lastContent := placeSystemPrompt(systemPrompt, history, ExtractTextContent(lastMsg.Content), options.EnvState)
 
 	// 4. Build currentMessage.
@@ -73,32 +72,24 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 	if options.ProfileARN != "" {
 		payload.ProfileARN = options.ProfileARN
 	}
-	return payload, nil
+	return payload, nameMap, nil
 }
 
 // buildSystemAndTools extracts the system prompt and converts tools.
-func buildSystemAndTools(req *anthropic.Request, tsCtx *toolsearch.Context) (string, []kiroproto.ToolEntry, error) {
+func buildSystemAndTools(req *anthropic.Request, tsCtx *toolsearch.Context, nameMap *ToolNameMap) (string, []kiroproto.ToolEntry) {
 	systemPrompt := ExtractSystemPrompt(req.System)
 
 	var toolEntries []kiroproto.ToolEntry
 	if tsCtx != nil {
 		// Tool search mode: convert only active tools, inject ToolSearch tool.
-		var err error
-		toolEntries, err = ConvertTools(tsCtx.ActiveTools)
-		if err != nil {
-			return "", nil, err
-		}
+		toolEntries = ConvertTools(tsCtx.ActiveTools, nameMap)
 		toolEntries = ApplyToolCachePoints(tsCtx.ActiveTools, toolEntries)
 		toolEntries = append(toolEntries, toolsearch.KiroToolSearchEntry())
 	} else if len(req.Tools) > 0 {
-		var err error
-		toolEntries, err = ConvertTools(req.Tools)
-		if err != nil {
-			return "", nil, err
-		}
+		toolEntries = ConvertTools(req.Tools, nameMap)
 		toolEntries = ApplyToolCachePoints(req.Tools, toolEntries)
 	}
-	return systemPrompt, toolEntries, nil
+	return systemPrompt, toolEntries
 }
 
 // splitMessages splits normalized messages into history messages and the last message.
@@ -243,7 +234,7 @@ func extractToolUseIDs(msg anthropic.Message) []string {
 }
 
 // buildHistory converts normalized Anthropic messages to Kiro history entries.
-func buildHistory(msgs []anthropic.Message, envState *kiroproto.EnvState) []kiroproto.HistoryEntry {
+func buildHistory(msgs []anthropic.Message, envState *kiroproto.EnvState, nameMap *ToolNameMap) []kiroproto.HistoryEntry {
 	var history []kiroproto.HistoryEntry
 
 	for i, msg := range msgs {
@@ -278,6 +269,9 @@ func buildHistory(msgs []anthropic.Message, envState *kiroproto.EnvState) []kiro
 			// v3 captures show messageId must be stable across requests for the same
 			// assistant history entry. Using SHA1-based UUID ensures this.
 			allToolUses := ExtractToolUses(msg.Content)
+			for i := range allToolUses {
+				allToolUses[i].Name = nameMap.Shorten(allToolUses[i].Name)
+			}
 			var idSeedBuilder strings.Builder
 			idSeedBuilder.WriteString("assistant-msg:")
 			idSeedBuilder.WriteString(content)

--- a/internal/reqconv/build_payload_test.go
+++ b/internal/reqconv/build_payload_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func buildPayloadForTest(req *anthropic.Request, profileARN, modelID, conversationID string, thinking bool, thinkingBudget int, envState *kiroproto.EnvState) (*kiroproto.Payload, error) {
-	return BuildPayload(req, BuildOptions{
+	p, _, err := BuildPayload(req, BuildOptions{
 		ProfileARN:     profileARN,
 		ModelID:        modelID,
 		ConversationID: conversationID,
@@ -17,6 +17,7 @@ func buildPayloadForTest(req *anthropic.Request, profileARN, modelID, conversati
 		ThinkingBudget: thinkingBudget,
 		EnvState:       envState,
 	})
+	return p, err
 }
 
 func TestBuildPayload_SimpleMessage(t *testing.T) {
@@ -483,7 +484,7 @@ func TestBuildPayload_UsesProvidedConversationID(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
 		},
 	}
-	p, err := BuildPayload(req, BuildOptions{ModelID: "claude-sonnet-4.6", ConversationID: "session-abc-123"})
+	p, _, err := BuildPayload(req, BuildOptions{ModelID: "claude-sonnet-4.6", ConversationID: "session-abc-123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -499,7 +500,7 @@ func TestBuildPayload_EmptyConversationID(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
 		},
 	}
-	p, _ := BuildPayload(req, BuildOptions{ModelID: "claude-sonnet-4.6"})
+	p, _, _ := BuildPayload(req, BuildOptions{ModelID: "claude-sonnet-4.6"})
 	if p.ConversationState.ConversationID != "" {
 		t.Fatalf("got %q; want empty", p.ConversationState.ConversationID)
 	}

--- a/internal/reqconv/tool_name_map.go
+++ b/internal/reqconv/tool_name_map.go
@@ -1,0 +1,61 @@
+package reqconv
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+const maxToolNameLen = 64
+
+// ToolNameMap provides bidirectional mapping between original and shortened tool names.
+// All methods are safe to call on a nil receiver (no-op passthrough).
+type ToolNameMap struct {
+	toShort    map[string]string
+	toOriginal map[string]string
+}
+
+// NewToolNameMap creates a new ToolNameMap. Maps are lazily allocated on first use.
+func NewToolNameMap() *ToolNameMap {
+	return &ToolNameMap{}
+}
+
+// Shorten returns name as-is if <= 64 chars. Otherwise shortens, registers mapping,
+// and returns the shortened name. Safe to call on nil receiver.
+func (m *ToolNameMap) Shorten(name string) string {
+	if m == nil || len(name) <= maxToolNameLen {
+		return name
+	}
+	if short, ok := m.toShort[name]; ok {
+		return short
+	}
+	if m.toShort == nil {
+		m.toShort = make(map[string]string)
+		m.toOriginal = make(map[string]string)
+	}
+	h := sha256.Sum256([]byte(name))
+	short := name[:50] + "_" + hex.EncodeToString(h[:])[:13]
+	m.toShort[name] = short
+	m.toOriginal[short] = name
+	return short
+}
+
+// Restore returns the original name for a shortened name, or name itself if not mapped.
+// Safe to call on nil receiver.
+func (m *ToolNameMap) Restore(name string) string {
+	if m == nil {
+		return name
+	}
+	if orig, ok := m.toOriginal[name]; ok {
+		return orig
+	}
+	return name
+}
+
+// ReverseMap returns the short→original map for use in the response path.
+// Returns nil if no mappings exist.
+func (m *ToolNameMap) ReverseMap() map[string]string {
+	if m == nil || len(m.toOriginal) == 0 {
+		return nil
+	}
+	return m.toOriginal
+}

--- a/internal/reqconv/tool_name_map_test.go
+++ b/internal/reqconv/tool_name_map_test.go
@@ -1,0 +1,114 @@
+package reqconv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToolNameMap_Shorten_Short(t *testing.T) {
+	m := NewToolNameMap()
+	name := "get_weather"
+	if got := m.Shorten(name); got != name {
+		t.Fatalf("short name should pass through, got %q", got)
+	}
+}
+
+func TestToolNameMap_Shorten_Exact64(t *testing.T) {
+	m := NewToolNameMap()
+	name := strings.Repeat("a", 64)
+	if got := m.Shorten(name); got != name {
+		t.Fatal("64-char name should pass through")
+	}
+}
+
+func TestToolNameMap_Shorten_Long(t *testing.T) {
+	m := NewToolNameMap()
+	name := "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_network_request"
+	short := m.Shorten(name)
+	if len(short) != maxToolNameLen {
+		t.Fatalf("shortened name should be %d chars, got %d", maxToolNameLen, len(short))
+	}
+	if !strings.HasPrefix(short, name[:50]) {
+		t.Fatal("shortened name should start with first 50 chars of original")
+	}
+}
+
+func TestToolNameMap_Shorten_Deterministic(t *testing.T) {
+	m := NewToolNameMap()
+	name := strings.Repeat("x", 100)
+	a := m.Shorten(name)
+	b := m.Shorten(name)
+	if a != b {
+		t.Fatal("same input should produce same output")
+	}
+}
+
+func TestToolNameMap_Shorten_NilReceiver(t *testing.T) {
+	var m *ToolNameMap
+	long := strings.Repeat("a", 100)
+	if got := m.Shorten(long); got != long {
+		t.Fatal("nil receiver should return name unchanged")
+	}
+	if got := m.Shorten("short"); got != "short" {
+		t.Fatal("nil receiver should return short name unchanged")
+	}
+}
+
+func TestToolNameMap_Restore(t *testing.T) {
+	m := NewToolNameMap()
+	name := strings.Repeat("b", 80)
+	short := m.Shorten(name)
+	if got := m.Restore(short); got != name {
+		t.Fatalf("Restore(%q) = %q, want original", short, got)
+	}
+}
+
+func TestToolNameMap_Restore_Unknown(t *testing.T) {
+	m := NewToolNameMap()
+	if got := m.Restore("unknown"); got != "unknown" {
+		t.Fatal("unknown name should pass through")
+	}
+}
+
+func TestToolNameMap_Restore_NilReceiver(t *testing.T) {
+	var m *ToolNameMap
+	if got := m.Restore("anything"); got != "anything" {
+		t.Fatal("nil receiver should return name unchanged")
+	}
+}
+
+func TestToolNameMap_ReverseMap_Empty(t *testing.T) {
+	m := NewToolNameMap()
+	if got := m.ReverseMap(); got != nil {
+		t.Fatal("empty map should return nil")
+	}
+}
+
+func TestToolNameMap_ReverseMap_WithMappings(t *testing.T) {
+	m := NewToolNameMap()
+	name := strings.Repeat("c", 70)
+	short := m.Shorten(name)
+	rm := m.ReverseMap()
+	if rm == nil {
+		t.Fatal("should return non-nil map")
+	}
+	if rm[short] != name {
+		t.Fatal("reverse map should contain short→original")
+	}
+}
+
+func TestToolNameMap_LazyInit(t *testing.T) {
+	m := NewToolNameMap()
+	// Maps should be nil before first long name.
+	if m.toShort != nil || m.toOriginal != nil {
+		t.Fatal("maps should be nil before first use")
+	}
+	m.Shorten("short_name")
+	if m.toShort != nil {
+		t.Fatal("maps should stay nil for short names")
+	}
+	m.Shorten(strings.Repeat("z", 65))
+	if m.toShort == nil {
+		t.Fatal("maps should be initialized after first long name")
+	}
+}

--- a/internal/reqconv/tool_schema.go
+++ b/internal/reqconv/tool_schema.go
@@ -1,7 +1,6 @@
 package reqconv
 
 import (
-	"fmt"
 	"log/slog"
 	"maps"
 
@@ -9,9 +8,30 @@ import (
 	"github.com/d-kuro/kirocc/internal/kiroproto"
 )
 
-const (
-	maxToolNameLen = 64
-)
+// ConvertTools converts Anthropic tool definitions to Kiro tool entries.
+// Names exceeding 64 characters are shortened via nameMap.
+func ConvertTools(tools []anthropic.Tool, nameMap *ToolNameMap) []kiroproto.ToolEntry {
+	var entries []kiroproto.ToolEntry
+
+	for _, t := range tools {
+		name := nameMap.Shorten(t.Name)
+
+		desc := t.Description
+		if desc == "" {
+			desc = "Tool: " + t.Name
+		}
+
+		entries = append(entries, kiroproto.ToolEntry{
+			ToolSpecification: &kiroproto.ToolSpecification{
+				Name:        name,
+				Description: desc,
+				InputSchema: kiroproto.InputSchema{JSON: SanitizeJSONSchema(t.InputSchema)},
+			},
+		})
+	}
+
+	return entries
+}
 
 // unsupportedKeywords lists JSON Schema keywords that Kiro API rejects.
 var unsupportedKeywords = map[string]struct{}{
@@ -74,32 +94,6 @@ func ThinkingToolEntry() kiroproto.ToolEntry {
 			},
 		},
 	}
-}
-
-// ConvertTools converts Anthropic tool definitions to Kiro tool entries.
-func ConvertTools(tools []anthropic.Tool) ([]kiroproto.ToolEntry, error) {
-	var entries []kiroproto.ToolEntry
-
-	for _, t := range tools {
-		if len(t.Name) > maxToolNameLen {
-			return nil, fmt.Errorf("tool name %q exceeds %d characters", t.Name, maxToolNameLen)
-		}
-
-		desc := t.Description
-		if desc == "" {
-			desc = "Tool: " + t.Name
-		}
-
-		entries = append(entries, kiroproto.ToolEntry{
-			ToolSpecification: &kiroproto.ToolSpecification{
-				Name:        t.Name,
-				Description: desc,
-				InputSchema: kiroproto.InputSchema{JSON: SanitizeJSONSchema(t.InputSchema)},
-			},
-		})
-	}
-
-	return entries, nil
 }
 
 // SanitizeJSONSchema recursively removes fields that Kiro API rejects.

--- a/internal/reqconv/tool_schema_test.go
+++ b/internal/reqconv/tool_schema_test.go
@@ -21,10 +21,7 @@ func TestConvertTools_Basic(t *testing.T) {
 			},
 		},
 	}
-	entries, err := ConvertTools(tools)
-	if err != nil {
-		t.Fatal(err)
-	}
+	entries := ConvertTools(tools, nil)
 	if len(entries) != 1 {
 		t.Fatalf("got %d entries", len(entries))
 	}
@@ -36,10 +33,7 @@ func TestConvertTools_Basic(t *testing.T) {
 
 func TestConvertTools_EmptyDescription(t *testing.T) {
 	tools := []anthropic.Tool{{Name: "my_tool", InputSchema: map[string]any{}}}
-	entries, err := ConvertTools(tools)
-	if err != nil {
-		t.Fatal(err)
-	}
+	entries := ConvertTools(tools, nil)
 	if entries[0].ToolSpecification.Description != "Tool: my_tool" {
 		t.Fatalf("got %q", entries[0].ToolSpecification.Description)
 	}
@@ -48,20 +42,26 @@ func TestConvertTools_EmptyDescription(t *testing.T) {
 func TestConvertTools_LongDescription(t *testing.T) {
 	longDesc := strings.Repeat("x", 50001)
 	tools := []anthropic.Tool{{Name: "Bash", Description: longDesc, InputSchema: map[string]any{}}}
-	entries, err := ConvertTools(tools)
-	if err != nil {
-		t.Fatal(err)
-	}
+	entries := ConvertTools(tools, nil)
 	if entries[0].ToolSpecification.Description != longDesc {
 		t.Fatal("long description should be kept as-is")
 	}
 }
 
-func TestConvertTools_NameTooLong(t *testing.T) {
-	tools := []anthropic.Tool{{Name: strings.Repeat("a", 65), InputSchema: map[string]any{}}}
-	_, err := ConvertTools(tools)
-	if err == nil {
-		t.Fatal("expected error for long name")
+func TestConvertTools_LongNameShortened(t *testing.T) {
+	longName := strings.Repeat("a", 65)
+	tools := []anthropic.Tool{{Name: longName, InputSchema: map[string]any{}}}
+	nameMap := NewToolNameMap()
+	entries := ConvertTools(tools, nameMap)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries", len(entries))
+	}
+	short := entries[0].ToolSpecification.Name
+	if len(short) > maxToolNameLen {
+		t.Fatalf("shortened name still too long: %d chars", len(short))
+	}
+	if nameMap.Restore(short) != longName {
+		t.Fatal("reverse mapping failed")
 	}
 }
 

--- a/internal/respconv/event_accumulator.go
+++ b/internal/respconv/event_accumulator.go
@@ -81,6 +81,9 @@ type responseAccumulator struct {
 	// FilterToolName, when set, causes ProcessEvent to skip recording tool_use
 	// events with this name in HasToolUse/ToolCalls (used by tool search orchestrator).
 	FilterToolName string
+	// toolNameMap maps shortened tool names back to originals (short→original).
+	// When set, tool names from Kiro responses are restored before emitting to the client.
+	toolNameMap map[string]string
 }
 
 // newAccumulator creates a responseAccumulator with common initialization.
@@ -150,18 +153,23 @@ func (a *responseAccumulator) ProcessEvent(e kiroproto.Event) EventDelta {
 
 	case kiroproto.EventToolUse:
 		if e.ToolStop && !a.LocalStop {
+			// Restore original tool name if shortened.
+			toolName := e.ToolName
+			if mapped, ok := a.toolNameMap[toolName]; ok {
+				toolName = mapped
+			}
 			// Skip recording filtered tools (e.g. internal ToolSearch).
 			if a.FilterToolName != "" && e.ToolName == a.FilterToolName {
 				d.ToolStop = true
 				d.ToolUseID = e.ToolUseID
-				d.ToolName = e.ToolName
+				d.ToolName = toolName
 				d.ToolInput = e.ToolInput
 				return d
 			}
 			a.HasToolUse = true
 			tc := ToolCall{
 				ID:    e.ToolUseID,
-				Name:  e.ToolName,
+				Name:  toolName,
 				Input: e.ToolInput,
 			}
 			if !jsontext.Value(tc.Input).IsValid() {
@@ -180,7 +188,7 @@ func (a *responseAccumulator) ProcessEvent(e kiroproto.Event) EventDelta {
 			a.ToolCalls = append(a.ToolCalls, tc)
 			d.ToolStop = true
 			d.ToolUseID = e.ToolUseID
-			d.ToolName = e.ToolName
+			d.ToolName = toolName
 			d.ToolInput = e.ToolInput
 			if a.LocalStop {
 				d.StopSignal = true

--- a/internal/respconv/nonstreaming.go
+++ b/internal/respconv/nonstreaming.go
@@ -40,6 +40,11 @@ func (n *NonStreamingAccumulator) SetFilterToolName(name string) {
 	n.acc.FilterToolName = name
 }
 
+// SetToolNameMap sets the short→original tool name map for response remapping.
+func (n *NonStreamingAccumulator) SetToolNameMap(m map[string]string) {
+	n.acc.toolNameMap = m
+}
+
 // BuildResponse builds the final Anthropic response from accumulated events.
 func (n *NonStreamingAccumulator) BuildResponse(model string) (map[string]any, NonStreamingStats) {
 	return buildResponseFromAcc(&n.acc, model)

--- a/internal/respconv/streaming.go
+++ b/internal/respconv/streaming.go
@@ -329,12 +329,19 @@ func (s *SSEWriter) SetFilterToolName(name string) {
 	s.acc.FilterToolName = name
 }
 
+// SetToolNameMap sets the short→original tool name map for response remapping.
+func (s *SSEWriter) SetToolNameMap(m map[string]string) {
+	s.acc.toolNameMap = m
+}
+
 // ResetAccumulator replaces the internal accumulator with a fresh one,
 // preserving the SSEWriter's block index and started state for continuation.
 func (s *SSEWriter) ResetAccumulator(contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int) {
 	filterName := s.acc.FilterToolName
+	nameMap := s.acc.toolNameMap
 	s.acc = newAccumulator(contextWindowSize, stopSequences, maxTokens, preCountedInputTokens)
 	s.acc.FilterToolName = filterName
+	s.acc.toolNameMap = nameMap
 	s.activeType = ""
 }
 

--- a/internal/server/e2e_request_test.go
+++ b/internal/server/e2e_request_test.go
@@ -395,7 +395,7 @@ func TestE2E_SchemaSanitization(t *testing.T) {
 	}
 }
 
-func TestE2E_ToolNameValidation(t *testing.T) {
+func TestE2E_ToolNameShortening(t *testing.T) {
 	p1 := mustJSON(map[string]string{"content": "ok"})
 	client := &capturingClient{events: []any{"assistantResponseEvent", p1}}
 
@@ -412,7 +412,16 @@ func TestE2E_ToolNameValidation(t *testing.T) {
 	resp := postMessages(t, srv.URL, reqBody)
 	defer func() { _ = resp.Body.Close() }()
 
-	requireStatus(t, resp, 400)
+	requireStatus(t, resp, 200)
+	requireCaptured(t, client)
+
+	tools := client.captured.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext.Tools
+	if len(tools) == 0 {
+		t.Fatal("expected tools in payload")
+	}
+	if len(tools[0].ToolSpecification.Name) > 64 {
+		t.Fatalf("tool name should be shortened, got %d chars", len(tools[0].ToolSpecification.Name))
+	}
 }
 
 func TestE2E_MessageNormalization(t *testing.T) {


### PR DESCRIPTION
## Summary

- MCP tool names (e.g. `mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_network_request`) can exceed the Kiro backend's 64-character limit, causing `payload build error`
- Instead of rejecting with a hard error, introduce bidirectional name mapping: `name[:50] + "_" + sha256(name)[:13]` = 64 chars
- Names ≤ 64 chars pass through unchanged with zero overhead (lazy map initialization)
- Shortened names are sent to Kiro on the request path; original names are restored on the response path before returning to the Anthropic client
- Tool search history text also uses shortened names for consistency with tool schemas

## Test plan

- [x] `make test` — all existing tests pass
- [x] `make lint` — 0 issues
- [x] Updated `TestE2E_ToolNameValidation` → `TestE2E_ToolNameShortening` (65-char name now succeeds)
- [x] Added `TestConvertTools_LongNameShortened` for ConvertTools behavior
- [x] Added 11 unit tests for `ToolNameMap` (shortening, restore, nil receiver, lazy init, determinism)