### PR TITLE
feat: log Kiro credit consumption from meteringEvent

### DIFF
--- a/internal/app/messages/response.go
+++ b/internal/app/messages/response.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/d-kuro/kirocc/internal/httpx"
 	"github.com/d-kuro/kirocc/internal/kiroclient"
 	"github.com/d-kuro/kirocc/internal/kiroproto"
@@ -63,6 +66,8 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 			return false
 		}
 		// Distinguish adapter-side stop (Finish already called) from error.
+		// Closing the upstream body immediately on localStop avoids paying
+		// for tokens/credits the client will never receive.
 		if sw.LocalStop() {
 			localStop = true
 			return true
@@ -104,6 +109,9 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 		}
 		args = append(args, capture.logAttrs()...)
 		slog.WarnContext(ctx, "empty visible end_turn detected", args...)
+		if credits, ok := sw.Credits(); ok {
+			logAbortedAttemptCredits(ctx, short, credits, retryReasonEmptyVisibleEndTurn)
+		}
 		return retryReasonEmptyVisibleEndTurn
 	}
 
@@ -115,7 +123,8 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 			"headers", logging.SafeHeaders{H: gw.Header()},
 		)
 		inputTokens, outputTokens := sw.Usage()
-		logResponseStats(ctx, short, inputTokens, outputTokens, sw.HasContextUsage(), sw.ContextUsagePercentage(), contextWindowSize)
+		credits, hasCredits := sw.Credits()
+		logResponseStats(ctx, short, inputTokens, outputTokens, sw.HasContextUsage(), sw.ContextUsagePercentage(), contextWindowSize, credits, hasCredits)
 	}
 	return ""
 }
@@ -175,6 +184,9 @@ func (s *Service) handleNonStreamingResponse(ctx context.Context, w http.Respons
 		}
 		args = append(args, capture.logAttrs()...)
 		slog.WarnContext(ctx, "empty visible end_turn detected", args...)
+		if credits, ok := acc.Credits(); ok {
+			logAbortedAttemptCredits(ctx, short, credits, retryReasonEmptyVisibleEndTurn)
+		}
 		return retryReasonEmptyVisibleEndTurn
 	}
 
@@ -190,32 +202,52 @@ func (s *Service) handleNonStreamingResponse(ctx context.Context, w http.Respons
 	}
 	_, _ = w.Write([]byte("\n"))
 
-	logResponseStats(ctx, short, stats.InputTokens, stats.OutputTokens, stats.HasContextUsage, stats.ContextUsagePercentage, contextWindowSize)
+	logResponseStats(ctx, short, stats.InputTokens, stats.OutputTokens, stats.HasContextUsage, stats.ContextUsagePercentage, contextWindowSize, stats.Credits, stats.HasCredits)
 	return ""
 }
 
 // logResponseStats logs response completion and warns on context limit exceeded.
-func logResponseStats(ctx context.Context, short string, inputTokens, outputTokens int, hasContextUsage bool, contextUsagePct float64, contextWindowSize int) {
+func logResponseStats(ctx context.Context, short string, inputTokens, outputTokens int, hasContextUsage bool, contextUsagePct float64, contextWindowSize int, credits float64, hasCredits bool) {
 	hasUsage := inputTokens > 0 || outputTokens > 0 || hasContextUsage
 	pct := resolveContextPercent(contextUsagePct, hasContextUsage, inputTokens, contextWindowSize)
 	contextUsage := "unknown"
 	if hasUsage {
 		contextUsage = fmt.Sprintf("%.1fk(%.1f%%)", float64(inputTokens)/1000, pct)
 	}
-	slog.InfoContext(ctx, "<-- POST /v1/messages",
+	if hasCredits {
+		trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("kiro.credits", credits))
+	}
+	args := []any{
 		"trace_id", short,
 		"session_id", logging.ShortID(logging.SessionIDFromContext(ctx)),
 		"status", 200,
 		"input_tokens", inputTokens,
 		"output_tokens", outputTokens,
 		"context_usage", contextUsage,
-	)
+	}
+	if hasCredits {
+		args = append(args, "credits", credits)
+	}
+	slog.InfoContext(ctx, "<-- POST /v1/messages", args...)
 	if hasUsage && pct >= 100 {
 		slog.WarnContext(ctx, "context limit exceeded",
 			"trace_id", short,
 			"context_usage", fmt.Sprintf("%.1fk(%.1f%%)", float64(inputTokens)/1000, pct),
 		)
 	}
+}
+
+// logAbortedAttemptCredits logs the credits consumed by an upstream attempt
+// that the proxy decided to abandon (e.g. empty-visible end_turn that triggers
+// retry). The successful retry's credits flow through logResponseStats normally,
+// so this avoids under-reporting cumulative credit consumption.
+func logAbortedAttemptCredits(ctx context.Context, short string, credits float64, reason string) {
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("kiro.credits.aborted_attempt", credits))
+	slog.InfoContext(ctx, "upstream attempt credits (aborted)",
+		"trace_id", short,
+		"credits", credits,
+		"reason", reason,
+	)
 }
 
 // resolveContextPercent returns the context usage percentage, falling back to

