### PR TITLE
Release v0.0.11

### DIFF
--- a/docs/release-notes/v0.0.11.md
+++ b/docs/release-notes/v0.0.11.md
@@ -1,0 +1,46 @@
+# Release v0.0.11
+
+## New Features
+
+### Claude Opus 4.7 support with 1M context (#45)
+
+Added `claude-opus-4-7` to the model catalog and pinned both Opus 4.6 and 4.7 to the 1M-token context window.
+
+### xhigh thinking effort level (#46)
+
+Introduced a new `xhigh` effort level between `high` and `max`. The mapping is now `max` = 160000, `xhigh` = 80000, `high` = 40000, `medium` = 10000, `low` = 4000 (the `high` budget was adjusted from 31999 to 40000).
+
+### kiro-capture skill for HTTPS traffic analysis (#39)
+
+Added a new skill for capturing and analyzing HTTPS traffic against the Kiro backend.
+
+## Bug Fixes
+
+- Align request shape with kiro-cli v2.0.0 capture data (#40)
+- Use absolute URL for release notes link in PR body (#44)
+
+## Code Improvements
+
+- Remove dead code and simplify idle reader wrapping (#41)
+- Dedupe `req.Effort()` call in thinking budget switch (#47)
+
+## Dependencies
+
+- Update `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` to v0.68.0 (#38)
+- Update `modernc.org/sqlite` to v1.48.2 (#37)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.0.11
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.0.10...v0.0.11


### PR DESCRIPTION
## Summary

Release v0.0.11

See [docs/release-notes/v0.0.11.md](https://github.com/d-kuro/kirocc/blob/release/v0.0.11/docs/release-notes/v0.0.11.md) for details.