### PR TITLE
refactor: remove dead code and simplify idle reader wrapping

### DIFF
--- a/cmd/kirocc/main.go
+++ b/cmd/kirocc/main.go
@@ -5,9 +5,11 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -88,7 +90,7 @@ func main() {
 	// Eagerly initialize tiktoken so the first API request doesn't block on BPE data fetch.
 	go tokencount.Preload()
 
-	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
 	if cfg.APIKey == "" && cfg.Host != "127.0.0.1" && cfg.Host != "localhost" && cfg.Host != "::1" {
 		slog.Warn("server is binding to a non-loopback address without an API key — all endpoints are unauthenticated",
 			"host", cfg.Host)

--- a/internal/app/messages/errors.go
+++ b/internal/app/messages/errors.go
@@ -1,9 +1,13 @@
 package messages
 
 import (
+	"context"
 	"encoding/json/v2"
+	"errors"
 	"log/slog"
 	"net/http"
+
+	"github.com/d-kuro/kirocc/internal/kiroclient"
 )
 
 // Anthropic API error type constants.
@@ -34,6 +38,23 @@ func handleUpstreamError(w http.ResponseWriter, isException bool, invalidReason 
 	}
 	WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: request rejected by upstream")
 	return ""
+}
+
+// logUpstreamError logs a "kiro api error" with structured attributes when the
+// error is an *UpstreamError. Falls back to plain err logging otherwise.
+func logUpstreamError(ctx context.Context, short string, err error, extra ...any) {
+	attrs := []any{"trace_id", short, "err", err}
+	attrs = append(attrs, extra...)
+	var ue *kiroclient.UpstreamError
+	if errors.As(err, &ue) {
+		attrs = append(attrs,
+			"status", ue.Status,
+			"content_type", ue.ContentType,
+			"exception", ue.Exception,
+			"body", ue.Body,
+		)
+	}
+	slog.ErrorContext(ctx, "kiro api error", attrs...)
 }
 
 // WriteErrorJSON writes an Anthropic-compatible JSON error response.

--- a/internal/app/messages/errors.go
+++ b/internal/app/messages/errors.go
@@ -1,13 +1,9 @@
 package messages
 
 import (
-	"context"
 	"encoding/json/v2"
-	"errors"
 	"log/slog"
 	"net/http"
-
-	"github.com/d-kuro/kirocc/internal/kiroclient"
 )
 
 // Anthropic API error type constants.
@@ -38,23 +34,6 @@ func handleUpstreamError(w http.ResponseWriter, isException bool, invalidReason 
 	}
 	WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: request rejected by upstream")
 	return ""
-}
-
-// logUpstreamError logs a "kiro api error" with structured attributes when the
-// error is an *UpstreamError. Falls back to plain err logging otherwise.
-func logUpstreamError(ctx context.Context, short string, err error, extra ...any) {
-	attrs := []any{"trace_id", short, "err", err}
-	attrs = append(attrs, extra...)
-	var ue *kiroclient.UpstreamError
-	if errors.As(err, &ue) {
-		attrs = append(attrs,
-			"status", ue.Status,
-			"content_type", ue.ContentType,
-			"exception", ue.Exception,
-			"body", ue.Body,
-		)
-	}
-	slog.ErrorContext(ctx, "kiro api error", attrs...)
 }
 
 // WriteErrorJSON writes an Anthropic-compatible JSON error response.

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -219,8 +219,7 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req 
 
 	apiResp, err := s.client.GenerateAssistantResponse(ctx, creds.AccessToken, payload, creds.Region)
 	if err != nil {
-		slog.ErrorContext(ctx, "kiro api error",
-			"trace_id", short, "err", err)
+		logUpstreamError(ctx, short, err)
 		WriteErrorJSON(w, http.StatusBadGateway, errTypeAPI, "upstream API error")
 		return ""
 	}

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -219,7 +219,7 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req 
 
 	apiResp, err := s.client.GenerateAssistantResponse(ctx, creds.AccessToken, payload, creds.Region)
 	if err != nil {
-		slog.ErrorContext(ctx, "kiro api error", "trace_id", short, "err", err)
+		logUpstreamError(ctx, short, err)
 		WriteErrorJSON(w, http.StatusBadGateway, errTypeAPI, "upstream API error")
 		return ""
 	}

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -219,7 +219,7 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req 
 
 	apiResp, err := s.client.GenerateAssistantResponse(ctx, creds.AccessToken, payload, creds.Region)
 	if err != nil {
-		logUpstreamError(ctx, short, err)
+		slog.ErrorContext(ctx, "kiro api error", "trace_id", short, "err", err)
 		WriteErrorJSON(w, http.StatusBadGateway, errTypeAPI, "upstream API error")
 		return ""
 	}

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -52,7 +52,7 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 
 		apiResp, err := o.service.client.GenerateAssistantResponse(ctx, o.creds.AccessToken, payload, o.creds.Region)
 		if err != nil {
-			slog.ErrorContext(ctx, "kiro api error", "trace_id", short, "round", round+1, "err", err)
+			logUpstreamError(ctx, short, err, "round", round+1)
 			writeStreamingOrJSONError(gw, sw, w, http.StatusBadGateway, errTypeAPI, "upstream API error")
 			return ""
 		}
