### PR TITLE
fix: preserve [1m] suffix on Opus 4.6/4.7 default requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,17 +260,23 @@ Supported query forms:
 | `claude-sonnet-4.5`     | `claude-sonnet-4.5`    | 200k           |
 | `claude-sonnet-4.5[1m]` | `claude-sonnet-4.5-1m` | 1M             |
 | `claude-opus-4-7`       | `claude-opus-4.7`      | 1M             |
+| `claude-opus-4-7[1m]`   | `claude-opus-4.7`      | 1M             |
 | `claude-opus-4-6`       | `claude-opus-4.6`      | 1M             |
+| `claude-opus-4-6[1m]`   | `claude-opus-4.6`      | 1M             |
 | `claude-opus-4.5`       | `claude-opus-4.5`      | 200k           |
 | `claude-haiku-4.5`      | `claude-haiku-4.5`     | 200k           |
 
-Opus 4.6 and 4.7 always use 1M context (no 200k SKU exists upstream). Thinking is still opt-in via `[1m]` suffix, `Anthropic-Beta: context-1m` header, or `thinking` field.
+Opus 4.6 and 4.7 always use 1M context (no 200k SKU exists upstream). The explicit `[1m]`-suffixed aliases (`claude-opus-4-7[1m]` / `claude-opus-4-6[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field — this matches Claude Code's default Max-plan state (`lG()` emits `claude-opus-4-7[1m]`) and keeps its `mR()` 1M-context check happy without spuriously enabling extended thinking. Thinking is still opt-in via Sonnet `[1m]` suffix, `Anthropic-Beta: context-1m` header, or `thinking` field.
 
 Unmatched `claude-*` models are passed through as-is. Non-claude models fall back to `claude-sonnet-4.6`.
 
 #### Response model ID
 
-The `model` field in `/v1/messages` responses (streaming `message_start`, non-streaming body, and tool-search path) is returned as the **Anthropic-form ID** (e.g. `claude-opus-4-7`), not the Kiro SKU (`claude-opus-4.7`). Claude Code detects context window size by matching the response's model ID against its own hard-coded table of hyphenated Anthropic IDs — the dotted Kiro SKU would not match and would cause Claude Code to fall back to the 200k default, triggering auto-compact prematurely for 1M-context models like Opus 4.7 / 4.6 and Sonnet 4.6.
+The `model` field in `/v1/messages` responses (streaming `message_start`, non-streaming body, and tool-search path) is returned as the **Anthropic-form ID** (e.g. `claude-opus-4-7`), not the Kiro SKU (`claude-opus-4.7`).
+
+When the proxy routes to a **1M context window** (always-1M SKU such as `claude-opus-4.7` / `claude-opus-4.6`, or a model invoked with the `[1m]` suffix or `Anthropic-Beta: context-1m` header), a trailing `[1m]` is appended to the response model ID (e.g. `claude-opus-4-7[1m]`). Claude Code's client-side context-window logic matches `/\[1m\]/i` on the response model to pick the 1M window — without the suffix it defaults to 200k and auto-compacts at ~160k even when upstream actually has 1M of context.
+
+Note: `[1m]` has different meanings on request vs. response. On the **request** `model` it is a client-supplied thinking-opt-in signal (and is stripped before upstream routing). On the **response** `model` it is purely a context-window advertisement for Claude Code and does not imply that extended thinking was enabled.
 
 ## License
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,6 +27,8 @@ const (
 // Uses exact key matching against both Anthropic and Kiro fields (first match wins).
 // Order matters: specific entries must precede legacy aliases that share the same Kiro value.
 var modelMapOrdered = []Mapping{
+	{Anthropic: "claude-opus-4-7[1m]", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
+	{Anthropic: "claude-opus-4-6[1m]", Kiro: "claude-opus-4.6", Kiro1M: "claude-opus-4.6"},
 	{Anthropic: "claude-opus-4-7", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
 	{Anthropic: "claude-sonnet-4-6", Kiro: "claude-sonnet-4.6", Kiro1M: "claude-sonnet-4.6-1m"},
 	{Anthropic: "claude-sonnet-4.5", Kiro: "claude-sonnet-4.5", Kiro1M: "claude-sonnet-4.5-1m"},
@@ -92,25 +94,33 @@ func effectiveMappings() []Mapping {
 
 // Resolve maps an Anthropic or Kiro model name to the Kiro SKU sent upstream,
 // the thinking flag, the context window size, and the Anthropic-form ID to
-// echo back in /v1/messages responses. Returning the Anthropic-form ID matters
-// because Claude Code decides context window size by matching the response's
-// model against its own hyphenated-ID table; the dotted Kiro SKU would miss.
-// KIROCC_MODEL_MAPPINGS env var can override mappings.
+// echo back in /v1/messages responses.
+//
+// Lookup is two-tier:
+//  1. Exact match against `m.Anthropic` / `m.Kiro` first (no `[1m]` strip).
+//     This catches always-1M aliases like `claude-opus-4-7[1m]` that are a
+//     context-window advertisement, not a thinking opt-in — the suffix is
+//     preserved verbatim in `anthropicModel` and `thinking` stays false.
+//  2. If no exact match, strip a trailing `[1m]` from the input, set
+//     `thinking = true`, and retry the lookup. This is the legacy path
+//     used by aliases that don't have an explicit `[1m]` entry (e.g.
+//     `claude-sonnet-4-6[1m]` routes to the `-1m` Kiro SKU with thinking).
+//
+// The output `anthropicModel` gets a trailing `[1m]` when the routed
+// context window is 1M (regardless of thinking), so Claude Code's
+// `mR()` / `A2()` picks the 1M window even if the input was bare.
+//
+// Upstream `kiroModel` is never `[1m]`-suffixed — it always comes from
+// mapping tables. KIROCC_MODEL_MAPPINGS env var can override mappings.
 func Resolve(model string, context1M bool) (kiroModel string, thinking bool, contextWindowSize int, anthropicModel string) {
-	// Strip thinking suffix
-	if before, ok := strings.CutSuffix(model, ThinkingSuffix); ok {
-		model = before
-		thinking = true
-	}
-	if context1M {
-		thinking = true
-	}
-
 	var matchedWindowSize int
 	var matchedKiro1M string
 	var matchedAnthropic string
 	var matched bool
-	for _, m := range effectiveMappings() {
+
+	// Tier 1: exact match (no strip). Handles `claude-opus-4-7[1m]` etc.
+	mappings := effectiveMappings()
+	for _, m := range mappings {
 		if model == m.Anthropic || model == m.Kiro {
 			kiroModel = m.Kiro
 			matchedKiro1M = m.Kiro1M
@@ -119,6 +129,28 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 			matched = true
 			break
 		}
+	}
+
+	// Tier 2: strip `[1m]` (treated as thinking opt-in) and retry.
+	if !matched {
+		if before, ok := strings.CutSuffix(model, ThinkingSuffix); ok {
+			model = before
+			thinking = true
+			for _, m := range mappings {
+				if model == m.Anthropic || model == m.Kiro {
+					kiroModel = m.Kiro
+					matchedKiro1M = m.Kiro1M
+					matchedWindowSize = m.ContextWindowSize
+					matchedAnthropic = m.Anthropic
+					matched = true
+					break
+				}
+			}
+		}
+	}
+
+	if context1M {
+		thinking = true
 	}
 
 	if !matched {
@@ -150,6 +182,13 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 		contextWindowSize = matchedWindowSize
 	default:
 		contextWindowSize = DefaultContextWindowSize
+	}
+
+	// Advertise 1M context to Claude Code by appending ThinkingSuffix to the
+	// response model ID. Guarded against double-suffix when a user-supplied
+	// env override specifies an already-suffixed anthropic value.
+	if contextWindowSize == ThinkingContextWindowSize && !strings.HasSuffix(anthropicModel, ThinkingSuffix) {
+		anthropicModel += ThinkingSuffix
 	}
 
 	return kiroModel, thinking, contextWindowSize, anthropicModel

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -21,15 +21,14 @@ func TestResolve(t *testing.T) {
 			model:              "claude-opus-4-7",
 			wantKiroModel:      "claude-opus-4.7",
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-7",
+			wantAnthropicModel: "claude-opus-4-7[1m]",
 		},
 		{
-			name:               "claude-opus-4-7 with thinking suffix",
+			name:               "claude-opus-4-7[1m] exact-match preserves suffix without thinking",
 			model:              "claude-opus-4-7[1m]",
 			wantKiroModel:      "claude-opus-4.7",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-7",
+			wantAnthropicModel: "claude-opus-4-7[1m]",
 		},
 		{
 			name:               "claude-opus-4-7 with context1M",
@@ -38,7 +37,7 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      "claude-opus-4.7",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-7",
+			wantAnthropicModel: "claude-opus-4-7[1m]",
 		},
 		{
 			name:               "kiro model name claude-opus-4.7 always resolves to 1m",
@@ -46,22 +45,21 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      "claude-opus-4.7",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-7",
+			wantAnthropicModel: "claude-opus-4-7[1m]",
 		},
 		{
 			name:               "claude-opus-4-6 uses 1m context without thinking",
 			model:              "claude-opus-4-6",
 			wantKiroModel:      "claude-opus-4.6",
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-6",
+			wantAnthropicModel: "claude-opus-4-6[1m]",
 		},
 		{
-			name:               "claude-opus-4-6 with thinking suffix",
+			name:               "claude-opus-4-6[1m] exact-match preserves suffix without thinking",
 			model:              "claude-opus-4-6[1m]",
 			wantKiroModel:      "claude-opus-4.6",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-6",
+			wantAnthropicModel: "claude-opus-4-6[1m]",
 		},
 		{
 			name:               "claude-opus-4-6 with context1M",
@@ -70,7 +68,7 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      "claude-opus-4.6",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-6",
+			wantAnthropicModel: "claude-opus-4-6[1m]",
 		},
 		{
 			name:               "claude-sonnet-4-6",
@@ -92,7 +90,7 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      "claude-sonnet-4.6-1m",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-sonnet-4-6",
+			wantAnthropicModel: "claude-sonnet-4-6[1m]",
 		},
 		{
 			name:               "claude-sonnet-4-6 with context1M resolves to 1m",
@@ -101,7 +99,7 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      "claude-sonnet-4.6-1m",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-sonnet-4-6",
+			wantAnthropicModel: "claude-sonnet-4-6[1m]",
 		},
 		{
 			name:               "claude-sonnet-4 with thinking suffix passthrough no 1m variant",
@@ -141,7 +139,7 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      "claude-sonnet-4.6-1m",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-sonnet-4-6",
+			wantAnthropicModel: "claude-sonnet-4-6[1m]",
 		},
 		{
 			name:               "kiro model name claude-opus-4.6 with thinking suffix",
@@ -149,7 +147,7 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      "claude-opus-4.6",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
-			wantAnthropicModel: "claude-opus-4-6",
+			wantAnthropicModel: "claude-opus-4-6[1m]",
 		},
 		{
 			name:               "unknown claude model passthrough",
@@ -196,6 +194,14 @@ func TestResolve(t *testing.T) {
 			wantKiroModel:      DefaultModel,
 			wantContextWindow:  DefaultContextWindowSize,
 			wantAnthropicModel: "claude-sonnet-4-6",
+		},
+		{
+			name:               "env override with already-suffixed anthropic does not double-suffix at 1m",
+			envMappings:        `[{"anthropic":"custom-1m[1m]","kiro":"claude-custom-1m","kiro_1m":"claude-custom-1m"}]`,
+			model:              "claude-custom-1m",
+			wantKiroModel:      "claude-custom-1m",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "custom-1m[1m]",
 		},
 	}
 

--- a/internal/server/e2e_response_model_test.go
+++ b/internal/server/e2e_response_model_test.go
@@ -21,13 +21,13 @@ func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 		{
 			name:         "opus-4-7 hyphen preserved in response",
 			requestModel: "claude-opus-4-7",
-			wantResponse: "claude-opus-4-7",
+			wantResponse: "claude-opus-4-7[1m]",
 			wantUpstream: "claude-opus-4.7",
 		},
 		{
 			name:         "opus-4-6 hyphen preserved in response",
 			requestModel: "claude-opus-4-6",
-			wantResponse: "claude-opus-4-6",
+			wantResponse: "claude-opus-4-6[1m]",
 			wantUpstream: "claude-opus-4.6",
 		},
 		{
@@ -39,8 +39,20 @@ func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 		{
 			name:         "kiro dotted input is rewritten to anthropic hyphen in response",
 			requestModel: "claude-opus-4.7",
-			wantResponse: "claude-opus-4-7",
+			wantResponse: "claude-opus-4-7[1m]",
 			wantUpstream: "claude-opus-4.7",
+		},
+		{
+			name:         "opus-4-7[1m] exact-match preserved verbatim",
+			requestModel: "claude-opus-4-7[1m]",
+			wantResponse: "claude-opus-4-7[1m]",
+			wantUpstream: "claude-opus-4.7",
+		},
+		{
+			name:         "opus-4-6[1m] exact-match preserved verbatim",
+			requestModel: "claude-opus-4-6[1m]",
+			wantResponse: "claude-opus-4-6[1m]",
+			wantUpstream: "claude-opus-4.6",
 		},
 		{
 			name:         "unknown claude model passthrough",
@@ -94,12 +106,17 @@ func TestE2E_ResponseModel_Streaming(t *testing.T) {
 		{
 			name:         "opus-4-7 hyphen preserved in message_start",
 			requestModel: "claude-opus-4-7",
-			wantResponse: "claude-opus-4-7",
+			wantResponse: "claude-opus-4-7[1m]",
+		},
+		{
+			name:         "opus-4-7[1m] exact-match preserved verbatim in message_start",
+			requestModel: "claude-opus-4-7[1m]",
+			wantResponse: "claude-opus-4-7[1m]",
 		},
 		{
 			name:         "kiro dotted input is rewritten to hyphen in message_start",
 			requestModel: "claude-opus-4.7",
-			wantResponse: "claude-opus-4-7",
+			wantResponse: "claude-opus-4-7[1m]",
 		},
 	}
 
@@ -150,4 +167,78 @@ func extractMessageStartModel(t *testing.T, body io.Reader) string {
 	}
 	t.Fatal("message_start event not found in SSE body")
 	return ""
+}
+
+// TestE2E_ResponseModel_ToolSearch_1M verifies that the tool-search
+// orchestrator threads the `[1m]` suffix through both its streaming
+// message_start event and its final non-streaming JSON body when the
+// resolved context window is 1M.
+func TestE2E_ResponseModel_ToolSearch_1M(t *testing.T) {
+	toolSearchRequest := func(model string, stream bool) string {
+		streamStr := "false"
+		if stream {
+			streamStr = "true"
+		}
+		return `{"model":"` + model + `","max_tokens":16,"stream":` + streamStr + `,` +
+			`"messages":[{"role":"user","content":"hi"}],` +
+			`"tools":[` +
+			`{"type":"tool_search_tool_regex_20251119","name":"tool_search_tool_regex"},` +
+			`{"name":"Read","description":"Read a file","input_schema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]},"defer_loading":true}` +
+			`]}`
+	}
+
+	t.Run("streaming message_start carries [1m] suffix", func(t *testing.T) {
+		p1 := mustJSON(map[string]string{"content": "ok"})
+		client := &capturingClient{events: []any{"assistantResponseEvent", p1}}
+
+		srv := newE2EServer(t, client)
+		defer srv.Close()
+
+		resp := postMessages(t, srv.URL, toolSearchRequest("claude-opus-4-7", true))
+		defer func() { _ = resp.Body.Close() }()
+		requireStatus(t, resp, 200)
+
+		msg := extractMessageStartModel(t, resp.Body)
+		if msg != "claude-opus-4-7[1m]" {
+			t.Errorf("tool-search streaming message_start model = %q, want %q", msg, "claude-opus-4-7[1m]")
+		}
+	})
+
+	t.Run("non-streaming final JSON carries [1m] suffix", func(t *testing.T) {
+		p1 := mustJSON(map[string]string{"content": "ok"})
+		client := &capturingClient{events: []any{"assistantResponseEvent", p1}}
+
+		srv := newE2EServer(t, client)
+		defer srv.Close()
+
+		resp := postMessages(t, srv.URL, toolSearchRequest("claude-opus-4-7", false))
+		defer func() { _ = resp.Body.Close() }()
+		requireStatus(t, resp, 200)
+
+		var result map[string]any
+		if err := json.UnmarshalRead(resp.Body, &result); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		gotModel, _ := result["model"].(string)
+		if gotModel != "claude-opus-4-7[1m]" {
+			t.Errorf("tool-search non-streaming response model = %q, want %q", gotModel, "claude-opus-4-7[1m]")
+		}
+	})
+
+	t.Run("exact-match [1m] input preserved in streaming message_start", func(t *testing.T) {
+		p1 := mustJSON(map[string]string{"content": "ok"})
+		client := &capturingClient{events: []any{"assistantResponseEvent", p1}}
+
+		srv := newE2EServer(t, client)
+		defer srv.Close()
+
+		resp := postMessages(t, srv.URL, toolSearchRequest("claude-opus-4-7[1m]", true))
+		defer func() { _ = resp.Body.Close() }()
+		requireStatus(t, resp, 200)
+
+		msg := extractMessageStartModel(t, resp.Body)
+		if msg != "claude-opus-4-7[1m]" {
+			t.Errorf("tool-search streaming message_start model = %q, want %q", msg, "claude-opus-4-7[1m]")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Claude Code's Max-plan default state sends `claude-opus-4-7[1m]` as the request `model` (emitted by `lG()` when `bD()` is true). The previous `Resolve` unconditionally stripped `[1m]` at the top, dropping the signal needed to keep Claude Code's `mR()` 1M-context check happy and spuriously setting `thinking=true` upstream.
- Add explicit mapping entries for `claude-opus-4-7[1m]` and `claude-opus-4-6[1m]`, and switch `Resolve` to a two-tier lookup: exact match first (preserves the suffix verbatim with no thinking), then fall back to the legacy `[1m]`-strip path for Sonnet and unknown aliases.
- Follow-up to #49: that PR assumed clients key off the response `model` alone, but Claude Code 2.1.114 also consults the locally-held request model — so the suffix must survive the round trip verbatim when the client sends it.

## Behavior

| Input                     | Kiro SKU             | Thinking | Response model           |
| ------------------------- | -------------------- | -------- | ------------------------ |
| `claude-opus-4-7`         | `claude-opus-4.7`    | false    | `claude-opus-4-7[1m]`    |
| `claude-opus-4-7[1m]`     | `claude-opus-4.7`    | **false** (was `true`) | `claude-opus-4-7[1m]`    |
| `claude-opus-4-6[1m]`     | `claude-opus-4.6`    | **false** (was `true`) | `claude-opus-4-6[1m]`    |
| `claude-sonnet-4-6[1m]`   | `claude-sonnet-4.6-1m` | true   | `claude-sonnet-4-6[1m]`  |
| `claude-haiku-4.5[1m]`    | `claude-haiku-4.5`   | true     | `claude-haiku-4.5`       |

Sonnet/Haiku `[1m]` behavior is unchanged (no explicit mapping entry → strip path).

## Test plan

- [x] `make test` — existing + new table rows (Opus `[1m]` exact-match, e2e non-streaming / streaming / tool-search)
- [x] `make lint`
- [x] `make build`
- [ ] Manual: start proxy, run Claude Code with Opus 4.7, confirm `/context` shows `… / 1M tokens`