--- a/internal/app/messages/response.go
+++ b/internal/app/messages/response.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -16,6 +17,14 @@ import (
 	"github.com/d-kuro/kirocc/internal/logging"
 	"github.com/d-kuro/kirocc/internal/respconv"
 )
+
+// roundCredits rounds credit consumption to 3 decimals for human-readable
+// log output and OTel attributes. Kiro reports raw values like 0.19354654693200665
+// which are noisy at full precision; 0.001 (1 milli-credit) is the smallest
+// unit that matters for display.
+func roundCredits(c float64) float64 {
+	return math.Round(c*1000) / 1000
+}
 
 const retryReasonEmptyVisibleEndTurn = "empty_visible_end_turn"
 
@@ -214,9 +223,6 @@ func logResponseStats(ctx context.Context, short string, inputTokens, outputToke
 	if hasUsage {
 		contextUsage = fmt.Sprintf("%.1fk(%.1f%%)", float64(inputTokens)/1000, pct)
 	}
-	if hasCredits {
-		trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("kiro.credits", credits))
-	}
 	args := []any{
 		"trace_id", short,
 		"session_id", logging.ShortID(logging.SessionIDFromContext(ctx)),
@@ -226,7 +232,9 @@ func logResponseStats(ctx context.Context, short string, inputTokens, outputToke
 		"context_usage", contextUsage,
 	}
 	if hasCredits {
-		args = append(args, "credits", credits)
+		rounded := roundCredits(credits)
+		trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("kiro.credits", rounded))
+		args = append(args, "credits", rounded)
 	}
 	slog.InfoContext(ctx, "<-- POST /v1/messages", args...)
 	if hasUsage && pct >= 100 {
@@ -242,10 +250,11 @@ func logResponseStats(ctx context.Context, short string, inputTokens, outputToke
 // retry). The successful retry's credits flow through logResponseStats normally,
 // so this avoids under-reporting cumulative credit consumption.
 func logAbortedAttemptCredits(ctx context.Context, short string, credits float64, reason string) {
-	trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("kiro.credits.aborted_attempt", credits))
+	rounded := roundCredits(credits)
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("kiro.credits.aborted_attempt", rounded))
 	slog.InfoContext(ctx, "upstream attempt credits (aborted)",
 		"trace_id", short,
-		"credits", credits,
+		"credits", rounded,
 		"reason", reason,
 	)
 }

--- a/internal/app/messages/response_test.go
+++ b/internal/app/messages/response_test.go
@@ -1,0 +1,91 @@
+package messages
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/d-kuro/kirocc/internal/logging"
+)
+
+// captureSlog redirects slog.Default to a buffer-backed OTel handler for the
+// duration of the test, restoring the previous default in cleanup.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(logging.NewOTelHandler(&buf, slog.LevelDebug)))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+// findRecord scans the buffer for the first JSON-Lines record whose body matches.
+func findRecord(t *testing.T, buf *bytes.Buffer, body string) map[string]any {
+	t.Helper()
+	for line := range strings.SplitSeq(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["body"] == body {
+			return rec
+		}
+	}
+	t.Fatalf("no log record with body=%q in output:\n%s", body, buf.String())
+	return nil
+}
+
+func TestLogResponseStats_IncludesCredits(t *testing.T) {
+	buf := captureSlog(t)
+	logResponseStats(t.Context(), "abc123", 100, 50, true, 5.0, 200000, 0.5417, true)
+
+	rec := findRecord(t, buf, "<-- POST /v1/messages")
+	attrs, ok := rec["attributes"].(map[string]any)
+	if !ok {
+		t.Fatal("attributes missing")
+	}
+	got, ok := attrs["credits"]
+	if !ok {
+		t.Fatalf("credits attribute missing; attrs=%v", attrs)
+	}
+	if got != 0.5417 {
+		t.Fatalf("credits = %v, want 0.5417", got)
+	}
+}
+
+func TestLogResponseStats_OmitsCreditsWhenAbsent(t *testing.T) {
+	buf := captureSlog(t)
+	logResponseStats(t.Context(), "abc123", 100, 50, true, 5.0, 200000, 0, false)
+
+	rec := findRecord(t, buf, "<-- POST /v1/messages")
+	attrs, ok := rec["attributes"].(map[string]any)
+	if !ok {
+		t.Fatal("attributes missing")
+	}
+	if _, present := attrs["credits"]; present {
+		t.Fatalf("credits attribute should be omitted when hasCredits=false; attrs=%v", attrs)
+	}
+}
+
+func TestLogAbortedAttemptCredits(t *testing.T) {
+	buf := captureSlog(t)
+	logAbortedAttemptCredits(t.Context(), "abc123", 0.123, retryReasonEmptyVisibleEndTurn)
+
+	rec := findRecord(t, buf, "upstream attempt credits (aborted)")
+	attrs, ok := rec["attributes"].(map[string]any)
+	if !ok {
+		t.Fatal("attributes missing")
+	}
+	if attrs["credits"] != 0.123 {
+		t.Fatalf("credits = %v, want 0.123", attrs["credits"])
+	}
+	if attrs["reason"] != retryReasonEmptyVisibleEndTurn {
+		t.Fatalf("reason = %v, want %q", attrs["reason"], retryReasonEmptyVisibleEndTurn)
+	}
+}

