### PR TITLE
fix: return Anthropic model ID in responses to preserve 1M context detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ Opus 4.6 and 4.7 always use 1M context (no 200k SKU exists upstream). Thinking i
 
 Unmatched `claude-*` models are passed through as-is. Non-claude models fall back to `claude-sonnet-4.6`.
 
+#### Response model ID
+
+The `model` field in `/v1/messages` responses (streaming `message_start`, non-streaming body, and tool-search path) is returned as the **Anthropic-form ID** (e.g. `claude-opus-4-7`), not the Kiro SKU (`claude-opus-4.7`). Claude Code detects context window size by matching the response's model ID against its own hard-coded table of hyphenated Anthropic IDs — the dotted Kiro SKU would not match and would cause Claude Code to fall back to the 200k default, triggering auto-compact prematurely for 1M-context models like Opus 4.7 / 4.6 and Sonnet 4.6.
+
 ## License
 
 Apache License 2.0

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -51,7 +51,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kiroModel, thinking, contextWindowSize := models.Resolve(req.Model, hasContext1MBeta(r.Header))
+	kiroModel, thinking, contextWindowSize, anthropicModel := models.Resolve(req.Model, hasContext1MBeta(r.Header))
 
 	// Also check the request's thinking field (Anthropic API standard).
 	if req.IsThinkingEnabled() {
@@ -132,6 +132,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 				ToolSearchCtx:  tsCtx,
 			},
 			contextWindowSize: contextWindowSize,
+			responseModel:     anthropicModel,
 		}
 		var retryReason string
 		if req.Stream {
@@ -170,7 +171,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 	}
 	reverseMap := nameMap.ReverseMap()
 
-	retryReason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 1, reverseMap)
+	retryReason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, anthropicModel, contextWindowSize, thinking, 1, reverseMap)
 	if retryReason == "" {
 		return
 	}
@@ -185,7 +186,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		)
 		// Clear IDs to break out of stuck conversation state.
 		payload.ConversationState.ConversationID = ""
-		reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2, reverseMap)
+		reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, anthropicModel, contextWindowSize, thinking, 2, reverseMap)
 		if reason == "" {
 			return
 		}
@@ -208,7 +209,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		"reason", retryReason,
 	)
 	payload.ConversationState.ConversationID = ""
