### PR TITLE
fix: align request shape with kiro-cli v2.0.0

### DIFF
--- a/internal/app/messages/capture.go
+++ b/internal/app/messages/capture.go
@@ -55,19 +55,18 @@ type upstreamCapturedEvent struct {
 }
 
 type upstreamAttemptCapture struct {
-	traceID             string
-	attempt             int
-	model               string
-	thinking            bool
-	stream              bool
-	conversationID      string
-	agentContinuationID string
-	currentContentLen   int
-	toolCount           int
-	toolResultCount     int
-	requestBody         []byte
-	responseHeader      http.Header
-	events              []upstreamCapturedEvent
+	traceID           string
+	attempt           int
+	model             string
+	thinking          bool
+	stream            bool
+	conversationID    string
+	currentContentLen int
+	toolCount         int
+	toolResultCount   int
+	requestBody       []byte
+	responseHeader    http.Header
+	events            []upstreamCapturedEvent
 
 	assistantResponseEvents int
 	reasoningEvents         int
@@ -94,7 +93,6 @@ func newUpstreamAttemptCapture(ctx context.Context, payload *kiroproto.Payload, 
 	}
 
 	current := payload.ConversationState.CurrentMessage.UserInputMessage
-	agentContinuationID := payload.ConversationState.AgentContinuationID
 	currentContentLen := len(current.Content)
 	var toolCount int
 	var toolResultCount int
@@ -103,18 +101,17 @@ func newUpstreamAttemptCapture(ctx context.Context, payload *kiroproto.Payload, 
 		toolResultCount = len(current.UserInputMessageContext.ToolResults)
 	}
 	return &upstreamAttemptCapture{
-		traceID:             traceID,
-		attempt:             attempt,
-		model:               model,
-		thinking:            thinking,
-		stream:              stream,
-		conversationID:      payload.ConversationState.ConversationID,
-		agentContinuationID: agentContinuationID,
-		currentContentLen:   currentContentLen,
-		toolCount:           toolCount,
-		toolResultCount:     toolResultCount,
-		requestBody:         body,
-		toolUseNames:        make(map[string]int),
+		traceID:           traceID,
+		attempt:           attempt,
+		model:             model,
+		thinking:          thinking,
+		stream:            stream,
+		conversationID:    payload.ConversationState.ConversationID,
+		currentContentLen: currentContentLen,
+		toolCount:         toolCount,
+		toolResultCount:   toolResultCount,
+		requestBody:       body,
+		toolUseNames:      make(map[string]int),
 	}
 }
 
@@ -196,7 +193,6 @@ func (c *upstreamAttemptCapture) logAttrs() []any {
 	}
 	return []any{
 		"assistant_response_events", c.assistantResponseEvents,
-		"agent_continuation_id", c.agentContinuationID,
 		"current_content_len", c.currentContentLen,
 		"tool_count", c.toolCount,
 		"tool_result_count", c.toolResultCount,

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -126,7 +126,6 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 				ConversationID: ccSessionID,
 				Thinking:       thinking,
 				ThinkingBudget: thinkingBudget,
-				EnvState:       s.envState,
 				ToolSearchCtx:  tsCtx,
 			},
 			contextWindowSize: contextWindowSize,
@@ -159,7 +158,6 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		ConversationID: ccSessionID,
 		Thinking:       thinking,
 		ThinkingBudget: thinkingBudget,
-		EnvState:       s.envState,
 	})
 	if err != nil {
 		slog.WarnContext(r.Context(), "payload build error",
@@ -184,7 +182,6 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		)
 		// Clear IDs to break out of stuck conversation state.
 		payload.ConversationState.ConversationID = ""
-		payload.ConversationState.AgentContinuationID = ""
 		reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2, reverseMap)
 		if reason == "" {
 			return
@@ -208,7 +205,6 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		"reason", retryReason,
 	)
 	payload.ConversationState.ConversationID = ""
-	payload.ConversationState.AgentContinuationID = ""
 	if reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2, reverseMap); reason != "" {
 		WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: "+reason)
 	}