--- a/internal/app/messages/response_test.go
+++ b/internal/app/messages/response_test.go
@@ -43,7 +43,7 @@ func findRecord(t *testing.T, buf *bytes.Buffer, body string) map[string]any {
 
 func TestLogResponseStats_IncludesCredits(t *testing.T) {
 	buf := captureSlog(t)
-	logResponseStats(t.Context(), "abc123", 100, 50, true, 5.0, 200000, 0.5417, true)
+	logResponseStats(t.Context(), "abc123", 100, 50, true, 5.0, 200000, 0.19354654693200665, true)
 
 	rec := findRecord(t, buf, "<-- POST /v1/messages")
 	attrs, ok := rec["attributes"].(map[string]any)
@@ -54,8 +54,8 @@ func TestLogResponseStats_IncludesCredits(t *testing.T) {
 	if !ok {
 		t.Fatalf("credits attribute missing; attrs=%v", attrs)
 	}
-	if got != 0.5417 {
-		t.Fatalf("credits = %v, want 0.5417", got)
+	if got != 0.194 {
+		t.Fatalf("credits = %v, want 0.194 (rounded to 3 decimals)", got)
 	}
 }
 
@@ -73,9 +73,28 @@ func TestLogResponseStats_OmitsCreditsWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestRoundCredits(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want float64
+	}{
+		{0.19354654693200665, 0.194},
+		{0.5417483374129354, 0.542},
+		{0.0004, 0},
+		{0.0005, 0.001}, // half rounds away from zero (math.Round)
+		{0, 0},
+		{1, 1},
+	}
+	for _, tc := range cases {
+		if got := roundCredits(tc.in); got != tc.want {
+			t.Errorf("roundCredits(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestLogAbortedAttemptCredits(t *testing.T) {
 	buf := captureSlog(t)
-	logAbortedAttemptCredits(t.Context(), "abc123", 0.123, retryReasonEmptyVisibleEndTurn)
+	logAbortedAttemptCredits(t.Context(), "abc123", 0.12345, retryReasonEmptyVisibleEndTurn)
 
 	rec := findRecord(t, buf, "upstream attempt credits (aborted)")
 	attrs, ok := rec["attributes"].(map[string]any)
@@ -83,7 +102,7 @@ func TestLogAbortedAttemptCredits(t *testing.T) {
 		t.Fatal("attributes missing")
 	}
 	if attrs["credits"] != 0.123 {
-		t.Fatalf("credits = %v, want 0.123", attrs["credits"])
+		t.Fatalf("credits = %v, want 0.123 (rounded)", attrs["credits"])
 	}
 	if attrs["reason"] != retryReasonEmptyVisibleEndTurn {
 		t.Fatalf("reason = %v, want %q", attrs["reason"], retryReasonEmptyVisibleEndTurn)

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -22,6 +22,40 @@ import (
 
 const maxToolSearchRounds = 3
 
+// roundTotals accumulates per-round usage across tool-search rounds and folds
+// in the current (partial) round when a final summary is needed.
+type roundTotals struct {
+	inputTokens  int
+	outputTokens int
+	credits      float64
+	hasCredits   bool
+}
+
+// addCompleted accumulates a round whose accumulator is about to be reset.
+func (t *roundTotals) addCompleted(in, out int, credits float64, hasCredits bool) {
+	t.inputTokens += in
+	t.outputTokens += out
+	if hasCredits {
+		t.credits += credits
+		t.hasCredits = true
+	}
+}
+
+// withCurrent returns the totals folded together with the current round's stats.
+func (t roundTotals) withCurrent(in, out int, credits float64, hasCredits bool) (totalIn, totalOut int, totalCredits float64, totalHasCredits bool) {
+	totalIn = t.inputTokens + in
+	totalOut = t.outputTokens + out
+	totalCredits = t.credits + credits
+	totalHasCredits = t.hasCredits || hasCredits
+	return
+}
+
+// creditsWith returns cumulative credits including the current round; the bool
+// is true if any meteringEvent was observed across all rounds so far.
+func (t roundTotals) creditsWith(credits float64, hasCredits bool) (float64, bool) {
+	return t.credits + credits, t.hasCredits || hasCredits
+}
+
 // toolSearchOrchestrator manages the inner loop for tool search.
 type toolSearchOrchestrator struct {
 	service           *Service
@@ -52,7 +86,7 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 
 	msgs := slices.Clone(o.req.Messages)
 
-	var cumulativeInputTokens, cumulativeOutputTokens int
+	var totals roundTotals
 
 	for round := range maxToolSearchRounds {
 		payload, nameMap, err := o.buildPayload(msgs)
@@ -73,8 +107,8 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		if round > 0 {
 			// Accumulate usage from previous round before resetting.
 			in, out := sw.Usage()
-			cumulativeInputTokens += in
-			cumulativeOutputTokens += out
+			credits, hasCredits := sw.Credits()
+			totals.addCompleted(in, out, credits, hasCredits)
 			sw.ResetAccumulator(o.contextWindowSize, o.req.StopSequences, o.req.MaxTokens, 0)
 		}
 		sw.SetDropToolName(toolsearch.KiroToolSearchName)
@@ -84,8 +118,19 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		var streamErr, localStop bool
 
 		err = kiroproto.ParseStream(ctx, apiResp.Body, func(e kiroproto.Event) bool {
-			if streamErr || localStop || foundToolSearch {
+			if streamErr || localStop {
 				return true
+			}
+			// After the tool-search frame is observed, keep parsing so subsequent
+			// meteringEvent / contextUsageEvent frames flow into the accumulator.
+			// Upstream errors in the tail must still abort the round.
+			if foundToolSearch {
+				if e.Type == kiroproto.EventException || e.Type == kiroproto.EventInvalidState {
+					streamErr = true
+					return true
+				}
+				sw.RecordTail(e)
+				return false
 			}
 			if sw.WriteErr() {
 				streamErr = true
@@ -94,7 +139,7 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 			if e.Type == kiroproto.EventToolUse && e.ToolStop && e.ToolName == toolsearch.KiroToolSearchName {
 				foundToolSearch = true
 				toolSearchInput = e.ToolInput
-				return true
+				return false
 			}
 			shouldStop := sw.HandleEvent(e)
 			if sw.WriteErr() {
@@ -113,30 +158,34 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		})
 		_ = apiResp.Body.Close()
 
-		if err != nil && !foundToolSearch {
-			slog.ErrorContext(ctx, "stream error", "trace_id", short, "round", round+1, "err", err)
+		// A parse error or upstream error frame in the tail must abort the
+		// orchestrator even when the tool-search frame was already observed.
+		if err != nil || streamErr {
+			if err != nil {
+				slog.ErrorContext(ctx, "stream error", "trace_id", short, "round", round+1, "err", err)
+			}
 			writeStreamingOrJSONError(gw, sw, w, http.StatusBadGateway, errTypeAPI, "upstream stream error")
 			return ""
 		}
 
 		if !foundToolSearch {
-			if !streamErr && !localStop {
+			// streamErr was already handled above; only success/localStop reach here.
+			if !localStop {
 				sw.Finish()
 			}
 			// Detect empty visible end_turn (thinking-only response) and signal retry.
-			if !streamErr && !localStop && sw.IsEmptyVisibleEndTurn() && !gw.IsPromoted() {
+			if !localStop && sw.IsEmptyVisibleEndTurn() && !gw.IsPromoted() {
 				gw.Discard()
 				slog.WarnContext(ctx, "empty visible end_turn detected in tool search", "trace_id", short)
+				if credits, ok := totals.creditsWith(sw.Credits()); ok {
+					logAbortedAttemptCredits(ctx, short, credits, retryReasonEmptyVisibleEndTurn)
+				}
 				return retryReasonEmptyVisibleEndTurn
 			}
-			if streamErr && !gw.IsPromoted() {
-				gw.Discard()
-				httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream stream error")
-			}
-			if !streamErr {
-				inputTokens, outputTokens := sw.Usage()
-				logResponseStats(ctx, short, inputTokens+cumulativeInputTokens, outputTokens+cumulativeOutputTokens, sw.HasContextUsage(), sw.ContextUsagePercentage(), o.contextWindowSize)
-			}
+			in, out := sw.Usage()
+			credits, hasCredits := sw.Credits()
+			totalIn, totalOut, totalCredits, totalHasCredits := totals.withCurrent(in, out, credits, hasCredits)
+			logResponseStats(ctx, short, totalIn, totalOut, sw.HasContextUsage(), sw.ContextUsagePercentage(), o.contextWindowSize, totalCredits, totalHasCredits)
 			return ""
 		}
 
@@ -166,8 +215,10 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 	// Max rounds reached without normal completion.
 	slog.WarnContext(ctx, "tool search max rounds reached", "trace_id", short, "max_rounds", maxToolSearchRounds)
 	sw.Finish()
-	inputTokens, outputTokens := sw.Usage()
-	logResponseStats(ctx, short, inputTokens+cumulativeInputTokens, outputTokens+cumulativeOutputTokens, sw.HasContextUsage(), sw.ContextUsagePercentage(), o.contextWindowSize)
+	in, out := sw.Usage()
+	credits, hasCredits := sw.Credits()
+	totalIn, totalOut, totalCredits, totalHasCredits := totals.withCurrent(in, out, credits, hasCredits)
+	logResponseStats(ctx, short, totalIn, totalOut, sw.HasContextUsage(), sw.ContextUsagePercentage(), o.contextWindowSize, totalCredits, totalHasCredits)
 	return ""
 }
 
@@ -177,7 +228,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 	msgs := slices.Clone(o.req.Messages)
 
 	var orderedBlocks []any
-	var totalInputTokens, totalOutputTokens int
+	var totals roundTotals
 	var lastStopReason string
 	var lastStopSequence any
 
@@ -225,8 +276,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 		}
 
 		resp, stats := acc.BuildResponse(o.responseModel)
-		totalInputTokens += stats.InputTokens
-		totalOutputTokens += stats.OutputTokens
+		totals.addCompleted(stats.InputTokens, stats.OutputTokens, stats.Credits, stats.HasCredits)
 		lastStopReason, _ = resp["stop_reason"].(string)
 		lastStopSequence = resp["stop_sequence"]
 
@@ -238,6 +288,9 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 			// Detect empty visible end_turn (thinking-only response) and signal retry.
 			if acc.IsEmptyVisibleEndTurn() {
 				slog.WarnContext(ctx, "empty visible end_turn detected in tool search", "trace_id", short)
+				if totals.hasCredits {
+					logAbortedAttemptCredits(ctx, short, totals.credits, retryReasonEmptyVisibleEndTurn)
+				}
 				return retryReasonEmptyVisibleEndTurn
 			}
 			normalExit = true
@@ -303,8 +356,8 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 		"stop_reason":   lastStopReason,
 		"stop_sequence": lastStopSequence,
 		"usage": map[string]any{
-			"input_tokens":                totalInputTokens,
-			"output_tokens":               totalOutputTokens,
+			"input_tokens":                totals.inputTokens,
+			"output_tokens":               totals.outputTokens,
 			"cache_read_input_tokens":     0,
 			"cache_creation_input_tokens": 0,
 		},
@@ -316,7 +369,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 	}
 	_, _ = w.Write([]byte("\n"))
 
-	logResponseStats(ctx, short, totalInputTokens, totalOutputTokens, false, 0, o.contextWindowSize)
+	logResponseStats(ctx, short, totals.inputTokens, totals.outputTokens, false, 0, o.contextWindowSize, totals.credits, totals.hasCredits)
 	return ""
 }
 

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -164,6 +164,12 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 			if err != nil {
 				slog.ErrorContext(ctx, "stream error", "trace_id", short, "round", round+1, "err", err)
 			}
+			// If the stream is already promoted, sw.HandleEvent has already
+			// emitted an SSE error event for invalidStateEvent/exception;
+			// emitting another would produce duplicate/conflicting frames.
+			if sw.Started() && gw.IsPromoted() {
+				return ""
+			}
 			writeStreamingOrJSONError(gw, sw, w, http.StatusBadGateway, errTypeAPI, "upstream stream error")
 			return ""
 		}

--- a/internal/respconv/accumulator.go
+++ b/internal/respconv/accumulator.go
@@ -51,6 +51,9 @@ type responseAccumulator struct {
 	HasContextUsage        bool
 	ContextUsagePercentage float64
 	ContextWindowSize      int // set externally by SSEWriter / BuildNonStreamingResponse
+	// Credit usage from meteringEvent.
+	HasCredits bool
+	Credits    float64
 	// Signature from reasoningContentEvent.
 	Signature string
 	// Conversation metadata.

--- a/internal/respconv/event_accumulator_test.go
+++ b/internal/respconv/event_accumulator_test.go
@@ -113,6 +113,31 @@ func TestAccumulator_MeteringFallback(t *testing.T) {
 	}
 }
 
+func TestAccumulator_MeteringCredits(t *testing.T) {
+	var acc responseAccumulator
+
+	if acc.HasCredits {
+		t.Fatal("expected HasCredits=false before any event")
+	}
+
+	acc.ProcessEvent(kiroproto.Event{Type: "meteringEvent", Credits: 0.42})
+	if !acc.HasCredits {
+		t.Fatal("expected HasCredits=true after meteringEvent")
+	}
+	if acc.Credits != 0.42 {
+		t.Fatalf("Credits = %v, want 0.42", acc.Credits)
+	}
+
+	// Last-wins: a subsequent meteringEvent overwrites the value but keeps HasCredits.
+	acc.ProcessEvent(kiroproto.Event{Type: "meteringEvent", Credits: 0})
+	if !acc.HasCredits {
+		t.Fatal("HasCredits should remain true")
+	}
+	if acc.Credits != 0 {
+		t.Fatalf("Credits = %v, want 0 (last-wins)", acc.Credits)
+	}
+}
+
 func TestAccumulator_ConversationID(t *testing.T) {
 	var acc responseAccumulator
 	acc.ProcessEvent(kiroproto.Event{Type: "messageMetadataEvent", ConversationID: "conv-abc"})

--- a/internal/respconv/event_accumulator_test.go
+++ b/internal/respconv/event_accumulator_test.go
@@ -1,6 +1,7 @@
 package respconv
 
 import (
+	"math"
 	"testing"
 
 	"github.com/d-kuro/kirocc/internal/kiroproto"
@@ -135,6 +136,42 @@ func TestAccumulator_MeteringCredits(t *testing.T) {
 	}
 	if acc.Credits != 0 {
 		t.Fatalf("Credits = %v, want 0 (last-wins)", acc.Credits)
+	}
+}
+
+func TestAccumulator_MeteringInvalidCreditsIgnored(t *testing.T) {
+	cases := []struct {
+		name    string
+		credits float64
+	}{
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+		{"negative", -1.5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var acc responseAccumulator
+			acc.ProcessEvent(kiroproto.Event{Type: "meteringEvent", Credits: tc.credits})
+			if acc.HasCredits {
+				t.Fatalf("HasCredits should remain false for invalid credits=%v", tc.credits)
+			}
+			if acc.Credits != 0 {
+				t.Fatalf("Credits should remain 0 for invalid input, got %v", acc.Credits)
+			}
+		})
+	}
+}
+
+func TestAccumulator_MeteringInvalidPreservesPriorValue(t *testing.T) {
+	var acc responseAccumulator
+	acc.ProcessEvent(kiroproto.Event{Type: "meteringEvent", Credits: 0.5})
+	acc.ProcessEvent(kiroproto.Event{Type: "meteringEvent", Credits: math.NaN()})
+	if !acc.HasCredits {
+		t.Fatal("HasCredits should stay true when a later metering is invalid")
+	}
+	if acc.Credits != 0.5 {
+		t.Fatalf("Credits = %v, want 0.5 (invalid event must not overwrite prior valid value)", acc.Credits)
 	}
 }
 

--- a/internal/respconv/event_processor.go
+++ b/internal/respconv/event_processor.go
@@ -2,6 +2,7 @@ package respconv
 
 import (
 	"encoding/json/jsontext"
+	"math"
 	"unicode/utf8"
 
 	"github.com/d-kuro/kirocc/internal/kiroproto"
@@ -72,8 +73,13 @@ func (a *responseAccumulator) ProcessEvent(e kiroproto.Event) EventDelta {
 		a.CacheWriteInputTokens = e.CacheWriteInputTokens
 
 	case kiroproto.EventMetering:
-		a.HasCredits = true
-		a.Credits = e.Credits
+		// Reject NaN/Inf/negative so a malformed upstream payload never
+		// poisons the cumulative log/span values; downstream callers see
+		// HasCredits=false, the same as "no meteringEvent received".
+		if !math.IsNaN(e.Credits) && !math.IsInf(e.Credits, 0) && e.Credits >= 0 {
+			a.HasCredits = true
+			a.Credits = e.Credits
+		}
 		if !a.HasMetadata {
 			a.InputTokens = e.InputTokens
 			a.OutputTokens = e.OutputTokens

--- a/internal/respconv/event_processor.go
+++ b/internal/respconv/event_processor.go
@@ -72,6 +72,8 @@ func (a *responseAccumulator) ProcessEvent(e kiroproto.Event) EventDelta {
 		a.CacheWriteInputTokens = e.CacheWriteInputTokens
 
 	case kiroproto.EventMetering:
+		a.HasCredits = true
+		a.Credits = e.Credits
 		if !a.HasMetadata {
 			a.InputTokens = e.InputTokens
 			a.OutputTokens = e.OutputTokens

--- a/internal/respconv/nonstreaming.go
+++ b/internal/respconv/nonstreaming.go
@@ -16,6 +16,9 @@ type NonStreamingStats struct {
 	// Context usage from Kiro.
 	HasContextUsage        bool
 	ContextUsagePercentage float64
+	// Credit usage from meteringEvent.
+	HasCredits bool
+	Credits    float64
 }
 
 // NonStreamingAccumulator wraps responseAccumulator for incremental non-streaming processing.
@@ -58,6 +61,12 @@ func (n *NonStreamingAccumulator) IsEmptyVisibleEndTurn() bool {
 // ThinkingLen returns the length of accumulated thinking content.
 func (n *NonStreamingAccumulator) ThinkingLen() int {
 	return n.acc.ThinkingBuf.Len()
+}
+
+// Credits returns the per-response credit consumption from meteringEvent.
+// The bool is false if no meteringEvent was received.
+func (n *NonStreamingAccumulator) Credits() (float64, bool) {
+	return n.acc.Credits, n.acc.HasCredits
 }
 
 // BuildNonStreamingResponse builds a complete Anthropic response from buffered events.
@@ -115,6 +124,8 @@ func buildResponseFromAcc(acc *responseAccumulator, model string) (map[string]an
 		OutputTokens:           res.OutputTokens,
 		HasContextUsage:        acc.HasContextUsage,
 		ContextUsagePercentage: acc.ContextUsagePercentage,
+		HasCredits:             acc.HasCredits,
+		Credits:                acc.Credits,
 	}
 
 	return map[string]any{

--- a/internal/respconv/nonstreaming_test.go
+++ b/internal/respconv/nonstreaming_test.go
@@ -94,12 +94,29 @@ func TestBuildNonStreamingResponse_CacheTokens(t *testing.T) {
 func TestBuildNonStreamingResponse_MeteringFallback(t *testing.T) {
 	events := []kiroproto.Event{
 		{Type: "assistantResponseEvent", Content: "Hi"},
-		{Type: "meteringEvent", InputTokens: 30, OutputTokens: 10},
+		{Type: "meteringEvent", InputTokens: 30, OutputTokens: 10, Credits: 0.1234},
 	}
-	resp, _ := BuildNonStreamingResponse(events, "claude-sonnet-4.6", 200000, nil, 0, 0)
+	resp, stats := BuildNonStreamingResponse(events, "claude-sonnet-4.6", 200000, nil, 0, 0)
 	usage := resp["usage"].(map[string]any)
 	if usage["input_tokens"] != 30 {
 		t.Fatalf("input_tokens = %v", usage["input_tokens"])
+	}
+	if !stats.HasCredits {
+		t.Fatal("expected stats.HasCredits=true")
+	}
+	if stats.Credits != 0.1234 {
+		t.Fatalf("stats.Credits = %v, want 0.1234", stats.Credits)
+	}
+}
+
+func TestBuildNonStreamingResponse_NoMetering_NoCredits(t *testing.T) {
+	events := []kiroproto.Event{
+		{Type: "assistantResponseEvent", Content: "Hi"},
+		{Type: "metadataEvent", InputTokens: 10, OutputTokens: 5},
+	}
+	_, stats := BuildNonStreamingResponse(events, "claude-sonnet-4.6", 200000, nil, 0, 0)
+	if stats.HasCredits {
+		t.Fatal("expected stats.HasCredits=false when no meteringEvent")
 	}
 }
 

--- a/internal/respconv/streaming.go
+++ b/internal/respconv/streaming.go
@@ -309,6 +309,21 @@ func (s *SSEWriter) ContextUsagePercentage() float64 { return s.acc.ContextUsage
 // HasContextUsage reports whether a contextUsageEvent was received.
 func (s *SSEWriter) HasContextUsage() bool { return s.acc.HasContextUsage }
 
+// Credits returns the per-response credit consumption from meteringEvent.
+// The bool is false if no meteringEvent was received.
+func (s *SSEWriter) Credits() (float64, bool) { return s.acc.Credits, s.acc.HasCredits }
+
+// RecordTail forwards trailing metadata events (meteringEvent, contextUsageEvent)
+// to the inner accumulator without writing anything to the SSE stream. Used by
+// the tool-search orchestrator to keep collecting credit/context usage after the
+// upstream tool-use frame is detected, so cumulative stats remain accurate.
+func (s *SSEWriter) RecordTail(e kiroproto.Event) {
+	switch e.Type {
+	case kiroproto.EventMetering, kiroproto.EventContextUsage:
+		s.acc.ProcessEvent(e)
+	}
+}
+
 // writeThinkingDelta writes a thinking_delta SSE event using direct formatting.
 func (s *SSEWriter) writeThinkingDelta(d EventDelta) {
 	s.ensureStarted()

--- a/internal/respconv/streaming_test.go
+++ b/internal/respconv/streaming_test.go
@@ -142,6 +142,50 @@ func TestSSEWriter_MetadataEvent(t *testing.T) {
 	}
 }
 
+func TestSSEWriter_Credits(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)
+
+	if _, ok := sw.Credits(); ok {
+		t.Fatal("expected no credits before any meteringEvent")
+	}
+
+	sw.HandleEvent(kiroproto.Event{Type: "meteringEvent", Credits: 0.5417})
+	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hi"})
+	sw.Finish()
+
+	credits, ok := sw.Credits()
+	if !ok {
+		t.Fatal("expected credits to be present after meteringEvent")
+	}
+	if credits != 0.5417 {
+		t.Fatalf("Credits() = %v, want 0.5417", credits)
+	}
+}
+
+func TestSSEWriter_RecordTail(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)
+	bodyBefore := w.Body.Len()
+
+	// RecordTail should ingest credit/context info but not write SSE output.
+	sw.RecordTail(kiroproto.Event{Type: "meteringEvent", Credits: 0.99})
+	sw.RecordTail(kiroproto.Event{Type: "contextUsageEvent", ContextUsagePercentage: 12.5})
+	// A non-tail event must be ignored entirely (not routed to acc, no SSE).
+	sw.RecordTail(kiroproto.Event{Type: "assistantResponseEvent", Content: "should-not-appear"})
+
+	if w.Body.Len() != bodyBefore {
+		t.Fatalf("RecordTail wrote SSE bytes (%d → %d)", bodyBefore, w.Body.Len())
+	}
+	credits, ok := sw.Credits()
+	if !ok || credits != 0.99 {
+		t.Fatalf("Credits = (%v, %v), want (0.99, true)", credits, ok)
+	}
+	if !sw.HasContextUsage() || sw.ContextUsagePercentage() != 12.5 {
+		t.Fatalf("ContextUsage = (%v, %v), want (12.5, true)", sw.ContextUsagePercentage(), sw.HasContextUsage())
+	}
+}
+
 func TestSSEWriter_RedactedContent(t *testing.T) {
 	w := httptest.NewRecorder()
 	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)


### PR DESCRIPTION
## Summary

- Plumb `meteringEvent.usage` through the response accumulator and emit it on the existing `<-- POST /v1/messages` Info log as `credits=<float>`. Also attach `kiro.credits` to the active OTel server span when tracing is enabled.
- Tool search keeps parsing past the tool-use frame so trailing `meteringEvent` / `contextUsageEvent` reach the accumulator, while still honoring `exception` / `invalidStateEvent` in the tail. Cumulative credits across rounds are aggregated via a small `roundTotals` helper.
- When an attempt is abandoned (empty-visible end_turn retry), its credits are emitted on a separate `upstream attempt credits (aborted)` log line plus `kiro.credits.aborted_attempt` span attribute, so retries do not under-report.
- Streaming `localStop` (`stop_sequence` / `max_tokens`) keeps closing the upstream body immediately — we accept that a meteringEvent arriving after early stop is not collected, since draining would mean paying for tokens the client never receives.

## Behavior

Normal completion:

```
INFO <-- POST /v1/messages trace_id=abc input_tokens=100 output_tokens=50 context_usage=0.5k(0.3%) credits=0.193
```

Empty-visible retry:

```
INFO upstream attempt credits (aborted) trace_id=abc credits=0.193 reason=empty_visible_end_turn
INFO <-- POST /v1/messages trace_id=abc input_tokens=200 output_tokens=80 ... credits=0.215
```

The Anthropic-compatible response body is **not** modified.

## Test plan

- [x] `make test` passes (`go test -race ./...`)
- [x] `make lint` passes (`golangci-lint run`)
- [x] Unit tests added: accumulator credit tracking, streaming/non-streaming stats propagation, `SSEWriter.RecordTail`, `logResponseStats` slog output, `logAbortedAttemptCredits`
- [ ] Manual: send a real prompt through the proxy, grep server log for `credits=` on the summary line
- [ ] Manual: trigger tool search and confirm cumulative `credits` in the final summary log
- [ ] Manual (optional): run with `-otel` against `grafana/otel-lgtm` and confirm `kiro.credits` span attribute