@@ -174,7 +174,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 
 		apiResp, err := o.service.client.GenerateAssistantResponse(ctx, o.creds.AccessToken, payload, o.creds.Region)
 		if err != nil {
-			slog.ErrorContext(ctx, "kiro api error", "trace_id", short, "round", round+1, "err", err)
+			logUpstreamError(ctx, short, err, "round", round+1)
 			WriteErrorJSON(w, http.StatusBadGateway, errTypeAPI, "upstream API error")
 			return ""
 		}

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -52,7 +52,7 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 
 		apiResp, err := o.service.client.GenerateAssistantResponse(ctx, o.creds.AccessToken, payload, o.creds.Region)
 		if err != nil {
-			logUpstreamError(ctx, short, err, "round", round+1)
+			slog.ErrorContext(ctx, "kiro api error", "trace_id", short, "round", round+1, "err", err)
 			writeStreamingOrJSONError(gw, sw, w, http.StatusBadGateway, errTypeAPI, "upstream API error")
 			return ""
 		}
@@ -174,7 +174,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 
 		apiResp, err := o.service.client.GenerateAssistantResponse(ctx, o.creds.AccessToken, payload, o.creds.Region)
 		if err != nil {
-			logUpstreamError(ctx, short, err, "round", round+1)
+			slog.ErrorContext(ctx, "kiro api error", "trace_id", short, "round", round+1, "err", err)
 			WriteErrorJSON(w, http.StatusBadGateway, errTypeAPI, "upstream API error")
 			return ""
 		}

--- a/internal/auth/refresh_test.go
+++ b/internal/auth/refresh_test.go
@@ -259,15 +259,13 @@ func TestAuthManager_ConcurrentAccess(t *testing.T) {
 	tokens := make([]string, goroutines)
 
 	for i := range goroutines {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+		wg.Go(func() {
 			creds, err := mgr.GetToken(context.Background())
-			errors[idx] = err
+			errors[i] = err
 			if creds != nil {
-				tokens[idx] = creds.AccessToken
+				tokens[i] = creds.AccessToken
 			}
-		}(i)
+		})
 	}
 	wg.Wait()
 

--- a/internal/kiroclient/client.go
+++ b/internal/kiroclient/client.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -194,6 +195,38 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 				"status", resp.StatusCode,
 				"headers", logging.SafeHeaders{H: resp.Header},
 			)
+			// Kiro sometimes returns 200 with Content-Type application/json
+			// (AWS exception envelope such as ThrottlingException or
+			// InternalServerException) instead of the expected
+			// application/vnd.amazon.eventstream. Detect and surface that
+			// explicitly — otherwise the eventstream parser reads a
+			// non-framed body and eventually errors with a confusing
+			// "reading prelude" message, masking the real upstream error.
+			if ct := resp.Header.Get("Content-Type"); !isEventStreamContentType(ct) {
+				errBody := readLimitedBody(resp.Body, upstreamBodyLimit)
+				exType := resolveAWSException(errBody, resp.Header)
+				// Retry transient AWS exceptions (throttling / internal / 5xx-equivalent)
+				// even though the HTTP status is 200.
+				if attempt < maxRetries && isRetryableAWSException(exType) {
+					delay := backoffDelay(attempt)
+					slog.WarnContext(ctx, "kiro: 200 with non-eventstream exception, retrying",
+						"trace_id", short, "content_type", ct, "exception", exType,
+						"attempt", attempt+1, "max", maxRetries+1,
+						"delay", delay, "body", errBody)
+					if waitErr := retryWait(ctx, delay); waitErr != nil {
+						return nil, waitErr
+					}
+					continue
+				}
+				ue := &UpstreamError{
+					Status:      resp.StatusCode,
+					ContentType: ct,
+					Exception:   exType,
+					Body:        errBody,
+				}
+				c.recordError(ctx, ue)
+				return nil, ue
+			}
 			return &Response{
 				StatusCode:   resp.StatusCode,
 				Body:         resp.Body,
@@ -215,12 +248,12 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 					continue
 				}
 			}