--- a/internal/app/messages/request.go
+++ b/internal/app/messages/request.go
@@ -36,7 +36,7 @@ func (s *Service) HandleCountTokens(w http.ResponseWriter, r *http.Request) {
 
 	ccSessionID := r.Header.Get(headerCCSessionID)
 
-	payload, _, err := reqconv.BuildPayload(req, reqconv.BuildOptions{ProfileARN: profileARN, ModelID: kiroModel, ConversationID: ccSessionID, Thinking: thinking, ThinkingBudget: 0, EnvState: s.envState})
+	payload, _, err := reqconv.BuildPayload(req, reqconv.BuildOptions{ProfileARN: profileARN, ModelID: kiroModel, ConversationID: ccSessionID, Thinking: thinking, ThinkingBudget: 0})
 	if err != nil {
 		WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
 		return

--- a/internal/app/messages/service.go
+++ b/internal/app/messages/service.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/d-kuro/kirocc/internal/auth"
 	"github.com/d-kuro/kirocc/internal/kiroclient"
-	"github.com/d-kuro/kirocc/internal/kiroproto"
 )
 
 // TokenGetter loads valid upstream credentials for a request.
@@ -15,16 +14,14 @@ type TokenGetter interface {
 
 // Service owns message execution and token counting flows.
 type Service struct {
-	auth     TokenGetter
-	client   kiroclient.Client
-	envState *kiroproto.EnvState
+	auth   TokenGetter
+	client kiroclient.Client
 }
 
 // New constructs a message service.
-func New(authMgr TokenGetter, client kiroclient.Client, envState *kiroproto.EnvState) *Service {
+func New(authMgr TokenGetter, client kiroclient.Client) *Service {
 	return &Service{
-		auth:     authMgr,
-		client:   client,
-		envState: envState,
+		auth:   authMgr,
+		client: client,
 	}
 }

--- a/internal/kiroclient/client.go
+++ b/internal/kiroclient/client.go
@@ -25,8 +25,8 @@ const (
 	maxRetries     = 3
 	baseRetryDelay = 1 * time.Second
 
-	userAgentValue    = "aws-sdk-rust/1.3.12 ua/2.1 api/codewhispererstreaming/0.1.13922 os/macos lang/rust/1.92.0 md/appVersion-1.26.2 app/AmazonQ-For-CLI"
-	amzUserAgentValue = "aws-sdk-rust/1.3.12 ua/2.1 api/codewhispererstreaming/0.1.13922 os/macos lang/rust/1.92.0 m/F app/AmazonQ-For-CLI"
+	userAgentValue    = "aws-sdk-rust/1.3.14 ua/2.1 api/codewhispererstreaming/0.1.14474 os/macos lang/rust/1.92.0 md/appVersion-2.0.0 app/AmazonQ-For-CLI"
+	amzUserAgentValue = "aws-sdk-rust/1.3.14 ua/2.1 api/codewhispererstreaming/0.1.14474 os/macos lang/rust/1.92.0 m/F app/AmazonQ-For-CLI"
 )
 
 // Client is the interface for calling the Kiro API.
@@ -112,7 +112,7 @@ func (c *HTTPClient) endpointURL(region string) string {
 	if c.baseURL != "" {
 		return c.baseURL
 	}
-	return fmt.Sprintf("https://q.%s.amazonaws.com/generateAssistantResponse", region)
+	return fmt.Sprintf("https://q.%s.amazonaws.com/", region)
 }
 
 // GenerateAssistantResponse sends a request to the Kiro API with retry logic.
@@ -156,7 +156,7 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 
 		req.Header.Set("Authorization", "Bearer "+currentToken)
 		req.Header.Set("Content-Type", "application/x-amz-json-1.0")
-		req.Header.Set("Accept", "application/vnd.amazon.eventstream")
+		req.Header.Set("Accept", "*/*")
 		req.Header.Set("X-Amz-Target", amzTarget)
 		req.Header.Set("User-Agent", userAgentValue)
 		req.Header.Set("x-amz-user-agent", amzUserAgentValue)

--- a/internal/kiroclient/client_test.go
+++ b/internal/kiroclient/client_test.go
@@ -66,7 +66,7 @@ func TestHTTPClient_CorrectHeaders(t *testing.T) {
 		if r.Header.Get("X-Amz-Target") != "AmazonCodeWhispererStreamingService.GenerateAssistantResponse" {
 			t.Errorf("wrong X-Amz-Target: %q", r.Header.Get("X-Amz-Target"))
 		}
-		if r.Header.Get("Accept") != "application/vnd.amazon.eventstream" {
+		if r.Header.Get("Accept") != "*/*" {
 			t.Errorf("wrong Accept: %q", r.Header.Get("Accept"))
 		}
 		w.WriteHeader(http.StatusOK)
@@ -219,7 +219,7 @@ func TestHTTPClient_EndpointURL(t *testing.T) {
 		region  string
 		want    string
 	}{
-		{"region-based", "", "us-west-2", "https://q.us-west-2.amazonaws.com/generateAssistantResponse"},
+		{"region-based", "", "us-west-2", "https://q.us-west-2.amazonaws.com/"},
 		{"override", "http://localhost:8080", "us-west-2", "http://localhost:8080"},
 	}
 	for _, tt := range tests {

--- a/internal/kiroproto/eventstream.go
+++ b/internal/kiroproto/eventstream.go
@@ -15,6 +15,7 @@ import (
 type Event struct {
 	Type         string // event type from header
 	Content      string // assistantResponseEvent → content field
+	ModelID      string // assistantResponseEvent → modelId field
 	ThinkingText string // reasoningContentEvent → text field
 	ToolName     string // toolUseEvent
 	ToolUseID    string
@@ -68,6 +69,7 @@ const (
 	EventInteractionComps   = "interactionComponentsEvent"
 	EventDryRunSucceed      = "dryRunSucceedEvent"
 	EventContextUsage       = "contextUsageEvent"
+	EventInitialResponse    = "initial-response"
 )
 
 // ParseStream reads AWS Event Stream binary frames from r and calls callback for each parsed Event.
@@ -120,11 +122,12 @@ func ParseStream(ctx context.Context, r io.Reader, callback func(Event) bool) er
 		case EventAssistantResponse:
 			var m struct {
 				Content string `json:"content"`
+				ModelID string `json:"modelId"`
 			}
 			if err := json.Unmarshal(payload, &m); err != nil {
 				return fmt.Errorf("decode %s: %w", eventType, err)
 			}
-			stop = callback(Event{Type: eventType, Content: m.Content})
+			stop = callback(Event{Type: eventType, Content: m.Content, ModelID: m.ModelID})
 
 		case EventReasoningContent:
 			var m struct {
@@ -238,7 +241,7 @@ func ParseStream(ctx context.Context, r io.Reader, callback func(Event) bool) er
 
 		case EventFollowupPrompt, EventCitation, EventCode, EventCodeReference,
 			EventSupplementaryLinks, EventIntents, EventInteractionComps,
-			EventDryRunSucceed:
+			EventDryRunSucceed, EventInitialResponse:
 			// Known no-op events — silently ignore.
 
 		default:

--- a/internal/kiroproto/eventstream_test.go
+++ b/internal/kiroproto/eventstream_test.go
@@ -27,13 +27,16 @@ func TestParseStream_SingleEvents(t *testing.T) {
 		{
 			name:      "assistantResponseEvent",
 			eventType: "assistantResponseEvent",
-			payload:   map[string]string{"content": "Hello, world!"},
+			payload:   map[string]string{"content": "Hello, world!", "modelId": "claude-opus-4.6-1m"},
 			check: func(t *testing.T, e Event) {
 				if e.Type != "assistantResponseEvent" {
 					t.Errorf("Type = %q", e.Type)
 				}
 				if e.Content != "Hello, world!" {
 					t.Errorf("Content = %q", e.Content)
+				}
+				if e.ModelID != "claude-opus-4.6-1m" {
+					t.Errorf("ModelID = %q, want %q", e.ModelID, "claude-opus-4.6-1m")
 				}
 			},
 		},

--- a/internal/kiroproto/types.go
+++ b/internal/kiroproto/types.go
@@ -23,12 +23,11 @@ type Payload struct {
 
 // ConversationState holds the conversation context for the Kiro API.
 type ConversationState struct {
-	ConversationID      string         `json:"conversationId,omitempty"`
-	AgentContinuationID string         `json:"agentContinuationId,omitempty"`
-	ChatTriggerType     string         `json:"chatTriggerType"`
-	AgentTaskType       string         `json:"agentTaskType"`
-	CurrentMessage      CurrentMessage `json:"currentMessage,omitzero"`
-	History             []HistoryEntry `json:"history,omitempty"`
+	ConversationID  string         `json:"conversationId,omitempty"`
+	ChatTriggerType string         `json:"chatTriggerType"`
+	AgentTaskType   string         `json:"agentTaskType"`
+	CurrentMessage  CurrentMessage `json:"currentMessage,omitzero"`
+	History         []HistoryEntry `json:"history,omitempty"`
 }
 
 // CurrentMessage wraps the current user input message.
@@ -46,15 +45,8 @@ type UserInputMessage struct {
 	CachePoint              *CachePoint              `json:"cachePoint,omitempty"`
 }
 
-// EnvState holds environment context sent with each request.
-type EnvState struct {
-	OperatingSystem         string `json:"operatingSystem,omitempty"`
-	CurrentWorkingDirectory string `json:"currentWorkingDirectory,omitempty"`
-}
-
-// UserInputMessageContext holds tools, tool results, and environment state.
+// UserInputMessageContext holds tools and tool results.
 type UserInputMessageContext struct {
-	EnvState    *EnvState    `json:"envState,omitempty"`
 	Tools       []ToolEntry  `json:"tools,omitempty"`
 	ToolResults []ToolResult `json:"toolResults,omitempty"`
 }

--- a/internal/reqconv/build_payload.go
+++ b/internal/reqconv/build_payload.go
@@ -21,7 +21,6 @@ type BuildOptions struct {
 	ConversationID string
 	Thinking       bool
 	ThinkingBudget int
-	EnvState       *kiroproto.EnvState
 	ToolSearchCtx  *toolsearch.Context
 }
 
@@ -41,8 +40,8 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 	historyMsgs, lastMsg := splitMessages(msgs)
 
 	// 3. Build history and place system prompt.
-	history := buildHistory(historyMsgs, options.EnvState, nameMap)
-	history, lastContent := placeSystemPrompt(systemPrompt, history, ExtractTextContent(lastMsg.Content), options.EnvState)
+	history := buildHistory(historyMsgs, nameMap)
+	history, lastContent := placeSystemPrompt(systemPrompt, history, ExtractTextContent(lastMsg.Content))
 
 	// 4. Build currentMessage.
 	// Extract tool_use IDs from the preceding assistant message for reordering tool results.
@@ -50,14 +49,11 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 	if len(historyMsgs) > 0 {
 		precedingToolUseIDs = extractToolUseIDs(historyMsgs[len(historyMsgs)-1])
 	}
-	userInputMessage := buildCurrentMessage(lastMsg, lastContent, options.ModelID, toolEntries, options.Thinking, options.ThinkingBudget, options.EnvState, precedingToolUseIDs)
+	userInputMessage := buildCurrentMessage(lastMsg, lastContent, options.ModelID, toolEntries, options.Thinking, options.ThinkingBudget, precedingToolUseIDs)
 
 	// 5. Apply cache points.
 	ApplySystemCachePoints(req.System, history, &userInputMessage)
 
-	// Find the last user-initiated message content (not tool-result continuations)
-	// to make agentContinuationID change per utterance but stable for continuations.
-	lastUserContent := findLastUserUtterance(msgs)
 	convState := kiroproto.ConversationState{
 		ConversationID:  options.ConversationID,
 		ChatTriggerType: kiroproto.ChatTriggerTypeManual,
@@ -67,7 +63,6 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 	if len(history) > 0 {
 		convState.History = history
 	}
-	convState.AgentContinuationID = buildAgentContinuationID(options.ConversationID, lastUserContent)
 	payload := &kiroproto.Payload{ConversationState: convState}
 	if options.ProfileARN != "" {
 		payload.ProfileARN = options.ProfileARN
@@ -113,26 +108,26 @@ func splitMessages(msgs []anthropic.Message) (history []anthropic.Message, last 
 // in every request.
 const syntheticAck = "I will fully incorporate this information when generating my responses, and explicitly acknowledge relevant parts of the summary when answering questions."
 
+// syntheticAckMessageID is a deterministic UUID for the synthetic ack, computed once since the input is constant.
+var syntheticAckMessageID = uuid.NewSHA1(uuid.NameSpaceURL, []byte("synthetic-ack:"+syntheticAck)).String()
+
 // placeSystemPrompt inserts the system prompt as a dedicated history entry pair
 // (user message + synthetic assistant ack), matching the v2 kiro-cli structure.
 // v2 captures show this pair is present in every request, even the first one.
 // Returns a new history slice (original is not mutated) and the updated lastContent.
-func placeSystemPrompt(systemPrompt string, history []kiroproto.HistoryEntry, lastContent string, envState *kiroproto.EnvState) ([]kiroproto.HistoryEntry, string) {
+func placeSystemPrompt(systemPrompt string, history []kiroproto.HistoryEntry, lastContent string) ([]kiroproto.HistoryEntry, string) {
 	if systemPrompt == "" {
 		return history, lastContent
 	}
 	// Always build the system prompt pair: user message + synthetic assistant ack.
-	// v2 captures show envState is present on ALL user messages, including the system prompt entry.
 	systemPair := []kiroproto.HistoryEntry{
 		{UserInputMessage: &kiroproto.HistoryUserInputMessage{
 			Content: systemPrompt,
 			Origin:  kiroproto.OriginKiroCLI,
-			UserInputMessageContext: &kiroproto.UserInputMessageContext{
-				EnvState: envState,
-			},
 		}},
 		{AssistantResponseMessage: &kiroproto.AssistantResponseMessage{
-			Content: syntheticAck,
+			MessageID: syntheticAckMessageID,
+			Content:   syntheticAck,
 		}},
 	}
 	newHistory := make([]kiroproto.HistoryEntry, 0, len(systemPair)+len(history))
@@ -142,26 +137,26 @@ func placeSystemPrompt(systemPrompt string, history []kiroproto.HistoryEntry, la
 }
 
 // buildCurrentMessage constructs the Kiro UserInputMessage from the last Anthropic message.
-func buildCurrentMessage(lastMsg anthropic.Message, lastContent, modelID string, toolEntries []kiroproto.ToolEntry, thinking bool, thinkingBudget int, envState *kiroproto.EnvState, precedingToolUseIDs []string) kiroproto.UserInputMessage {
+func buildCurrentMessage(lastMsg anthropic.Message, lastContent, modelID string, toolEntries []kiroproto.ToolEntry, thinking bool, thinkingBudget int, precedingToolUseIDs []string) kiroproto.UserInputMessage {
 	msg := kiroproto.UserInputMessage{
 		Content: lastContent,
 		ModelID: modelID,
 		Origin:  kiroproto.OriginKiroCLI,
 	}
 
-	// Add tools, tool results, and env state to context.
+	// Add tools and tool results to context.
 	toolResults := ExtractToolResults(lastMsg.Content)
 	toolResults = ReorderToolResults(toolResults, precedingToolUseIDs)
-	ctx := &kiroproto.UserInputMessageContext{
-		EnvState: envState,
+	if len(toolEntries) > 0 || len(toolResults) > 0 {
+		ctx := &kiroproto.UserInputMessageContext{}
+		if len(toolEntries) > 0 {
+			ctx.Tools = toolEntries
+		}
+		if len(toolResults) > 0 {
+			ctx.ToolResults = toolResults
+		}
+		msg.UserInputMessageContext = ctx
 	}
-	if len(toolEntries) > 0 {
-		ctx.Tools = toolEntries
-	}
-	if len(toolResults) > 0 {
-		ctx.ToolResults = toolResults
-	}
-	msg.UserInputMessageContext = ctx
 
 	// Match the observed kiro-cli continuation shape:
 	// tool-result-only turns keep empty currentMessage.content instead of "Continue".
@@ -193,32 +188,6 @@ func buildCurrentMessage(lastMsg anthropic.Message, lastContent, modelID string,
 	return msg
 }
 
-// buildAgentContinuationID generates a deterministic agent continuation ID.
-// v2 captures show this changes per user utterance but stays the same for
-// tool-result continuations within the same utterance.
-func buildAgentContinuationID(conversationID, lastUserContent string) string {
-	if conversationID == "" {
-		return ""
-	}
-	return uuid.NewSHA1(uuid.NameSpaceURL, []byte("agent-continuation:"+conversationID+":"+lastUserContent)).String()
-}
-
-// findLastUserUtterance returns the text content of the last user message that
-// is a real utterance (has non-empty text content, not a tool-result-only continuation).
-// This is used to make agentContinuationID change per utterance but stay stable
-// for tool-result continuations within the same utterance.
-func findLastUserUtterance(msgs []anthropic.Message) string {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == "user" {
-			text := ExtractTextContent(msgs[i].Content)
-			if text != "" {
-				return text
-			}
-		}
-	}
-	return ""
-}
-
 // extractToolUseIDs returns the IDs of all tool_use blocks in a message's content.
 func extractToolUseIDs(msg anthropic.Message) []string {
 	if msg.Content.IsString() {
@@ -234,7 +203,7 @@ func extractToolUseIDs(msg anthropic.Message) []string {
 }
 
 // buildHistory converts normalized Anthropic messages to Kiro history entries.
-func buildHistory(msgs []anthropic.Message, envState *kiroproto.EnvState, nameMap *ToolNameMap) []kiroproto.HistoryEntry {
+func buildHistory(msgs []anthropic.Message, nameMap *ToolNameMap) []kiroproto.HistoryEntry {
 	var history []kiroproto.HistoryEntry
 
 	for i, msg := range msgs {
@@ -254,12 +223,10 @@ func buildHistory(msgs []anthropic.Message, envState *kiroproto.EnvState, nameMa
 			if len(toolResults) > 1 && i > 0 && msgs[i-1].Role == "assistant" {
 				toolResults = ReorderToolResults(toolResults, extractToolUseIDs(msgs[i-1]))
 			}
-			if envState != nil || len(toolResults) > 0 {
-				ctx := &kiroproto.UserInputMessageContext{EnvState: envState}
-				if len(toolResults) > 0 {
-					ctx.ToolResults = toolResults
+			if len(toolResults) > 0 {
+				userMsg.UserInputMessageContext = &kiroproto.UserInputMessageContext{
+					ToolResults: toolResults,
 				}
-				userMsg.UserInputMessageContext = ctx
 			}
 			history = append(history, kiroproto.HistoryEntry{UserInputMessage: userMsg})
 

--- a/internal/reqconv/build_payload_test.go
+++ b/internal/reqconv/build_payload_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/d-kuro/kirocc/internal/kiroproto"
 )
 
-func buildPayloadForTest(req *anthropic.Request, profileARN, modelID, conversationID string, thinking bool, thinkingBudget int, envState *kiroproto.EnvState) (*kiroproto.Payload, error) {
+func buildPayloadForTest(req *anthropic.Request, profileARN, modelID, conversationID string, thinking bool, thinkingBudget int) (*kiroproto.Payload, error) {
 	p, _, err := BuildPayload(req, BuildOptions{
 		ProfileARN:     profileARN,
 		ModelID:        modelID,
 		ConversationID: conversationID,
 		Thinking:       thinking,
 		ThinkingBudget: thinkingBudget,
-		EnvState:       envState,
 	})
 	return p, err
 }
@@ -27,7 +26,7 @@ func TestBuildPayload_SimpleMessage(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "arn:test", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "arn:test", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,9 +49,6 @@ func TestBuildPayload_SimpleMessage(t *testing.T) {
 	if len(cs.History) != 0 {
 		t.Fatalf("history should be empty, got %d", len(cs.History))
 	}
-	if cs.AgentContinuationID == "" {
-		t.Fatal("agentContinuationId should always be set")
-	}
 }
 
 func TestBuildPayload_SystemPromptInHistory(t *testing.T) {
@@ -65,7 +61,7 @@ func TestBuildPayload_SystemPromptInHistory(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "How are you?"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +105,7 @@ func TestBuildPayload_SystemPromptNoHistory(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +133,7 @@ func TestBuildPayload_LastAssistant(t *testing.T) {
 			{Role: "assistant", Content: anthropic.MessageContent{Text: "Hi there"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +173,7 @@ func TestBuildPayload_ToolUseFlow(t *testing.T) {
 			},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,9 +194,6 @@ func TestBuildPayload_ToolUseFlow(t *testing.T) {
 	}
 	if cs.CurrentMessage.UserInputMessage.Content != "" {
 		t.Fatalf("currentMessage.content = %q, want empty", cs.CurrentMessage.UserInputMessage.Content)
-	}
-	if cs.AgentContinuationID == "" {
-		t.Fatal("agentContinuationId should be set for continuation request")
 	}
 	// History should have assistant with toolUses.
 	if len(cs.History) != 2 {
@@ -242,7 +235,7 @@ func TestBuildPayload_ThinkingXML_ToolResultOnly(t *testing.T) {
 			},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 10000, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 10000)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,52 +246,6 @@ func TestBuildPayload_ThinkingXML_ToolResultOnly(t *testing.T) {
 	}
 }
 
-func TestBuildPayload_AgentContinuationID_Deterministic(t *testing.T) {
-	req := &anthropic.Request{
-		Model: "claude-sonnet-4-6",
-		Tools: []anthropic.Tool{
-			{Name: "get_weather", Description: "Get weather", InputSchema: map[string]any{"type": "object"}},
-		},
-		Messages: []anthropic.Message{
-			{Role: "user", Content: anthropic.MessageContent{Text: "Weather?"}},
-			{
-				Role: "assistant",
-				Content: anthropic.MessageContent{
-					Blocks: []anthropic.ContentBlock{
-						{Type: "tool_use", ID: "toolu_01", Name: "get_weather", Input: map[string]any{"city": "Tokyo"}},
-					},
-				},
-			},
-			{
-				Role: "user",
-				Content: anthropic.MessageContent{
-					Blocks: []anthropic.ContentBlock{
-						{Type: "tool_result", ToolUseID: "toolu_01", Content: anthropic.MessageContent{Text: "Sunny"}},
-					},
-				},
-			},
-		},
-	}
-
-	p1, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p2, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	id1 := p1.ConversationState.AgentContinuationID
-	id2 := p2.ConversationState.AgentContinuationID
-	if id1 == "" || id2 == "" {
-		t.Fatalf("agentContinuationIds should be set, got %q / %q", id1, id2)
-	}
-	if id1 != id2 {
-		t.Fatalf("agentContinuationId should be deterministic: %q vs %q", id1, id2)
-	}
-}
-
 func TestBuildPayload_ThinkingMode(t *testing.T) {
 	req := &anthropic.Request{
 		Model: "claude-sonnet-4-6",
@@ -306,7 +253,7 @@ func TestBuildPayload_ThinkingMode(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Think about this."}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +287,7 @@ func TestBuildPayload_ThinkingMode_NoThinking(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +309,7 @@ func TestBuildPayload_EmptyProfileARN(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +348,7 @@ func TestBuildPayload_ThinkingInHistory(t *testing.T) {
 			{Name: "bash", Description: "Run bash", InputSchema: map[string]any{"type": "object"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +402,7 @@ func TestBuildPayload_ThinkingPendingToCurrentMessage(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Follow up"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", true, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +500,7 @@ func TestBuildPayload_Doc09_FullExample(t *testing.T) {
 		},
 	}
 
-	payload, err := buildPayloadForTest(req, "arn:aws:codewhisperer:us-east-1:123456789:profile/example", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "arn:aws:codewhisperer:us-east-1:123456789:profile/example", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -566,9 +513,6 @@ func TestBuildPayload_Doc09_FullExample(t *testing.T) {
 	// tool_result-only continuation should keep empty currentMessage.content.
 	if cs.CurrentMessage.UserInputMessage.Content != "" {
 		t.Fatalf("currentMessage.content = %q, want empty", cs.CurrentMessage.UserInputMessage.Content)
-	}
-	if cs.AgentContinuationID == "" {
-		t.Fatal("agentContinuationId should be set for tool-result continuation")
 	}
 	// Tool results
 	ctx := cs.CurrentMessage.UserInputMessage.UserInputMessageContext
@@ -629,34 +573,7 @@ func TestBuildPayload_Doc09_FullExample(t *testing.T) {
 	}
 }
 
-func TestBuildPayload_EnvStateInjected(t *testing.T) {
-	req := &anthropic.Request{
-		Model: "claude-sonnet-4-6",
-		Messages: []anthropic.Message{
-			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
-		},
-	}
-	envState := &kiroproto.EnvState{
-		OperatingSystem:         "linux",
-		CurrentWorkingDirectory: "/test/dir",
-	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, envState)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx := payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext
-	if ctx == nil {
-		t.Fatal("expected UserInputMessageContext")
-	}
-	if ctx.EnvState != envState {
-		t.Fatal("envState not injected")
-	}
-	if ctx.EnvState.OperatingSystem != "linux" {
-		t.Fatalf("OS = %q, want linux", ctx.EnvState.OperatingSystem)
-	}
-}
-
-func TestBuildPayload_EnvStateInHistory(t *testing.T) {
+func TestBuildPayload_NoContextWhenNoToolsOrResults(t *testing.T) {
 	req := &anthropic.Request{
 		Model: "claude-sonnet-4-6",
 		Messages: []anthropic.Message{
@@ -665,43 +582,17 @@ func TestBuildPayload_EnvStateInHistory(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "How are you?"}},
 		},
 	}
-	envState := &kiroproto.EnvState{
-		OperatingSystem:         "macos",
-		CurrentWorkingDirectory: "/test",
-	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, envState)
-	if err != nil {
-		t.Fatal(err)
-	}
-	h0 := payload.ConversationState.History[0].UserInputMessage
-	if h0.UserInputMessageContext == nil {
-		t.Fatal("history user message should have UserInputMessageContext with envState")
-	}
-	if h0.UserInputMessageContext.EnvState != envState {
-		t.Fatal("history user message envState mismatch")
-	}
-}
-
-func TestBuildPayload_EnvStateNil(t *testing.T) {
-	req := &anthropic.Request{
-		Model: "claude-sonnet-4-6",
-		Messages: []anthropic.Message{
-			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
-			{Role: "assistant", Content: anthropic.MessageContent{Text: "Hi"}},
-			{Role: "user", Content: anthropic.MessageContent{Text: "How are you?"}},
-		},
-	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	h0 := payload.ConversationState.History[0].UserInputMessage
 	if h0.UserInputMessageContext != nil {
-		t.Fatal("history user message should not have UserInputMessageContext when envState is nil and no toolResults")
+		t.Fatal("history user message should not have UserInputMessageContext when no tools or toolResults")
 	}
 }
 
-func TestBuildPayload_EnvStateNilWithToolResults(t *testing.T) {
+func TestBuildPayload_ToolResultsInHistory(t *testing.T) {
 	req := &anthropic.Request{
 		Model: "claude-sonnet-4-6",
 		Tools: []anthropic.Tool{
@@ -723,20 +614,17 @@ func TestBuildPayload_EnvStateNilWithToolResults(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "Thanks"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// history[2] is the user message with tool_result — should have ToolResults but no EnvState.
+	// history[2] is the user message with tool_result — should have ToolResults.
 	h2 := payload.ConversationState.History[2].UserInputMessage
 	if h2 == nil {
 		t.Fatal("history[2] should be user message")
 	}
 	if h2.UserInputMessageContext == nil {
 		t.Fatal("history[2] should have UserInputMessageContext for toolResults")
-	}
-	if h2.UserInputMessageContext.EnvState != nil {
-		t.Fatal("envState should be nil when not provided")
 	}
 	if len(h2.UserInputMessageContext.ToolResults) != 1 {
 		t.Fatalf("toolResults len = %d, want 1", len(h2.UserInputMessageContext.ToolResults))
@@ -752,7 +640,7 @@ func TestBuildPayload_AssistantMessageID(t *testing.T) {
 			{Role: "user", Content: anthropic.MessageContent{Text: "How are you?"}},
 		},
 	}
-	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0, nil)
+	payload, err := buildPayloadForTest(req, "", "claude-sonnet-4.6", "conv-test", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +657,7 @@ func TestPlaceSystemPrompt_InjectsIntoHistory(t *testing.T) {
 	history := []kiroproto.HistoryEntry{
 		{UserInputMessage: &kiroproto.HistoryUserInputMessage{Content: "hello"}},
 	}
-	newHistory, last := placeSystemPrompt("System", history, "current", &kiroproto.EnvState{OperatingSystem: "macos"})
+	newHistory, last := placeSystemPrompt("System", history, "current")
 	if last != "current" {
 		t.Fatalf("lastContent changed: %q", last)
 	}
@@ -783,6 +671,9 @@ func TestPlaceSystemPrompt_InjectsIntoHistory(t *testing.T) {
 	if newHistory[1].AssistantResponseMessage == nil || newHistory[1].AssistantResponseMessage.Content != syntheticAck {
 		t.Fatal("history[1] should be synthetic ack")
 	}
+	if newHistory[1].AssistantResponseMessage.MessageID == "" {
+		t.Fatal("synthetic ack should have a non-empty MessageID")
+	}
 	if newHistory[2].UserInputMessage.Content != "hello" {
 		t.Fatalf("history[2] = %q", newHistory[2].UserInputMessage.Content)
 	}
@@ -793,7 +684,7 @@ func TestPlaceSystemPrompt_InjectsIntoHistory(t *testing.T) {
 }
 
 func TestPlaceSystemPrompt_NoHistory(t *testing.T) {
-	newHistory, last := placeSystemPrompt("System", nil, "current", &kiroproto.EnvState{OperatingSystem: "macos"})
+	newHistory, last := placeSystemPrompt("System", nil, "current")
 	if last != "current" {
 		t.Fatalf("last = %q", last)
 	}
@@ -807,13 +698,16 @@ func TestPlaceSystemPrompt_NoHistory(t *testing.T) {
 	if newHistory[1].AssistantResponseMessage == nil || newHistory[1].AssistantResponseMessage.Content != syntheticAck {
 		t.Fatal("history[1] should be synthetic ack")
 	}
+	if newHistory[1].AssistantResponseMessage.MessageID == "" {
+		t.Fatal("synthetic ack should have a non-empty MessageID")
+	}
 }
 
 func TestPlaceSystemPrompt_EmptySystem(t *testing.T) {
 	history := []kiroproto.HistoryEntry{
 		{UserInputMessage: &kiroproto.HistoryUserInputMessage{Content: "hello"}},
 	}
-	newHistory, last := placeSystemPrompt("", history, "current", nil)
+	newHistory, last := placeSystemPrompt("", history, "current")
 	if last != "current" {
 		t.Fatalf("last = %q", last)
 	}

--- a/internal/server/e2e_response_test.go
+++ b/internal/server/e2e_response_test.go
@@ -453,7 +453,7 @@ func TestE2E_EmptyVisibleEndTurn_NonStreaming_RetryAlsoFails(t *testing.T) {
 }
 
 func TestE2E_EmptyVisibleEndTurn_RetryClearsIDs(t *testing.T) {
-	// Verify that retry clears ConversationID and AgentContinuationID.
+	// Verify that retry clears ConversationID.
 	thinkingOnly := []any{
 		"assistantResponseEvent", mustJSON(map[string]string{"content": "<thinking>Let me think</thinking>"}),
 		"metadataEvent", mustJSON(map[string]any{
@@ -481,9 +481,6 @@ func TestE2E_EmptyVisibleEndTurn_RetryClearsIDs(t *testing.T) {
 	// so we verify the final state has cleared IDs.
 	if client.payloads[1].ConversationState.ConversationID != "" {
 		t.Fatalf("attempt-2 ConversationID should be empty, got %q", client.payloads[1].ConversationState.ConversationID)
-	}
-	if client.payloads[1].ConversationState.AgentContinuationID != "" {
-		t.Fatalf("attempt-2 AgentContinuationID should be empty, got %q", client.payloads[1].ConversationState.AgentContinuationID)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,12 +2,9 @@ package server
 
 import (
 	"net/http"
-	"os"
-	"runtime"
 
 	messagesapp "github.com/d-kuro/kirocc/internal/app/messages"
 	"github.com/d-kuro/kirocc/internal/kiroclient"
-	"github.com/d-kuro/kirocc/internal/kiroproto"
 	"github.com/d-kuro/kirocc/internal/tracing"
 )
 
@@ -33,20 +30,10 @@ type Server struct {
 
 // New creates a new Server.
 func New(authMgr messagesapp.TokenGetter, apiKey string, client kiroclient.Client, opts ...ServerOption) *Server {
-	cwd, _ := os.Getwd()
-	osName := runtime.GOOS
-	if osName == "darwin" {
-		osName = "macos"
-	}
-
-	envState := &kiroproto.EnvState{
-		OperatingSystem:         osName,
-		CurrentWorkingDirectory: cwd,
-	}
 	s := &Server{
 		apiKey:   apiKey,
 		mux:      http.NewServeMux(),
-		messages: messagesapp.New(authMgr, client, envState),
+		messages: messagesapp.New(authMgr, client),
 	}
 	for _, opt := range opts {
 		opt(s)


### PR DESCRIPTION
## Summary

- Captured real kiro-cli v2.0.0 HTTPS traffic using mitmdump and compared against kirocc proxy output
- Fixed 8 discrepancies to match the actual request/response shape

## Changes

### HTTP layer
- Change endpoint URL from `/generateAssistantResponse` to root `/`
- Change `Accept` header from `application/vnd.amazon.eventstream` to `*/*`
- Update User-Agent version strings to match v2.0.0 (`aws-sdk-rust/1.3.14`, `appVersion-2.0.0`)

### Payload layer
- Remove `agentContinuationId` field — kiro-cli v2.0.0 does not send it
- Remove `envState` field — kiro-cli v2.0.0 does not send it
- Add deterministic `messageId` to synthetic ack in history
- Omit `userInputMessageContext` entirely when no tools/toolResults present (instead of sending empty `{}`)

### Response layer
- Parse `modelId` from `assistantResponseEvent` into `Event.ModelID`
- Add `initial-response` to known no-op event types (suppresses warning log)

## Test plan
- [x] `make test` — all packages pass with `-race`
- [x] `make lint` — 0 issues