### PR TITLE
Release v0.2.0

### DIFF
--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -1,0 +1,60 @@
+# Release v0.2.0
+
+## New Features
+
+### Log Kiro credit consumption from `meteringEvent` (#61)
+
+The proxy now surfaces upstream Kiro credit usage on its summary log line and on the active OTel span, so operators can correlate token volume with actual Kiro spend without parsing raw event streams.
+
+- The response accumulator parses `meteringEvent.usage` past the `tool_use` frame, sums credits across tool-search rounds, and emits the cumulative total on the existing `<-- POST /v1/messages` Info log as `credits=<float>`. When tracing is enabled, the same value is attached to the server span as `kiro.credits`.
+- Trailing `meteringEvent` / `contextUsageEvent` frames are still collected after a tool-use frame, while `exception` / `invalidStateEvent` continue to terminate parsing as before.
+- When an attempt is abandoned (the empty-visible `end_turn` retry path), the abandoned attempt's credits are emitted on a separate `upstream attempt credits (aborted)` log line and recorded as `kiro.credits.aborted_attempt` on the span — retries no longer under-report spend.
+- Streaming `localStop` (`stop_sequence` / `max_tokens`) keeps closing the upstream body immediately. A `meteringEvent` arriving after early stop is intentionally not collected, since draining would mean paying for tokens the client never receives.
+
+The Anthropic-compatible response body is unchanged.
+
+Example summary log on normal completion:
+
+```
+INFO <-- POST /v1/messages trace_id=abc input_tokens=100 output_tokens=50 context_usage=0.5k(0.3%) credits=0.193
+```
+
+Example with an aborted retry:
+
+```
+INFO upstream attempt credits (aborted) trace_id=abc credits=0.193 reason=empty_visible_end_turn
+INFO <-- POST /v1/messages trace_id=abc input_tokens=200 output_tokens=80 ... credits=0.215
+```
+
+## Bug Fixes
+
+### Derive region from profile ARN for social login (#62)
+
+Social-login credentials (Google / Builder ID) are stored without a top-level `region` field and without `state.auth.idc.region`, so the previous loader left `creds.Region` empty. Every request then went to `https://q..amazonaws.com/` (double dot) and failed with `EOF`.
+
+- `profile_arn` / `profileArn` is now read from the token JSON, populating `Credentials.ProfileARN` for social-login users.
+- API region resolution priority: token JSON `region` → token ARN region → state ARN region → state `auth.idc.region` → `us-east-1`. The CodeWhisperer profile ARN encodes the API region (`q.<region>.amazonaws.com`), so it must beat the SSO region for IDC users whose API and SSO regions legitimately differ.
+- `SSORegion` is still derived only from explicit region values (token JSON or state), so the OIDC refresh path keeps failing fast on misconfigured IDC credentials. ARN-derived regions never silently populate `SSORegion`.
+
+Closes #60.
+
+## Code Improvements
+
+- Update `modernc.org/sqlite` to v1.50.1 (#59)
+- Update `modernc.org/sqlite` to v1.50.0 (#58)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.2.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
## Summary

Release v0.2.0

See `docs/release-notes/v0.2.0.md` for details.