### PR TITLE
fix(auth): derive region from profile ARN for social login

### DIFF
--- a/internal/auth/credentials_parser.go
+++ b/internal/auth/credentials_parser.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/json/v2"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -63,4 +64,42 @@ func extractProfileARN(raw string) string {
 		return obj.ARN
 	}
 	return raw
+}
+
+// extractRegionFromARN parses the region segment from an AWS ARN.
+// ARN format: arn:partition:service:region:account-id:resource
+// Returns "" if the input is not a valid ARN with a non-empty region segment.
+func extractRegionFromARN(arn string) string {
+	if arn == "" {
+		return ""
+	}
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) < 6 || parts[0] != "arn" {
+		return ""
+	}
+	return parts[3]
+}
+
+// resolveRegion picks the first non-empty region in priority order, falling back
+// to "us-east-1" when none is set. Intended for Credentials.Region (the API
+// region embedded in q.<region>.amazonaws.com). Do NOT use for SSORegion: the
+// token refresh path relies on an empty SSORegion to fail fast when IDC is
+// misconfigured, and the fallback would mask that condition.
+//
+// The CodeWhisperer profile ARN encodes the API region directly, so ARN-derived
+// values are preferred over auth.idc.region (which is the OIDC/SSO region and
+// can legitimately differ from the API region for IDC users).
+func resolveRegion(tokenRegion, tokenProfileARN, stateRegion, stateProfileARN string) string {
+	candidates := []string{
+		tokenRegion,
+		extractRegionFromARN(tokenProfileARN),
+		extractRegionFromARN(stateProfileARN),
+		stateRegion,
+	}
+	for _, r := range candidates {
+		if r != "" {
+			return r
+		}
+	}
+	return "us-east-1"
 }