-			err := fmt.Errorf("kiro api returned 403 Forbidden")
-			c.recordError(ctx, err)
-			return nil, err
+			ue := &UpstreamError{Status: resp.StatusCode, ContentType: resp.Header.Get("Content-Type")}
+			c.recordError(ctx, ue)
+			return nil, ue
 
 		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
-			errBody := readErrorBody(resp.Body)
+			errBody := readLimitedBody(resp.Body, upstreamBodyLimit)
 			if attempt < maxRetries {
 				delay := backoffDelay(attempt)
 				slog.WarnContext(ctx, "kiro: upstream error, retrying",
@@ -232,21 +265,136 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 				}
 				continue
 			}
-			err := fmt.Errorf("kiro api returned %d: %s", resp.StatusCode, errBody)
-			c.recordError(ctx, err)
-			return nil, err
+			ue := &UpstreamError{
+				Status:      resp.StatusCode,
+				ContentType: resp.Header.Get("Content-Type"),
+				Exception:   resolveAWSException(errBody, resp.Header),
+				Body:        errBody,
+			}
+			c.recordError(ctx, ue)
+			return nil, ue
 
 		default:
-			errBody := readErrorBody(resp.Body)
-			err := fmt.Errorf("kiro api returned %d: %s", resp.StatusCode, errBody)
-			c.recordError(ctx, err)
-			return nil, err
+			errBody := readLimitedBody(resp.Body, upstreamBodyLimit)
+			ue := &UpstreamError{
+				Status:      resp.StatusCode,
+				ContentType: resp.Header.Get("Content-Type"),
+				Exception:   resolveAWSException(errBody, resp.Header),
+				Body:        errBody,
+			}
+			c.recordError(ctx, ue)
+			return nil, ue
 		}
 	}
 
 	err = fmt.Errorf("kiro api: max retries exceeded")
 	c.recordError(ctx, err)
 	return nil, err
+}
+
+// parseAWSExceptionType extracts the AWS exception type from an error body.
+// AWS JSON 1.0 errors encode the exception class as "__type", optionally
+// prefixed by a shape name ("com.amazonaws...#ThrottlingException").
+// Returns "" if the body cannot be parsed.
+func parseAWSExceptionType(body string) string {
+	if body == "" {
+		return ""
+	}
+	var m struct {
+		Type1 string `json:"__type"`
+		Type2 string `json:"type"`
+		Code  string `json:"code"`
+	}
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		return ""
+	}
+	t := m.Type1
+	if t == "" {
+		t = m.Type2
+	}
+	if t == "" {
+		t = m.Code
+	}
+	return normalizeAWSExceptionType(t)
+}
+
+// isRetryableAWSException reports whether an AWS exception type is transient
+// and worth retrying (modeled after the AWS SDK retry policy).
+func isRetryableAWSException(exType string) bool {
+	switch exType {
+	case "ThrottlingException",
+		"TooManyRequestsException",
+		"ServiceUnavailableException",
+		"InternalServerException",
+		"InternalFailureException",
+		"InternalServerError":
+		return true
+	}
+	return false
+}
+
+// UpstreamError is returned when the Kiro API responds with an HTTP error
+// (any non-success status) or an unexpected Content-Type on a 200 response.
+// Callers can use errors.As to extract structured fields for logging.
+type UpstreamError struct {
+	Status      int    // HTTP status code
+	ContentType string // Content-Type header value
+	Exception   string // AWS exception class (normalized, may be "")
+	Body        string // response body (up to 8 KiB)
+}
+
+func (e *UpstreamError) Error() string {
+	return fmt.Sprintf("kiro api: status=%d content_type=%q exception=%q: %s",
+		e.Status, e.ContentType, e.Exception, e.Body)
+}
+
+// normalizeAWSExceptionType strips namespace prefixes and hostname suffixes
+// from an AWS exception type string. AWS uses two formats:
+//   - JSON __type: "com.amazon.coral.service#ThrottlingException"
+//   - Header X-Amzn-ErrorType: "ThrottlingException:http://example.com"
+//
+// This function handles both by stripping after '#' and before ':'.
+func normalizeAWSExceptionType(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// Strip namespace prefix (e.g. "com.amazon.coral.service#ThrottlingException").
+	if i := strings.LastIndexByte(raw, '#'); i >= 0 {
+		raw = raw[i+1:]
+	}
+	// Strip hostname suffix (e.g. "ThrottlingException:http://example.com").
+	if colon, _, ok := strings.Cut(raw, ":"); ok {
+		raw = colon
+	}
+	return raw
+}
+
+// resolveAWSException determines the AWS exception type from the response,
+// checking the body first, then falling back to the X-Amzn-ErrorType header.
+func resolveAWSException(body string, header http.Header) string {
+	if exType := parseAWSExceptionType(body); exType != "" {
+		return exType
+	}
+	return normalizeAWSExceptionType(header.Get("X-Amzn-ErrorType"))
+}
+
+// isEventStreamContentType reports whether ct matches the AWS event stream
+// content type (with or without parameters such as "; charset=...").
+func isEventStreamContentType(ct string) bool {
+	const want = "application/vnd.amazon.eventstream"
+	if len(ct) < len(want) {
+		return false
+	}
+	head := ct[:len(want)]
+	if !strings.EqualFold(head, want) {
+		return false
+	}
+	// Accept either exact match or media-type parameter separator.
+	if len(ct) == len(want) {
+		return true
+	}
+	c := ct[len(want)]
+	return c == ';' || c == ' ' || c == '\t'
 }
 
 // backoffDelay returns exponential backoff delay with ±25% jitter.