-	if reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, contextWindowSize, thinking, 2, reverseMap); reason != "" {
+	if reason := s.callAndHandle(r.Context(), w, req, payload, creds, kiroModel, anthropicModel, contextWindowSize, thinking, 2, reverseMap); reason != "" {
 		WriteErrorJSON(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: "+reason)
 	}
 }
@@ -216,7 +217,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 // callAndHandle calls the Kiro API and handles the response.
 // Returns a non-empty reason string if the request failed with a retryable invalidStateEvent
 // before the stream started (i.e., no bytes written to w yet). Returns "" on success or non-retryable error.
-func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req *anthropic.Request, payload *kiroproto.Payload, creds *auth.Credentials, model string, contextWindowSize int, thinking bool, attempt int, toolNameMap map[string]string) string {
+func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req *anthropic.Request, payload *kiroproto.Payload, creds *auth.Credentials, model, responseModel string, contextWindowSize int, thinking bool, attempt int, toolNameMap map[string]string) string {
 	_, short := logging.TraceIDs(ctx)
 	capture := newUpstreamAttemptCapture(ctx, payload, model, thinking, req.Stream, attempt)
 
@@ -234,9 +235,9 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, req 
 
 	var reason string
 	if req.Stream {
-		reason = s.handleStreamingResponse(ctx, w, apiResp, model, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture, toolNameMap)
+		reason = s.handleStreamingResponse(ctx, w, apiResp, responseModel, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture, toolNameMap)
 	} else {
-		reason = s.handleNonStreamingResponse(ctx, w, apiResp, model, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture, toolNameMap)
+		reason = s.handleNonStreamingResponse(ctx, w, apiResp, responseModel, contextWindowSize, req.StopSequences, req.MaxTokens, apiResp.PromptTokens, capture, toolNameMap)
 	}
 	if reason == retryReasonEmptyVisibleEndTurn {
 		capture.logCapture(ctx, reason)

--- a/internal/app/messages/request.go
+++ b/internal/app/messages/request.go
@@ -29,7 +29,7 @@ func (s *Service) HandleCountTokens(w http.ResponseWriter, r *http.Request) {
 		profileARN = creds.ProfileARN
 	}
 
-	kiroModel, thinking, _ := models.Resolve(req.Model, hasContext1MBeta(r.Header))
+	kiroModel, thinking, _, _ := models.Resolve(req.Model, hasContext1MBeta(r.Header))
 	if req.IsThinkingEnabled() {
 		thinking = true
 	}

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -28,13 +28,14 @@ type toolSearchOrchestrator struct {
 	creds             *auth.Credentials
 	buildOpts         reqconv.BuildOptions
 	contextWindowSize int
+	responseModel     string
 }
 
 func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.ResponseWriter) string {
 	_, short := logging.TraceIDs(ctx)
 
 	gw := NewGateWriter(w)
-	sw := respconv.NewSSEWriter(ctx, gw, o.buildOpts.ModelID, o.contextWindowSize, o.req.StopSequences, o.req.MaxTokens, 0)
+	sw := respconv.NewSSEWriter(ctx, gw, o.responseModel, o.contextWindowSize, o.req.StopSequences, o.req.MaxTokens, 0)
 	sw.OnVisibleOutput = func() { gw.Promote() }
 
 	msgs := slices.Clone(o.req.Messages)
@@ -206,7 +207,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 			return ""
 		}
 
-		resp, stats := acc.BuildResponse(o.buildOpts.ModelID)
+		resp, stats := acc.BuildResponse(o.responseModel)
 		totalInputTokens += stats.InputTokens
 		totalOutputTokens += stats.OutputTokens
 		lastStopReason, _ = resp["stop_reason"].(string)
@@ -276,7 +277,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 		"type":          "message",
 		"role":          "assistant",
 		"content":       orderedBlocks,
-		"model":         o.buildOpts.ModelID,
+		"model":         o.responseModel,
 		"stop_reason":   lastStopReason,
 		"stop_sequence": lastStopSequence,
 		"usage": map[string]any{

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -93,7 +93,17 @@ func effectiveMappings() []Mapping {
 // its default context window. Unmatched claude-* models are passed through.
 // Non-claude models return DefaultModel.
 // KIROCC_MODEL_MAPPINGS env var can override mappings.
-func Resolve(model string, context1M bool) (kiroModel string, thinking bool, contextWindowSize int) {
+//
+// anthropicModel is the model ID to return in /v1/messages responses. Claude
+// Code reads the response model and matches it against its own hard-coded
+// hyphenated-ID table to decide context window size, so the response must use
+// the Anthropic-form ID (e.g. "claude-opus-4-7") rather than the Kiro SKU
+// ("claude-opus-4.7"). When a mapping matches, the mapping's Anthropic field
+// is used. For unmatched claude-* passthrough, the request model (with
+// ThinkingSuffix stripped) is returned. For the non-claude DefaultModel
+// fallback, the built-in mapping is reverse-looked-up so env overrides cannot
+// poison it with an empty Anthropic field.
+func Resolve(model string, context1M bool) (kiroModel string, thinking bool, contextWindowSize int, anthropicModel string) {
 	// Strip thinking suffix
 	if before, ok := strings.CutSuffix(model, ThinkingSuffix); ok {
 		model = before
@@ -105,12 +115,14 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 
 	var matchedWindowSize int
 	var matchedKiro1M string
+	var matchedAnthropic string
 	var matched bool
 	for _, m := range effectiveMappings() {
 		if model == m.Anthropic || model == m.Kiro {
 			kiroModel = m.Kiro
 			matchedKiro1M = m.Kiro1M
 			matchedWindowSize = m.ContextWindowSize
+			matchedAnthropic = m.Anthropic
 			matched = true
 			break
 		}
@@ -119,13 +131,17 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 	if !matched {
 		if strings.HasPrefix(model, "claude-") {
 			kiroModel = model
+			anthropicModel = model
 		} else {
 			slog.Warn("models.Resolve: non-claude model, falling back to default",
 				"requested_model", model,
 				"kiro_model", DefaultModel,
 			)
 			kiroModel = DefaultModel
+			anthropicModel = defaultAnthropicModel()
 		}
+	} else {
+		anthropicModel = matchedAnthropic
 	}
 
 	// A mapping with Kiro1M == Kiro means the model always uses 1M context
@@ -143,7 +159,19 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 		contextWindowSize = DefaultContextWindowSize
 	}
 
-	return kiroModel, thinking, contextWindowSize
+	return kiroModel, thinking, contextWindowSize, anthropicModel
+}
+
+// defaultAnthropicModel returns the Anthropic-form ID for DefaultModel by
+// reverse-looking-up the built-in mapping table. Env overrides are ignored
+// here so a malformed override cannot leave us returning an empty string.
+func defaultAnthropicModel() string {
+	for _, m := range modelMapOrdered {
+		if m.Kiro == DefaultModel && m.Anthropic != "" {
+			return m.Anthropic
+		}
+	}
+	return DefaultModel
 }
 
 // ListModels returns a deduplicated list of all Kiro model values from

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -37,6 +37,12 @@ var modelMapOrdered = []Mapping{
 
 const DefaultModel = "claude-sonnet-4.6"
 
+// DefaultAnthropicModel is the Anthropic-form ID corresponding to DefaultModel.
+// Returned as the response model for non-claude fallback so callers like
+// Claude Code can map it to a context window size. Kept as a separate constant
+// (not derived from modelMapOrdered) so env overrides cannot poison it.
+const DefaultAnthropicModel = "claude-sonnet-4-6"
+
 // envCache caches parsed env mappings, re-parsing only when the raw string changes.
 var envCache struct {
 	mu     sync.Mutex
@@ -84,25 +90,12 @@ func effectiveMappings() []Mapping {
 	return result
 }
 
-// Resolve maps an Anthropic or Kiro model name to a Kiro model name and context window size.
-// It strips ThinkingSuffix if present (sets thinking=true), then matches
-// against effective mappings (env overrides + built-in) on both Anthropic and
-// Kiro fields using first-match semantics. When thinking is true and the
-// matched mapping has a Kiro1M value, that value is used as the model with a
-// 1M context window. If Kiro1M is empty, the base Kiro model is used with
-// its default context window. Unmatched claude-* models are passed through.
-// Non-claude models return DefaultModel.
+// Resolve maps an Anthropic or Kiro model name to the Kiro SKU sent upstream,
+// the thinking flag, the context window size, and the Anthropic-form ID to
+// echo back in /v1/messages responses. Returning the Anthropic-form ID matters
+// because Claude Code decides context window size by matching the response's
+// model against its own hyphenated-ID table; the dotted Kiro SKU would miss.
 // KIROCC_MODEL_MAPPINGS env var can override mappings.
-//
-// anthropicModel is the model ID to return in /v1/messages responses. Claude
-// Code reads the response model and matches it against its own hard-coded
-// hyphenated-ID table to decide context window size, so the response must use
-// the Anthropic-form ID (e.g. "claude-opus-4-7") rather than the Kiro SKU
-// ("claude-opus-4.7"). When a mapping matches, the mapping's Anthropic field
-// is used. For unmatched claude-* passthrough, the request model (with
-// ThinkingSuffix stripped) is returned. For the non-claude DefaultModel
-// fallback, the built-in mapping is reverse-looked-up so env overrides cannot
-// poison it with an empty Anthropic field.
 func Resolve(model string, context1M bool) (kiroModel string, thinking bool, contextWindowSize int, anthropicModel string) {
 	// Strip thinking suffix
 	if before, ok := strings.CutSuffix(model, ThinkingSuffix); ok {
@@ -138,7 +131,7 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 				"kiro_model", DefaultModel,
 			)
 			kiroModel = DefaultModel
-			anthropicModel = defaultAnthropicModel()
+			anthropicModel = DefaultAnthropicModel
 		}
 	} else {
 		anthropicModel = matchedAnthropic
@@ -160,18 +153,6 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 	}
 
 	return kiroModel, thinking, contextWindowSize, anthropicModel
-}
-
-// defaultAnthropicModel returns the Anthropic-form ID for DefaultModel by
-// reverse-looking-up the built-in mapping table. Env overrides are ignored
-// here so a malformed override cannot leave us returning an empty string.
-func defaultAnthropicModel() string {
-	for _, m := range modelMapOrdered {
-		if m.Kiro == DefaultModel && m.Anthropic != "" {
-			return m.Anthropic
-		}
-	}
-	return DefaultModel
 }
 
 // ListModels returns a deduplicated list of all Kiro model values from

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -7,164 +7,195 @@ import (
 
 func TestResolve(t *testing.T) {
 	tests := []struct {
-		name              string
-		envMappings       string // KIROCC_MODEL_MAPPINGS value; empty = unset
-		model             string
-		context1M         bool
-		wantKiroModel     string
-		wantThinking      bool
-		wantContextWindow int
+		name               string
+		envMappings        string // KIROCC_MODEL_MAPPINGS value; empty = unset
+		model              string
+		context1M          bool
+		wantKiroModel      string
+		wantThinking       bool
+		wantContextWindow  int
+		wantAnthropicModel string
 	}{
 		{
-			name:              "claude-opus-4-7 uses 1m context without thinking",
-			model:             "claude-opus-4-7",
-			wantKiroModel:     "claude-opus-4.7",
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-opus-4-7 uses 1m context without thinking",
+			model:              "claude-opus-4-7",
+			wantKiroModel:      "claude-opus-4.7",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-7",
 		},
 		{
-			name:              "claude-opus-4-7 with thinking suffix",
-			model:             "claude-opus-4-7[1m]",
-			wantKiroModel:     "claude-opus-4.7",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-opus-4-7 with thinking suffix",
+			model:              "claude-opus-4-7[1m]",
+			wantKiroModel:      "claude-opus-4.7",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-7",
 		},
 		{
-			name:              "claude-opus-4-7 with context1M",
-			model:             "claude-opus-4-7",
-			context1M:         true,
-			wantKiroModel:     "claude-opus-4.7",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-opus-4-7 with context1M",
+			model:              "claude-opus-4-7",
+			context1M:          true,
+			wantKiroModel:      "claude-opus-4.7",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-7",
 		},
 		{
-			name:              "kiro model name claude-opus-4.7 always resolves to 1m",
-			model:             "claude-opus-4.7[1m]",
-			wantKiroModel:     "claude-opus-4.7",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "kiro model name claude-opus-4.7 always resolves to 1m",
+			model:              "claude-opus-4.7[1m]",
+			wantKiroModel:      "claude-opus-4.7",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-7",
 		},
 		{
-			name:              "claude-opus-4-6 uses 1m context without thinking",
-			model:             "claude-opus-4-6",
-			wantKiroModel:     "claude-opus-4.6",
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-opus-4-6 uses 1m context without thinking",
+			model:              "claude-opus-4-6",
+			wantKiroModel:      "claude-opus-4.6",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-6",
 		},
 		{
-			name:              "claude-opus-4-6 with thinking suffix",
-			model:             "claude-opus-4-6[1m]",
-			wantKiroModel:     "claude-opus-4.6",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-opus-4-6 with thinking suffix",
+			model:              "claude-opus-4-6[1m]",
+			wantKiroModel:      "claude-opus-4.6",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-6",
 		},
 		{
-			name:              "claude-opus-4-6 with context1M",
-			model:             "claude-opus-4-6",
-			context1M:         true,
-			wantKiroModel:     "claude-opus-4.6",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-opus-4-6 with context1M",
+			model:              "claude-opus-4-6",
+			context1M:          true,
+			wantKiroModel:      "claude-opus-4.6",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-6",
 		},
 		{
-			name:              "claude-sonnet-4-6",
-			model:             "claude-sonnet-4-6",
-			wantKiroModel:     "claude-sonnet-4.6",
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "claude-sonnet-4-6",
+			model:              "claude-sonnet-4-6",
+			wantKiroModel:      "claude-sonnet-4.6",
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 		{
-			name:              "kiro model name claude-sonnet-4.6 without thinking suffix",
-			model:             "claude-sonnet-4.6",
-			wantKiroModel:     "claude-sonnet-4.6",
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "kiro model name claude-sonnet-4.6 without thinking suffix",
+			model:              "claude-sonnet-4.6",
+			wantKiroModel:      "claude-sonnet-4.6",
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 		{
-			name:              "claude-sonnet-4-6 with thinking suffix",
-			model:             "claude-sonnet-4-6[1m]",
-			wantKiroModel:     "claude-sonnet-4.6-1m",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-sonnet-4-6 with thinking suffix",
+			model:              "claude-sonnet-4-6[1m]",
+			wantKiroModel:      "claude-sonnet-4.6-1m",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 		{
-			name:              "claude-sonnet-4-6 with context1M resolves to 1m",
-			model:             "claude-sonnet-4-6",
-			context1M:         true,
-			wantKiroModel:     "claude-sonnet-4.6-1m",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "claude-sonnet-4-6 with context1M resolves to 1m",
+			model:              "claude-sonnet-4-6",
+			context1M:          true,
+			wantKiroModel:      "claude-sonnet-4.6-1m",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 		{
-			name:              "claude-sonnet-4 with thinking suffix passthrough no 1m variant",
-			model:             "claude-sonnet-4[1m]",
-			wantKiroModel:     "claude-sonnet-4",
-			wantThinking:      true,
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "claude-sonnet-4 with thinking suffix passthrough no 1m variant",
+			model:              "claude-sonnet-4[1m]",
+			wantKiroModel:      "claude-sonnet-4",
+			wantThinking:       true,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4",
 		},
 		{
-			name:              "claude-haiku-4.5",
-			model:             "claude-haiku-4.5",
-			wantKiroModel:     "claude-haiku-4.5",
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "claude-haiku-4.5",
+			model:              "claude-haiku-4.5",
+			wantKiroModel:      "claude-haiku-4.5",
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-haiku-4.5",
 		},
 		{
-			name:              "claude-haiku-4.5 with thinking suffix no 1m variant",
-			model:             "claude-haiku-4.5[1m]",
-			wantKiroModel:     "claude-haiku-4.5",
-			wantThinking:      true,
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "claude-haiku-4.5 with thinking suffix no 1m variant",
+			model:              "claude-haiku-4.5[1m]",
+			wantKiroModel:      "claude-haiku-4.5",
+			wantThinking:       true,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-haiku-4.5",
 		},
 		{
-			name:              "claude-haiku-4.5 with context1M no 1m variant",
-			model:             "claude-haiku-4.5",
-			context1M:         true,
-			wantKiroModel:     "claude-haiku-4.5",
-			wantThinking:      true,
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "claude-haiku-4.5 with context1M no 1m variant",
+			model:              "claude-haiku-4.5",
+			context1M:          true,
+			wantKiroModel:      "claude-haiku-4.5",
+			wantThinking:       true,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-haiku-4.5",
 		},
 		{
-			name:              "kiro model name claude-sonnet-4.6 with thinking suffix resolves to 1m",
-			model:             "claude-sonnet-4.6[1m]",
-			wantKiroModel:     "claude-sonnet-4.6-1m",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "kiro model name claude-sonnet-4.6 with thinking suffix resolves to 1m",
+			model:              "claude-sonnet-4.6[1m]",
+			wantKiroModel:      "claude-sonnet-4.6-1m",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 		{
-			name:              "kiro model name claude-opus-4.6 with thinking suffix",
-			model:             "claude-opus-4.6[1m]",
-			wantKiroModel:     "claude-opus-4.6",
-			wantThinking:      true,
-			wantContextWindow: ThinkingContextWindowSize,
+			name:               "kiro model name claude-opus-4.6 with thinking suffix",
+			model:              "claude-opus-4.6[1m]",
+			wantKiroModel:      "claude-opus-4.6",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-6",
 		},
 		{
-			name:              "unknown claude model passthrough",
-			model:             "claude-future-99",
-			wantKiroModel:     "claude-future-99",
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "unknown claude model passthrough",
+			model:              "claude-future-99",
+			wantKiroModel:      "claude-future-99",
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-future-99",
 		},
 		{
-			name:              "unknown claude model with thinking suffix passthrough",
-			model:             "claude-future-99[1m]",
-			wantKiroModel:     "claude-future-99",
-			wantThinking:      true,
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "unknown claude model with thinking suffix passthrough",
+			model:              "claude-future-99[1m]",
+			wantKiroModel:      "claude-future-99",
+			wantThinking:       true,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-future-99",
 		},
 		{
-			name:              "non-claude model returns default",
-			model:             "gpt-4o",
-			wantKiroModel:     DefaultModel,
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "non-claude model returns default",
+			model:              "gpt-4o",
+			wantKiroModel:      DefaultModel,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 		{
-			name:              "env override custom model",
-			envMappings:       `[{"anthropic":"my-custom-model","kiro":"claude-custom-1"}]`,
-			model:             "my-custom-model",
-			wantKiroModel:     "claude-custom-1",
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "env override custom model",
+			envMappings:        `[{"anthropic":"my-custom-model","kiro":"claude-custom-1"}]`,
+			model:              "my-custom-model",
+			wantKiroModel:      "claude-custom-1",
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "my-custom-model",
 		},
 		{
-			name:              "env override invalid JSON falls back",
-			envMappings:       `not-valid-json`,
-			model:             "claude-sonnet-4-6",
-			wantKiroModel:     "claude-sonnet-4.6",
-			wantContextWindow: DefaultContextWindowSize,
+			name:               "env override invalid JSON falls back",
+			envMappings:        `not-valid-json`,
+			model:              "claude-sonnet-4-6",
+			wantKiroModel:      "claude-sonnet-4.6",
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
+		},
+		{
+			name:               "env override with empty anthropic does not poison non-claude fallback",
+			envMappings:        `[{"anthropic":"","kiro":"claude-sonnet-4.6"}]`,
+			model:              "gpt-4o",
+			wantKiroModel:      DefaultModel,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 	}
 
@@ -173,15 +204,18 @@ func TestResolve(t *testing.T) {
 			if tt.envMappings != "" {
 				t.Setenv("KIROCC_MODEL_MAPPINGS", tt.envMappings)
 			}
-			gotModel, gotThinking, gotWindow := Resolve(tt.model, tt.context1M)
+			gotModel, gotThinking, gotWindow, gotAnthropic := Resolve(tt.model, tt.context1M)
 			if gotModel != tt.wantKiroModel {
-				t.Errorf("Resolve(%q) model = %q, want %q", tt.model, gotModel, tt.wantKiroModel)
+				t.Errorf("Resolve(%q) kiroModel = %q, want %q", tt.model, gotModel, tt.wantKiroModel)
 			}
 			if gotThinking != tt.wantThinking {
 				t.Errorf("Resolve(%q) thinking = %v, want %v", tt.model, gotThinking, tt.wantThinking)
 			}
 			if gotWindow != tt.wantContextWindow {
 				t.Errorf("Resolve(%q) contextWindowSize = %d, want %d", tt.model, gotWindow, tt.wantContextWindow)
+			}
+			if gotAnthropic != tt.wantAnthropicModel {
+				t.Errorf("Resolve(%q) anthropicModel = %q, want %q", tt.model, gotAnthropic, tt.wantAnthropicModel)
 			}
 		})
 	}

--- a/internal/server/e2e_response_model_test.go
+++ b/internal/server/e2e_response_model_test.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"bufio"
+	"encoding/json/v2"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestE2E_ResponseModel_NonStreaming verifies that the /v1/messages non-streaming
+// response body returns the Anthropic-form model ID (e.g. claude-opus-4-7), not
+// the Kiro SKU (claude-opus-4.7). Claude Code matches this ID against its
+// hard-coded table to detect the 1M context window; the dotted Kiro SKU would
+// fall back to the 200k default and trigger premature auto-compact.
+func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestModel string
+		wantResponse string
+		wantUpstream string // Kiro SKU sent upstream
+	}{
+		{
+			name:         "opus-4-7 hyphen preserved in response",
+			requestModel: "claude-opus-4-7",
+			wantResponse: "claude-opus-4-7",
+			wantUpstream: "claude-opus-4.7",
+		},
+		{
+			name:         "opus-4-6 hyphen preserved in response",
+			requestModel: "claude-opus-4-6",
+			wantResponse: "claude-opus-4-6",
+			wantUpstream: "claude-opus-4.6",
+		},
+		{
+			name:         "sonnet-4-6 hyphen preserved in response",
+			requestModel: "claude-sonnet-4-6",
+			wantResponse: "claude-sonnet-4-6",
+			wantUpstream: "claude-sonnet-4.6",
+		},
+		{
+			name:         "kiro dotted input is rewritten to anthropic hyphen in response",
+			requestModel: "claude-opus-4.7",
+			wantResponse: "claude-opus-4-7",
+			wantUpstream: "claude-opus-4.7",
+		},
+		{
+			name:         "unknown claude model passthrough",
+			requestModel: "claude-future-99",
+			wantResponse: "claude-future-99",
+			wantUpstream: "claude-future-99",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p1 := mustJSON(map[string]string{"content": "ok"})
+			client := &capturingClient{events: []any{"assistantResponseEvent", p1}}
+
+			srv := newE2EServer(t, client)
+			defer srv.Close()
+
+			body := `{"model":"` + tt.requestModel + `","messages":[{"role":"user","content":"hi"}],"stream":false}`
+			resp := postMessages(t, srv.URL, body)
+			defer func() { _ = resp.Body.Close() }()
+
+			requireStatus(t, resp, 200)
+
+			var result map[string]any
+			if err := json.UnmarshalRead(resp.Body, &result); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			gotModel, _ := result["model"].(string)
+			if gotModel != tt.wantResponse {
+				t.Errorf("response model = %q, want %q", gotModel, tt.wantResponse)
+			}
+
+			requireCaptured(t, client)
+			if client.captured.ConversationState.CurrentMessage.UserInputMessage.ModelID != tt.wantUpstream {
+				t.Errorf("upstream ModelID = %q, want %q",
+					client.captured.ConversationState.CurrentMessage.UserInputMessage.ModelID,
+					tt.wantUpstream)
+			}
+		})
+	}
+}
+
+// TestE2E_ResponseModel_Streaming verifies that the SSE message_start event
+// contains the Anthropic-form model ID.
+func TestE2E_ResponseModel_Streaming(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestModel string
+		wantResponse string
+	}{
+		{
+			name:         "opus-4-7 hyphen preserved in message_start",
+			requestModel: "claude-opus-4-7",
+			wantResponse: "claude-opus-4-7",
+		},
+		{
+			name:         "kiro dotted input is rewritten to hyphen in message_start",
+			requestModel: "claude-opus-4.7",
+			wantResponse: "claude-opus-4-7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p1 := mustJSON(map[string]string{"content": "Hello"})
+			client := &capturingClient{events: []any{"assistantResponseEvent", p1}}
+
+			srv := newE2EServer(t, client)
+			defer srv.Close()
+
+			body := `{"model":"` + tt.requestModel + `","messages":[{"role":"user","content":"hi"}],"stream":true}`
+			resp := postMessages(t, srv.URL, body)
+			defer func() { _ = resp.Body.Close() }()
+
+			requireStatus(t, resp, 200)
+
+			msg := extractMessageStartModel(t, resp.Body)
+			if msg != tt.wantResponse {
+				t.Errorf("message_start model = %q, want %q", msg, tt.wantResponse)
+			}
+		})
+	}
+}
+
+// extractMessageStartModel scans an SSE body for the message_start event and
+// returns its message.model field.
+func extractMessageStartModel(t *testing.T, body io.Reader) string {
+	t.Helper()
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	var eventType string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if after, ok := strings.CutPrefix(line, "event: "); ok {
+			eventType = after
+			continue
+		}
+		if eventType == "message_start" && strings.HasPrefix(line, "data: ") {
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &payload); err != nil {
+				t.Fatalf("parse message_start data: %v", err)
+			}
+			msg, _ := payload["message"].(map[string]any)
+			model, _ := msg["model"].(string)
+			return model
+		}
+	}
+	t.Fatal("message_start event not found in SSE body")
+	return ""
+}

--- a/internal/server/e2e_response_model_test.go
+++ b/internal/server/e2e_response_model_test.go
@@ -8,11 +8,9 @@ import (
 	"testing"
 )
 
-// TestE2E_ResponseModel_NonStreaming verifies that the /v1/messages non-streaming
-// response body returns the Anthropic-form model ID (e.g. claude-opus-4-7), not
-// the Kiro SKU (claude-opus-4.7). Claude Code matches this ID against its
-// hard-coded table to detect the 1M context window; the dotted Kiro SKU would
-// fall back to the 200k default and trigger premature auto-compact.
+// TestE2E_ResponseModel_NonStreaming verifies the non-streaming response body
+// carries the Anthropic-form model ID so Claude Code's context-window table
+// (which keys off hyphenated IDs) picks up 1M-context models correctly.
 func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -85,8 +83,8 @@ func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 	}
 }
 
-// TestE2E_ResponseModel_Streaming verifies that the SSE message_start event
-// contains the Anthropic-form model ID.
+// TestE2E_ResponseModel_Streaming verifies message_start carries the
+// Anthropic-form model ID.
 func TestE2E_ResponseModel_Streaming(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -127,8 +125,8 @@ func TestE2E_ResponseModel_Streaming(t *testing.T) {
 	}
 }
 
-// extractMessageStartModel scans an SSE body for the message_start event and
-// returns its message.model field.
+// extractMessageStartModel returns message.model from the first message_start
+// SSE event in body.
 func extractMessageStartModel(t *testing.T, body io.Reader) string {
 	t.Helper()
 	scanner := bufio.NewScanner(body)


### PR DESCRIPTION
## Summary

- Return the **Anthropic-form model ID** (e.g. `claude-opus-4-7`) in `/v1/messages` response bodies, streaming `message_start` events, and the tool-search final JSON, instead of the Kiro SKU (`claude-opus-4.7`).
- Upstream calls to Kiro still use the Kiro SKU — only the external response surface changed.

## Why

Claude Code decides context window size **client-side** by matching the response's `model` field against a hard-coded table of hyphenated Anthropic IDs (`cli.js` — `ff(modelID, sdkBetas)` → `AX()` → `vo()`). The dotted Kiro SKU did not match any branch of `AX`, so `vo` returned false, `ff` fell back to the 200k default, and auto-compact fired at ~160k (80% of 200k) even though Opus 4.7 is pinned to 1M context upstream.

## Changes

- `internal/models/models.go` — `Resolve` now returns a fourth value `anthropicModel`. Non-claude fallback maps to `DefaultAnthropicModel = "claude-sonnet-4-6"`. Env overrides cannot poison the fallback.
- `internal/app/messages/handler.go` — threads `anthropicModel` through `callAndHandle` and the tool-search orchestrator as `responseModel`.
- `internal/app/messages/toolsearch.go` — `toolSearchOrchestrator` gains a `responseModel` field; three sites (`NewSSEWriter`, `BuildResponse`, final JSON `model`) now use it instead of `o.buildOpts.ModelID`.
- `README.md` — documents the Anthropic-form response ID and why it matters.

## Test plan

- [x] `make test` — new `TestE2E_ResponseModel_NonStreaming` and `TestE2E_ResponseModel_Streaming` verify the response `model` field and the upstream `ModelID` independently (hyphen preserved, dotted input rewritten to hyphen, unknown `claude-*` passthrough).
- [x] `make lint`
- [x] `make build`
- [ ] Manual: run a Claude Code session against the proxy with Opus 4.7 and confirm `/context` reports the 1M window and auto-compact does not fire at 160k.