--- a/internal/auth/credentials_parser_test.go
+++ b/internal/auth/credentials_parser_test.go
@@ -1,0 +1,57 @@
+package auth
+
+import "testing"
+
+func TestExtractRegionFromARN(t *testing.T) {
+	tests := []struct {
+		name string
+		arn  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"valid social ARN", "arn:aws:codewhisperer:us-east-1:123456789012:profile/X", "us-east-1"},
+		{"valid eu-west-1", "arn:aws:codewhisperer:eu-west-1:123:profile/y", "eu-west-1"},
+		{"too few segments", "arn:aws:codewhisperer", ""},
+		{"missing arn prefix", "not:aws:codewhisperer:us-east-1:123:profile/x", ""},
+		{"empty region segment", "arn:aws:codewhisperer::123:profile/x", ""},
+		{"non-arn string", "not-an-arn", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractRegionFromARN(tt.arn); got != tt.want {
+				t.Errorf("extractRegionFromARN(%q) = %q, want %q", tt.arn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveRegion(t *testing.T) {
+	const (
+		arnUSEast = "arn:aws:codewhisperer:us-east-1:123:profile/x"
+		arnEUWest = "arn:aws:codewhisperer:eu-west-1:123:profile/x"
+	)
+	tests := []struct {
+		name        string
+		tokenRegion string
+		tokenARN    string
+		stateRegion string
+		stateARN    string
+		want        string
+	}{
+		{"token region wins over everything", "ap-northeast-1", arnUSEast, "us-west-2", arnEUWest, "ap-northeast-1"},
+		{"token ARN beats state side when token region empty", "", arnUSEast, "us-west-2", arnEUWest, "us-east-1"},
+		{"state ARN beats stateRegion (API region from profile ARN)", "", "", "us-west-2", arnEUWest, "eu-west-1"},
+		{"stateRegion used only when no ARN anywhere", "", "", "us-west-2", "", "us-west-2"},
+		{"state ARN used when others empty", "", "", "", arnEUWest, "eu-west-1"},
+		{"all empty falls back to us-east-1", "", "", "", "", "us-east-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveRegion(tt.tokenRegion, tt.tokenARN, tt.stateRegion, tt.stateARN)
+			if got != tt.want {
+				t.Errorf("resolveRegion(%q,%q,%q,%q) = %q, want %q",
+					tt.tokenRegion, tt.tokenARN, tt.stateRegion, tt.stateARN, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/auth/db.go
+++ b/internal/auth/db.go
@@ -69,6 +69,8 @@ func ReadCredentials(db *sql.DB) (*Credentials, error) {
 		RefreshTokenS string `json:"refresh_token"`
 		ExpiresAtS    any    `json:"expires_at"`
 		Region        string `json:"region"`
+		ProfileARN    string `json:"profileArn"`  // social camelCase
+		ProfileARNS   string `json:"profile_arn"` // social snake_case
 	}
 	if err := json.Unmarshal([]byte(tokenJSON), &tokenData); err != nil {
 		return nil, fmt.Errorf("parse token JSON: %w", err)
@@ -108,26 +110,30 @@ func ReadCredentials(db *sql.DB) (*Credentials, error) {
 		creds.ClientSecret = coalesce(regData.ClientSecret, regData.ClientSecretS)
 	}
 
-	// Region: prefer token's region, then state table.
 	stateRegion, stateErr := readState(db, "auth.idc.region")
 	if stateErr != nil && !errors.Is(stateErr, sql.ErrNoRows) {
 		return nil, stateErr
 	}
-	if tokenData.Region != "" {
-		creds.Region = tokenData.Region
-		creds.SSORegion = tokenData.Region
-	} else {
-		creds.Region = stateRegion
-		creds.SSORegion = stateRegion
-	}
 
-	// Read profile ARN from state table.
-	// May be a JSON object {"arn":"...","profile_name":"..."} or a plain string.
+	// State profile ARN may be a JSON object {"arn":"...","profile_name":"..."} or a plain string.
 	profileRaw, profileErr := readState(db, "api.codewhisperer.profile")
 	if profileErr != nil && !errors.Is(profileErr, sql.ErrNoRows) {
 		return nil, profileErr
 	}
-	creds.ProfileARN = extractProfileARN(profileRaw)
+	stateProfileARN := extractProfileARN(profileRaw)
+
+	// ProfileARN: token JSON wins (social login), state table is fallback (IDC).
+	tokenProfileARN := coalesce(tokenData.ProfileARN, tokenData.ProfileARNS)
+	creds.ProfileARN = coalesce(tokenProfileARN, stateProfileARN)
+
+	// SSORegion must come from an explicitly stored region (token JSON or state).
+	// Do not fall back to the ARN-derived region or "us-east-1" — refreshCredentials
+	// relies on an empty SSORegion to fail fast for misconfigured IDC credentials.
+	creds.SSORegion = coalesce(tokenData.Region, stateRegion)
+
+	// Region (API region used to build https://q.<region>.amazonaws.com/) can be
+	// derived from the profile ARN and falls back to "us-east-1" when unavailable.
+	creds.Region = resolveRegion(tokenData.Region, tokenProfileARN, stateRegion, stateProfileARN)
 
 	return creds, nil
 }

--- a/internal/auth/db_test.go
+++ b/internal/auth/db_test.go
@@ -220,6 +220,135 @@ func TestReadCredentials(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "social token with snake_case profile_arn populates region",
+			authKV: map[string]string{
+				"kirocli:social:token": `{"access_token":"a","refresh_token":"r","provider":"google","profile_arn":"arn:aws:codewhisperer:us-east-1:123456789012:profile/X"}`,
+			},
+			check: func(t *testing.T, c *Credentials) {
+				if c.AuthType != "social" {
+					t.Errorf("AuthType = %q, want %q", c.AuthType, "social")
+				}
+				if c.Region != "us-east-1" {
+					t.Errorf("Region = %q, want %q", c.Region, "us-east-1")
+				}
+				// SSORegion must remain empty when no explicit region is stored —
+				// only ARN-derived values are in play, which should not satisfy
+				// the OIDC refresh path's region check.
+				if c.SSORegion != "" {
+					t.Errorf("SSORegion = %q, want empty (ARN-derived region must not populate SSORegion)", c.SSORegion)
+				}
+				if c.ProfileARN != "arn:aws:codewhisperer:us-east-1:123456789012:profile/X" {
+					t.Errorf("ProfileARN = %q", c.ProfileARN)
+				}
+			},
+		},
+		{
+			name: "social token with camelCase profileArn",
+			authKV: map[string]string{
+				"kirocli:social:token": `{"accessToken":"a","refreshToken":"r","profileArn":"arn:aws:codewhisperer:eu-west-1:123:profile/Y"}`,
+			},
+			check: func(t *testing.T, c *Credentials) {
+				if c.Region != "eu-west-1" {
+					t.Errorf("Region = %q, want %q", c.Region, "eu-west-1")
+				}
+				if c.ProfileARN != "arn:aws:codewhisperer:eu-west-1:123:profile/Y" {
+					t.Errorf("ProfileARN = %q", c.ProfileARN)
+				}
+			},
+		},
+		{
+			name: "social token without region or ARN falls back to us-east-1",
+			authKV: map[string]string{
+				"kirocli:social:token": `{"accessToken":"a","refreshToken":"r"}`,
+			},
+			check: func(t *testing.T, c *Credentials) {
+				if c.Region != "us-east-1" {
+					t.Errorf("Region = %q, want %q", c.Region, "us-east-1")
+				}
+				if c.ProfileARN != "" {
+					t.Errorf("ProfileARN = %q, want empty", c.ProfileARN)
+				}
+			},
+		},
+		{
+			name: "token JSON profile_arn beats state ARN",
+			authKV: map[string]string{
+				"kirocli:social:token": `{"access_token":"a","refresh_token":"r","profile_arn":"arn:aws:codewhisperer:ap-northeast-1:111:profile/token"}`,
+			},
+			state: map[string]string{
+				"api.codewhisperer.profile": "arn:aws:codewhisperer:eu-west-1:222:profile/state",
+			},
+			check: func(t *testing.T, c *Credentials) {
+				if c.ProfileARN != "arn:aws:codewhisperer:ap-northeast-1:111:profile/token" {
+					t.Errorf("ProfileARN = %q, want token JSON ARN", c.ProfileARN)
+				}
+				if c.Region != "ap-northeast-1" {
+					t.Errorf("Region = %q, want %q", c.Region, "ap-northeast-1")
+				}
+			},
+		},
+		{
+			name: "token JSON region beats ARN region",
+			authKV: map[string]string{
+				"kirocli:social:token": `{"accessToken":"a","refreshToken":"r","region":"eu-west-1","profile_arn":"arn:aws:codewhisperer:us-east-1:123:profile/X"}`,
+			},
+			check: func(t *testing.T, c *Credentials) {
+				if c.Region != "eu-west-1" {
+					t.Errorf("Region = %q, want %q (token region must win over ARN region)", c.Region, "eu-west-1")
+				}
+			},
+		},
+		{
+			name: "IDC token without any region leaves SSORegion empty",
+			authKV: map[string]string{
+				"kirocli:odic:token": `{"accessToken":"a","refreshToken":"r","expiresAt":1}`,
+			},
+			// No state.auth.idc.region and no profile ARN.
+			check: func(t *testing.T, c *Credentials) {
+				if c.SSORegion != "" {
+					t.Errorf("SSORegion = %q, want empty so refreshCredentials fails fast for misconfigured IDC", c.SSORegion)
+				}
+				if c.Region != "us-east-1" {
+					t.Errorf("Region = %q, want %q (API region falls back)", c.Region, "us-east-1")
+				}
+			},
+		},
+		{
+			name: "IDC token with state profile ARN does not derive SSORegion from ARN",
+			authKV: map[string]string{
+				"kirocli:odic:token": `{"accessToken":"a","refreshToken":"r","expiresAt":1}`,
+			},
+			state: map[string]string{
+				"api.codewhisperer.profile": "arn:aws:codewhisperer:eu-west-1:123:profile/idc",
+			},
+			check: func(t *testing.T, c *Credentials) {
+				if c.SSORegion != "" {
+					t.Errorf("SSORegion = %q, want empty (ARN region must not leak into SSORegion)", c.SSORegion)
+				}
+				if c.Region != "eu-west-1" {
+					t.Errorf("Region = %q, want %q (API region may use ARN)", c.Region, "eu-west-1")
+				}
+			},
+		},
+		{
+			name: "IDC profile ARN region wins over SSO region for API endpoint",
+			authKV: map[string]string{
+				"kirocli:odic:token": `{"accessToken":"a","refreshToken":"r","expiresAt":1}`,
+			},
+			state: map[string]string{
+				"auth.idc.region":           "us-east-1", // OIDC SSO region
+				"api.codewhisperer.profile": "arn:aws:codewhisperer:eu-west-1:123:profile/idc",
+			},
+			check: func(t *testing.T, c *Credentials) {
+				if c.Region != "eu-west-1" {
+					t.Errorf("Region = %q, want %q (API region must come from profile ARN, not SSO region)", c.Region, "eu-west-1")
+				}
+				if c.SSORegion != "us-east-1" {
+					t.Errorf("SSORegion = %q, want %q (SSO region from auth.idc.region)", c.SSORegion, "us-east-1")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Read `profile_arn` / `profileArn` from the token JSON so social-login credentials populate `Credentials.ProfileARN` and feed region resolution.
- Resolve the API region with priority: token JSON `region` → token ARN region → state ARN region → state `auth.idc.region` → `us-east-1`. The CodeWhisperer profile ARN encodes the API region, so it must beat the SSO region for IDC users whose API and SSO regions differ.
- Keep `SSORegion` derived only from explicit region values (token JSON or state) so the OIDC refresh path can still fail fast on misconfigured IDC credentials.

Closes #60.

## Why

Social login (Google / Builder ID) stores credentials as:

```json
{ "access_token": "...", "provider": "google", "profile_arn": "arn:aws:codewhisperer:us-east-1:...:profile/X" }
```

There is no top-level `region` field, and the IDC `state.auth.idc.region` key is also absent. The previous loader left `creds.Region` empty, so every request went to `https://q..amazonaws.com/` (double dot) and failed with `EOF`.

The region encoded in the profile ARN is the API region (`q.<region>.amazonaws.com`), so it must take precedence over `auth.idc.region` (which is the OIDC SSO region and may legitimately differ for IDC users).

## Test plan

- [x] `make test` (race) — unit tests, including new region-resolution cases
- [x] `make lint` — `golangci-lint run`
- [x] `TestExtractRegionFromARN` (7 cases): valid ARNs, missing prefix, empty region segment, non-ARN strings
- [x] `TestResolveRegion` (6 cases): priority ordering and `us-east-1` fallback
- [x] `TestReadCredentials` additions:
  - social token with `profile_arn` (snake_case) populates region; `SSORegion` stays empty
  - social token with `profileArn` (camelCase)
  - social token without region or ARN falls back to `us-east-1`
  - token JSON `profile_arn` beats state ARN
  - token JSON `region` beats ARN region
  - IDC token without any region leaves `SSORegion` empty (fail-fast guard)
  - IDC token with state ARN does not derive `SSORegion` from ARN
  - IDC profile ARN region wins over SSO region for the API endpoint
- [ ] Manual verification with a real Kiro CLI social-login DB (logs should show `credentials loaded auth_type=social region=us-east-1`)