@@ -256,12 +404,19 @@ func backoffDelay(attempt int) time.Duration {
 	return base + jitter
 }
 
-// readErrorBody reads up to 1024 bytes from body and closes it.
-func readErrorBody(body io.ReadCloser) string {
-	b, _ := io.ReadAll(io.LimitReader(body, 1024))
+// readLimitedBody reads up to n bytes from body and closes it.
+func readLimitedBody(body io.ReadCloser, n int64) string {
+	b, _ := io.ReadAll(io.LimitReader(body, n))
 	_ = body.Close()
 	return string(b)
 }
+
+// readErrorBody reads up to 1024 bytes from body and closes it.
+func readErrorBody(body io.ReadCloser) string {
+	return readLimitedBody(body, 1024)
+}
+
+const upstreamBodyLimit = 8192
 
 // retryWait waits for the given delay, respecting ctx cancellation.
 func retryWait(ctx context.Context, delay time.Duration) error {

--- a/internal/kiroclient/client.go
+++ b/internal/kiroclient/client.go
@@ -288,10 +288,7 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 				c.recordError(ctx, ue)
 				return nil, ue
 			}
-			body := io.ReadCloser(resp.Body)
-			if idle := c.bodyReadIdleTimeout(); idle > 0 {
-				body = &idleReader{rc: resp.Body, idle: idle}
-			}
+			body := io.ReadCloser(&idleReader{rc: resp.Body, idle: c.bodyReadIdleTimeout()})
 			return &Response{
 				StatusCode:   resp.StatusCode,
 				Body:         body,
@@ -413,6 +410,17 @@ func (e *UpstreamError) Error() string {
 		e.Status, e.ContentType, e.Exception, e.Body)
 }
 
+// LogValue implements slog.LogValuer so that structured fields are
+// automatically expanded when an UpstreamError is logged via slog.
+func (e *UpstreamError) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("status", e.Status),
+		slog.String("content_type", e.ContentType),
+		slog.String("exception", e.Exception),
+		slog.String("body", e.Body),
+	)
+}
+
 // normalizeAWSExceptionType strips namespace prefixes and hostname suffixes
 // from an AWS exception type string. AWS uses two formats:
 //   - JSON __type: "com.amazon.coral.service#ThrottlingException"
@@ -474,11 +482,6 @@ func readLimitedBody(body io.ReadCloser, n int64) string {
 	b, _ := io.ReadAll(io.LimitReader(body, n))
 	_ = body.Close()
 	return string(b)
-}
-
-// readErrorBody reads up to 1024 bytes from body and closes it.
-func readErrorBody(body io.ReadCloser) string {
-	return readLimitedBody(body, 1024)
 }
 
 const upstreamBodyLimit = 8192

--- a/internal/kiroclient/client.go
+++ b/internal/kiroclient/client.go
@@ -410,17 +410,6 @@ func (e *UpstreamError) Error() string {
 		e.Status, e.ContentType, e.Exception, e.Body)
 }
 
-// LogValue implements slog.LogValuer so that structured fields are
-// automatically expanded when an UpstreamError is logged via slog.
-func (e *UpstreamError) LogValue() slog.Value {
-	return slog.GroupValue(
-		slog.Int("status", e.Status),
-		slog.String("content_type", e.ContentType),
-		slog.String("exception", e.Exception),
-		slog.String("body", e.Body),
-	)
-}
-
 // normalizeAWSExceptionType strips namespace prefixes and hostname suffixes
 // from an AWS exception type string. AWS uses two formats:
 //   - JSON __type: "com.amazon.coral.service#ThrottlingException"

