### PR TITLE
feat: add xhigh thinking effort level and adjust high budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Thinking is enabled by any of:
 The thinking budget is determined by:
 
 1. `thinking.budget_tokens` if explicitly set
-2. Derived from `output_config.effort`: `max` = 160000, `high` = 31999, `medium` = 10000, `low` = 4000
+2. Derived from `output_config.effort`: `max` = 160000, `xhigh` = 80000, `high` = 40000, `medium` = 10000, `low` = 4000
 3. Default: 10000 (medium)
 
 ### Tool Search

--- a/internal/anthropic/types.go
+++ b/internal/anthropic/types.go
@@ -39,6 +39,7 @@ const (
 // Effort level constants (set via output_config.effort).
 const (
 	EffortMax    = "max"
+	EffortXHigh  = "xhigh"
 	EffortHigh   = "high"
 	EffortMedium = "medium"
 	EffortLow    = "low"
@@ -47,7 +48,8 @@ const (
 // Thinking budget tokens per reasoning effort level.
 const (
 	ThinkingBudgetMax    = 160000
-	ThinkingBudgetHigh   = 31999
+	ThinkingBudgetXHigh  = 80000
+	ThinkingBudgetHigh   = 40000
 	ThinkingBudgetMedium = 10000
 	ThinkingBudgetLow    = 4000
 )

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -87,6 +87,8 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 			switch req.Effort() {
 			case anthropic.EffortMax:
 				thinkingBudget = anthropic.ThinkingBudgetMax
+			case anthropic.EffortXHigh:
+				thinkingBudget = anthropic.ThinkingBudgetXHigh
 			case anthropic.EffortHigh:
 				thinkingBudget = anthropic.ThinkingBudgetHigh
 			case anthropic.EffortLow:


### PR DESCRIPTION
## Summary

- Add `xhigh` thinking effort level (budget_tokens=80000) to support the new Claude Code effort option
- Adjust `high` budget from 31999 to 40000 for a cleaner progression
- Final mapping: `low`=4000, `medium`=10000, `high`=40000, `xhigh`=80000, `max`=160000

## Test plan

- [x] `make build` passes
- [x] `make test` passes (no existing tests reference `ThinkingBudgetHigh` or `31999`)
- [x] `make lint` passes
- [ ] Manual: send a request with `output_config.effort: "xhigh"` and verify budget resolves to 80000 in logs