### PR TITLE
Release v0.1.0

### DIFF
--- a/docs/release-notes/v0.1.0.md
+++ b/docs/release-notes/v0.1.0.md
@@ -1,0 +1,46 @@
+# Release v0.1.0
+
+## Bug Fixes
+
+### Preserve `[1m]` suffix on Opus 4.6/4.7 default requests (#53)
+
+Claude Code's Max-plan default state sends `claude-opus-4-7[1m]` as the request `model`. The previous `Resolve` unconditionally stripped the `[1m]` suffix, dropping the signal needed to keep Claude Code's 1M-context check happy and spuriously enabling `thinking=true` upstream.
+
+`Resolve` now performs a two-tier lookup: exact match first (preserves the suffix verbatim with no thinking for Opus 4.6/4.7), then falls back to the legacy `[1m]`-strip path for Sonnet and unknown aliases. Sonnet/Haiku `[1m]` behavior is unchanged.
+
+This is a follow-up to #49 in v0.0.12: that PR assumed clients key off the response `model` alone, but Claude Code 2.1.114 also consults the locally-held request model — so the suffix must survive the round trip verbatim when the client sends it.
+
+### Remove 404-prone release notes link from release PR body (#52)
+
+The `release-kirocc` skill embedded an absolute blob URL pointing at the `release/<version>` branch in the PR body. Because the repo has `delete_branch_on_merge=true`, that URL 404'd right after the PR was merged. The hyperlink is now rendered as a plain-text file path.
+
+## Code Improvements
+
+### Decompose hot paths and extract shared HTTP/tracing helpers (#54)
+
+Large internal refactor spanning the whole proxy pipeline. No change to the public Anthropic Messages API (SSE / JSON shapes, status codes, error envelope). Tests grew from 599 → 611 as RED reproducers were added.
+
+- **Shared HTTP / tracing helpers** — Extract `internal/httpx.WriteError` / `WriteJSON` with Anthropic error-type constants; move `sanitizedHeaderAttrs` and OTel body-event recording into `internal/tracing/header_attrs.go`; unwind the `server → app/messages` reverse reference.
+- **respconv split & pipeline consolidation** — Break up the 540-line `event_accumulator.go` into focused files (`accumulator.go`, `stop_sequence.go`, `thinking_tags.go`, `token_budget.go`, `usage.go`, `event_processor.go`). New `finalize.go` shares the `FinalizeStream → resolveStopReason → resolvedUsage → UsageMap` pipeline between streaming and non-streaming paths. Add `SSEWriter.writeBlock` helper to dedupe the `content_block_start/delta/stop` sequence.
+- **reqconv cleanup** — Rename numbered normalizer steps to intent names (`textualizeToolContent`, `normalizeRoles`, `mergeAdjacentSameRole`, `ensureStartsWithUser`, `ensureAlternatingRoles`). `mergeAdjacentSameRole` now accumulates via a single `strings.Builder` (was O(n²) concat). Collapse 3 passes over `lastMsg.Content` in `buildCurrentMessage` into a single `scanCurrentMessage` walk. `ReverseMap` returns a defensive copy.
+- **messages handler decomposition** — `HandleMessages` went from 195 → 146 lines. `callAndHandle`'s 11 positional args collapsed into a single `invocation` struct. `parseToolSearchInput` now surfaces `invalid_request_error` to clients instead of silently swallowing bad JSON. `upstreamCaptureEnabled` is no longer a package-global — capture is now wired through `messages.WithCapture(bool)` from `main` using `cfg.Debug`.
+- **kiroclient / auth / config / main** — Split `kiroclient/client.go` (481 → 321 lines) into `aws_error.go`, `backoff.go`, `idle_reader.go`. `isEventStreamContentType` now uses `mime.ParseMediaType` instead of ad-hoc string matching. Add `Config.Validate()` (port range, non-empty host, non-negative OTel body limit). `main()` split into `main() + run(ctx, args) error`.
+- **CLI help** — `-h` / `--help` now exits 0 after printing usage (was exiting non-zero).
+
+### Update modernc.org/sqlite to v1.49.1 (#51)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.1.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.0.12...v0.1.0


### PR DESCRIPTION
## Summary

Release v0.1.0

See `docs/release-notes/v0.1.0.md` for details.