--- a/internal/kiroclient/client.go
+++ b/internal/kiroclient/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -46,6 +47,13 @@ type Response struct {
 // TokenRefresher is called when a 403 is received to get a fresh token.
 type TokenRefresher func(ctx context.Context) (newToken string, err error)
 
+// ErrBodyReadIdle is returned when the Kiro response body has not produced
+// any data within the configured idle timeout. This guards against silent
+// hangs where the server sends eventstream headers but never delivers frames.
+var ErrBodyReadIdle = errors.New("kiroclient: body read idle timeout")
+
+const defaultBodyReadIdleTimeout = 180 * time.Second
+
 // HTTPClient is the production implementation of Client.
 type HTTPClient struct {
 	httpClient     *http.Client
@@ -54,6 +62,7 @@ type HTTPClient struct {
 	otelBodyLimit  int
 	tokenRefresher TokenRefresher
 	countTokens    func([]byte) (int, error) // nil = skip token counting
+	bodyReadIdle   time.Duration             // idle timeout for response body reads; 0 = use default
 }
 
 // HTTPClientOption configures an HTTPClient.
@@ -72,6 +81,17 @@ func WithTokenRefresher(fn TokenRefresher) HTTPClientOption {
 // WithTokenCounter sets a function to count prompt tokens from the serialized payload.
 func WithTokenCounter(fn func([]byte) (int, error)) HTTPClientOption {
 	return func(c *HTTPClient) { c.countTokens = fn }
+}
+
+// WithBodyReadIdleTimeout sets the idle read deadline applied to the
+// response body of a successful 200 eventstream response. If no byte is
+// read within the given duration, the body Read returns ErrBodyReadIdle.
+//
+// NOTE: The idle reader calls Close() to unblock a pending Read. This is
+// guaranteed to work for net/http.Response.Body but is NOT a general
+// guarantee for arbitrary io.ReadCloser implementations.
+func WithBodyReadIdleTimeout(d time.Duration) HTTPClientOption {
+	return func(c *HTTPClient) { c.bodyReadIdle = d }
 }
 
 // WithOTel enables OpenTelemetry tracing on outgoing requests.
@@ -102,6 +122,47 @@ func NewHTTPClient(opts ...HTTPClientOption) *HTTPClient {
 	c.httpClient = &http.Client{Transport: rt}
 	return c
 }
+
+func (c *HTTPClient) bodyReadIdleTimeout() time.Duration {
+	if c.bodyReadIdle > 0 {
+		return c.bodyReadIdle
+	}
+	return defaultBodyReadIdleTimeout
+}
+
+// idleReader wraps an io.ReadCloser and enforces an idle timeout per Read call.
+// If no data is read within the configured duration, Read returns ErrBodyReadIdle.
+//
+// The timeout recovery works by calling Close on the underlying reader, which
+// is guaranteed to unblock a pending Read for net/http.Response.Body. This is
+// NOT a general guarantee for arbitrary io.ReadCloser implementations.
+type idleReader struct {
+	rc   io.ReadCloser
+	idle time.Duration
+}
+
+func (r *idleReader) Read(p []byte) (int, error) {
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1) // buffered: sender never blocks even if we time out
+	go func() {
+		n, err := r.rc.Read(p)
+		ch <- result{n, err}
+	}()
+	t := time.NewTimer(r.idle)
+	defer t.Stop()
+	select {
+	case res := <-ch:
+		return res.n, res.err
+	case <-t.C:
+		_ = r.rc.Close() // forces the pending Read to unblock (net/http guarantee)
+		return 0, ErrBodyReadIdle
+	}
+}
+
+func (r *idleReader) Close() error { return r.rc.Close() }
 
 func (c *HTTPClient) recordError(ctx context.Context, err error) {
 	if c.otel {
@@ -227,9 +288,13 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 				c.recordError(ctx, ue)
 				return nil, ue
 			}
+			body := io.ReadCloser(resp.Body)
+			if idle := c.bodyReadIdleTimeout(); idle > 0 {
+				body = &idleReader{rc: resp.Body, idle: idle}
+			}
 			return &Response{
 				StatusCode:   resp.StatusCode,
-				Body:         resp.Body,
+				Body:         body,
 				Header:       resp.Header,
 				PromptTokens: promptTokens,
 			}, nil

--- a/internal/kiroclient/client_test.go
+++ b/internal/kiroclient/client_test.go
@@ -517,6 +517,47 @@ func TestUpstreamError_XAmznErrorTypeHeader(t *testing.T) {
 	}
 }
 
+// TestHTTPClient_BodyReadIdleTimeout verifies that when the Kiro API returns
+// 200 with eventstream headers but then stops sending data, the idle watchdog
+// fires and surfaces an error through ParseStream.
+func TestHTTPClient_BodyReadIdleTimeout(t *testing.T) {
+	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+		w.WriteHeader(http.StatusOK)
+		// Flush headers, then hang — never send body bytes.
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done() // hold connection until test client disconnects
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(
+		WithBaseURL(srv.URL),
+		WithBodyReadIdleTimeout(50*time.Millisecond),
+	)
+	payload := &kiroproto.Payload{ConversationState: kiroproto.ConversationState{AgentTaskType: "vibe", ChatTriggerType: "MANUAL", CurrentMessage: kiroproto.CurrentMessage{UserInputMessage: kiroproto.UserInputMessage{Content: "Hi"}}}}
+	resp, err := c.GenerateAssistantResponse(context.Background(), "tok", payload, "us-east-1")
+	if err != nil {
+		t.Fatalf("GenerateAssistantResponse should succeed (200), got error: %v", err)
+	}
+
+	// Feed the body through ParseStream — the real production path.
+	// ParseStream uses bufio.Reader + io.ReadFull internally.
+	parseErr := kiroproto.ParseStream(context.Background(), resp.Body, func(e kiroproto.Event) bool {
+		t.Errorf("unexpected event: %+v", e)
+		return true
+	})
+	_ = resp.Body.Close()
+
+	if parseErr == nil {
+		t.Fatal("expected ParseStream to fail with idle timeout, got nil")
+	}
+	if !errors.Is(parseErr, ErrBodyReadIdle) {
+		t.Fatalf("expected ErrBodyReadIdle, got: %v", parseErr)
+	}
+}
+
 func TestNormalizeAWSExceptionType(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/kiroclient/client_test.go
+++ b/internal/kiroclient/client_test.go
@@ -3,6 +3,7 @@ package kiroclient
 import (
 	"context"
 	"encoding/json/v2"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,6 +33,7 @@ func TestHTTPClient_Success(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/x-amz-json-1.0" {
 			t.Errorf("Content-Type = %q", r.Header.Get("Content-Type"))
 		}
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("stream-body"))
 	}))
