### PR TITLE
fix: use absolute URL for release notes link in PR body

### DIFF
--- a/.claude/skills/release-kirocc/SKILL.md
+++ b/.claude/skills/release-kirocc/SKILL.md
@@ -136,7 +136,7 @@ gh pr create --title "Release <version>" --body "$(cat <<'EOF'
 
 Release <version>
 
-See [docs/release-notes/<version>.md](docs/release-notes/<version>.md) for details.
+See [docs/release-notes/<version>.md](https://github.com/d-kuro/kirocc/blob/release/<version>/docs/release-notes/<version>.md) for details.
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary

- Fix broken release notes link in PR descriptions created by the `/release-kirocc` skill
- The relative path `docs/release-notes/<version>.md` resolved against the PR page URL, resulting in a 404
- Replace with an absolute GitHub blob URL pointing to the `release/<version>` branch

## Test plan

- [ ] Verify the link in SKILL.md points to the correct blob URL format
- [ ] Next release PR should have a clickable release notes link