### PR TITLE
fix: remove 404-prone release notes link from release PR body

### DIFF
--- a/.claude/skills/release-kirocc/SKILL.md
+++ b/.claude/skills/release-kirocc/SKILL.md
@@ -136,7 +136,7 @@ gh pr create --title "Release <version>" --body "$(cat <<'EOF'
 
 Release <version>
 
-See [docs/release-notes/<version>.md](https://github.com/d-kuro/kirocc/blob/release/<version>/docs/release-notes/<version>.md) for details.
+See `docs/release-notes/<version>.md` for details.
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary

- The `release-kirocc` skill embedded an absolute blob URL pointing at the `release/<version>` branch in the PR body. Because the repo has `delete_branch_on_merge=true`, that URL 404s right after the PR is merged.
- Drop the hyperlink and reference the file path in plain text. Reviewers can still open the file from the PR Files changed tab, and there is no link left to break after merge.
- Mirrors d-kuro/gwq#101.

## Test plan

- [ ] Next release PR body shows \`docs/release-notes/<version>.md\` as plain text (no hyperlink)
- [ ] Post-merge revisit of the PR body has no 404-ing link