@@ -69,6 +71,7 @@ func TestHTTPClient_CorrectHeaders(t *testing.T) {
 		if r.Header.Get("Accept") != "*/*" {
 			t.Errorf("wrong Accept: %q", r.Header.Get("Accept"))
 		}
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -86,6 +89,7 @@ func TestHTTPClient_PayloadSerialization(t *testing.T) {
 	var captured []byte
 	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -126,6 +130,7 @@ func TestHTTPClient_Retry403_WithRefresh(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer new-token" {
 			t.Errorf("expected new token, got %q", r.Header.Get("Authorization"))
 		}
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -157,6 +162,7 @@ func TestHTTPClient_Retry429(t *testing.T) {
 			_, _ = w.Write([]byte("rate limited"))
 			return
 		}
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -291,6 +297,245 @@ func TestHTTPClient_ContextTimeout(t *testing.T) {
 	_, err := c.GenerateAssistantResponse(ctx, "tok", payload, "us-east-1")
 	if err == nil {
 		t.Fatal("expected error from context timeout")
+	}
+}
+
+// TestHTTPClient_NonEventStreamContentType verifies that a 200 response with a
+// non-eventstream Content-Type (e.g. application/json error envelope returned
+// by Kiro under throttling or internal errors) is surfaced as an error instead
+// of being passed to the frame parser, which would otherwise fail with a
+// confusing "reading prelude" message.
+func TestHTTPClient_NonEventStreamContentType(t *testing.T) {
+	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"__type":"ThrottlingException","message":"Rate exceeded"}`))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(WithBaseURL(srv.URL))
+	payload := &kiroproto.Payload{ConversationState: kiroproto.ConversationState{AgentTaskType: "vibe", ChatTriggerType: "MANUAL", CurrentMessage: kiroproto.CurrentMessage{UserInputMessage: kiroproto.UserInputMessage{Content: "Hi"}}}}
+	_, err := c.GenerateAssistantResponse(context.Background(), "tok", payload, "us-east-1")
+	if err == nil {
+		t.Fatal("expected error for non-eventstream Content-Type")
+	}
+
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *UpstreamError, got %T: %v", err, err)
+	}
+	if ue.Status != http.StatusOK {
+		t.Errorf("Status = %d, want %d", ue.Status, http.StatusOK)
+	}
+	if ue.ContentType != "application/json" {
+		t.Errorf("ContentType = %q, want %q", ue.ContentType, "application/json")
+	}
+	if ue.Exception != "ThrottlingException" {
+		t.Errorf("Exception = %q, want %q", ue.Exception, "ThrottlingException")
+	}
+	if !strings.Contains(ue.Body, "Rate exceeded") {
+		t.Errorf("Body should contain upstream message, got %q", ue.Body)
+	}
+}
+
+// TestHTTPClient_NonEventStreamThrottlingRetries verifies that a 200 response
+// with an AWS-style ThrottlingException JSON body triggers retry rather than
+// failing immediately.
+func TestHTTPClient_NonEventStreamThrottlingRetries(t *testing.T) {
+	var callCount atomic.Int32
+	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n <= 2 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"__type":"ThrottlingException","message":"Rate exceeded"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(WithBaseURL(srv.URL))
+	payload := &kiroproto.Payload{ConversationState: kiroproto.ConversationState{AgentTaskType: "vibe", ChatTriggerType: "MANUAL", CurrentMessage: kiroproto.CurrentMessage{UserInputMessage: kiroproto.UserInputMessage{Content: "Hi"}}}}
+	resp, err := c.GenerateAssistantResponse(context.Background(), "tok", payload, "us-east-1")
+	if err != nil {
+		t.Fatalf("unexpected error after retry: %v", err)
+	}
+	_ = resp.Body.Close()
+	if callCount.Load() != 3 {
+		t.Fatalf("expected 3 calls after 2 throttles, got %d", callCount.Load())
+	}
+}
+
+func TestParseAWSExceptionType(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"throttling", `{"__type":"ThrottlingException","message":"..."}`, "ThrottlingException"},
+		{"shape prefix", `{"__type":"com.amazon.coral.service#ThrottlingException"}`, "ThrottlingException"},
+		{"type field", `{"type":"InternalServerException"}`, "InternalServerException"},
+		{"code field", `{"code":"ServiceUnavailableException"}`, "ServiceUnavailableException"},
+		{"empty", ``, ""},
+		{"invalid", `not json`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAWSExceptionType(tc.body)
+			if got != tc.want {
+				t.Errorf("parseAWSExceptionType(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableAWSException(t *testing.T) {
+	retryable := []string{
+		"ThrottlingException",
+		"TooManyRequestsException",
+		"ServiceUnavailableException",
+		"InternalServerException",
+		"InternalFailureException",
+		"InternalServerError",
+	}
+	for _, e := range retryable {
+		if !isRetryableAWSException(e) {
+			t.Errorf("%q should be retryable", e)
+		}
+	}
+	nonRetryable := []string{"", "ValidationException", "AccessDeniedException", "ResourceNotFoundException"}
+	for _, e := range nonRetryable {
+		if isRetryableAWSException(e) {
+			t.Errorf("%q should NOT be retryable", e)
+		}
+	}
+}
+
+func TestIsEventStreamContentType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"application/vnd.amazon.eventstream", true},
+		{"application/vnd.amazon.eventstream; charset=utf-8", true},
+		{"application/vnd.amazon.eventstream;charset=utf-8", true},
+		{"Application/VND.Amazon.EventStream", true},
+		{"application/json", false},
+		{"application/json; charset=utf-8", false},
+		{"", false},
+		{"text/plain", false},
+		{"application/vnd.amazon.eventstreamx", false}, // no separator
+	}
+	for _, tc := range cases {
+		if got := isEventStreamContentType(tc.in); got != tc.want {
+			t.Errorf("isEventStreamContentType(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestUpstreamError_429 verifies that 429 errors return *UpstreamError.
+func TestUpstreamError_429(t *testing.T) {
+	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"slow down"}`))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(WithBaseURL(srv.URL))
+	payload := &kiroproto.Payload{ConversationState: kiroproto.ConversationState{AgentTaskType: "vibe", ChatTriggerType: "MANUAL", CurrentMessage: kiroproto.CurrentMessage{UserInputMessage: kiroproto.UserInputMessage{Content: "Hi"}}}}
+	_, err := c.GenerateAssistantResponse(context.Background(), "tok", payload, "us-east-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *UpstreamError, got %T: %v", err, err)
+	}
+	if ue.Status != http.StatusTooManyRequests {
+		t.Errorf("Status = %d, want %d", ue.Status, http.StatusTooManyRequests)
+	}
+	if !strings.Contains(ue.Body, "slow down") {
+		t.Errorf("Body = %q, want to contain %q", ue.Body, "slow down")
+	}
+}
+
+// TestUpstreamError_400 verifies that 400 errors return *UpstreamError.
+func TestUpstreamError_400(t *testing.T) {
+	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad request body"))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(WithBaseURL(srv.URL))
+	payload := &kiroproto.Payload{ConversationState: kiroproto.ConversationState{AgentTaskType: "vibe", ChatTriggerType: "MANUAL", CurrentMessage: kiroproto.CurrentMessage{UserInputMessage: kiroproto.UserInputMessage{Content: "Hi"}}}}
+	_, err := c.GenerateAssistantResponse(context.Background(), "tok", payload, "us-east-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *UpstreamError, got %T: %v", err, err)
+	}
+	if ue.Status != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", ue.Status, http.StatusBadRequest)
+	}
+	if ue.Body != "bad request body" {
+		t.Errorf("Body = %q, want %q", ue.Body, "bad request body")
+	}
+}
+
+// TestUpstreamError_XAmznErrorTypeHeader verifies that X-Amzn-ErrorType header
+// is used as fallback when __type is absent from the body.
+func TestUpstreamError_XAmznErrorTypeHeader(t *testing.T) {
+	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Amzn-ErrorType", "ValidationException:http://example.com")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"invalid"}`))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(WithBaseURL(srv.URL))
+	payload := &kiroproto.Payload{ConversationState: kiroproto.ConversationState{AgentTaskType: "vibe", ChatTriggerType: "MANUAL", CurrentMessage: kiroproto.CurrentMessage{UserInputMessage: kiroproto.UserInputMessage{Content: "Hi"}}}}
+	_, err := c.GenerateAssistantResponse(context.Background(), "tok", payload, "us-east-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var ue *UpstreamError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *UpstreamError, got %T: %v", err, err)
+	}
+	if ue.Exception != "ValidationException" {
+		t.Errorf("Exception = %q, want %q", ue.Exception, "ValidationException")
+	}
+}
+
+func TestNormalizeAWSExceptionType(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "ThrottlingException", "ThrottlingException"},
+		{"hash prefix", "com.amazon.coral.service#ThrottlingException", "ThrottlingException"},
+		{"colon suffix", "ValidationException:http://example.com", "ValidationException"},
+		{"both hash and colon", "ns#ThrottlingException:hostname", "ThrottlingException"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeAWSExceptionType(tc.in)
+			if got != tc.want {
+				t.Errorf("normalizeAWSExceptionType(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/kiroclient/client_test.go
+++ b/internal/kiroclient/client_test.go
@@ -264,9 +264,9 @@ func TestBackoffDelay_Values(t *testing.T) {
 	}
 }
 
-func TestReadErrorBody_Truncates(t *testing.T) {
+func TestReadLimitedBody_Truncates(t *testing.T) {
 	big := strings.Repeat("x", 2000)
-	got := readErrorBody(io.NopCloser(strings.NewReader(big)))
+	got := readLimitedBody(io.NopCloser(strings.NewReader(big)), 1024)
 	if len(got) > 1024 {
 		t.Fatalf("expected ≤1024 bytes, got %d", len(got))
 	}

--- a/internal/respconv/chunk_delta.go
+++ b/internal/respconv/chunk_delta.go
@@ -49,6 +49,9 @@ func kmpOverlap(a, b string) int {
 	}
 
 	// Match b against a using the failure function.
+	// Must iterate over all bytes (not rune boundaries via `for i := range a`),
+	// since KMP here is a byte-level match — `range` over a string skips the
+	// interior bytes of multi-byte UTF-8 sequences and corrupts the overlap.
 	k = 0
 	for i := 0; i < len(a); i++ {
 		for k > 0 && b[k] != a[i] {

--- a/internal/respconv/chunk_delta_test.go
+++ b/internal/respconv/chunk_delta_test.go
@@ -18,6 +18,12 @@ func TestNormalizeChunk(t *testing.T) {
 		{"overlap", "world!", "Hello world", "!"},
 		{"no overlap", "Goodbye", "Hello", "Goodbye"},
 		{"empty chunk", "", "Hello", ""},
+		// Multi-byte UTF-8 overlap: previous ends with "日本", chunk starts with
+		// "日本". Overlap detection must match all 6 bytes of "日本" (not only
+		// the rune-start bytes) or the resulting delta begins mid-rune and
+		// emits invalid UTF-8 into the SSE stream.
+		{"multibyte overlap", "日本語のテスト", "こんにちは日本", "語のテスト"},
+		{"multibyte overlap kanji only", "日本語", "日本", "語"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/respconv/event_accumulator.go
+++ b/internal/respconv/event_accumulator.go
@@ -312,7 +312,7 @@ func (a *responseAccumulator) applyStopSequenceFilter(delta string) string {
 	}
 	// Find the byte offset after (runeCount - stopSeqMaxKeep) runes.
 	splitAt := 0
-	for i := 0; i < runeCount-a.stopSeqMaxKeep; i++ {
+	for range runeCount - a.stopSeqMaxKeep {
 		_, size := utf8.DecodeRuneInString(a.stopSeqPending[splitAt:])
 		splitAt += size
 	}


### PR DESCRIPTION
## Summary

- Remove dead code `readErrorBody` (unused in production); update test to call `readLimitedBody` directly.
- Remove always-true `idle > 0` guard in `GenerateAssistantResponse` since `bodyReadIdleTimeout()` never returns zero.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` — all 575 tests pass
- [x] `golangci-lint run` — no issues
- [x] pre-commit hooks pass