### PR TITLE
Release v0.0.12

### DIFF
--- a/docs/release-notes/v0.0.12.md
+++ b/docs/release-notes/v0.0.12.md
@@ -1,0 +1,23 @@
+# Release v0.0.12
+
+## Bug Fixes
+
+### Return Anthropic model ID in responses to preserve 1M context detection (#49)
+
+`/v1/messages` responses (streaming `message_start`, non-streaming body, and the tool-search final JSON) now return the Anthropic-form model ID (e.g. `claude-opus-4-7`) instead of the Kiro SKU (`claude-opus-4.7`). Claude Code decides context window size client-side by matching the response's `model` against its own hard-coded table of hyphenated Anthropic IDs; the dotted Kiro SKU did not match, causing Claude Code to fall back to the 200k default and trigger auto-compact prematurely for 1M-context models like Opus 4.7 / 4.6 and Sonnet 4.6. Upstream calls to Kiro still use the Kiro SKU unchanged.
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.0.12
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.0.11...v0.0.12


### PR DESCRIPTION
## Summary

Release v0.0.12

See [docs/release-notes/v0.0.12.md](https://github.com/d-kuro/kirocc/blob/release/v0.0.12/docs/release-notes/v0.0.12.md) for details.