### PR TITLE
feat: add Claude Opus 4.8 mappings pinned to 1M context

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ Supported query forms:
 | `claude-sonnet-4-6[1m]` | `claude-sonnet-4.6-1m` | 1M             |
 | `claude-sonnet-4.5`     | `claude-sonnet-4.5`    | 200k           |
 | `claude-sonnet-4.5[1m]` | `claude-sonnet-4.5-1m` | 1M             |
+| `claude-opus-4-8`       | `claude-opus-4.8`      | 1M             |
+| `claude-opus-4-8[1m]`   | `claude-opus-4.8`      | 1M             |
 | `claude-opus-4-7`       | `claude-opus-4.7`      | 1M             |
 | `claude-opus-4-7[1m]`   | `claude-opus-4.7`      | 1M             |
 | `claude-opus-4-6`       | `claude-opus-4.6`      | 1M             |
@@ -266,7 +268,7 @@ Supported query forms:
 | `claude-opus-4.5`       | `claude-opus-4.5`      | 200k           |
 | `claude-haiku-4.5`      | `claude-haiku-4.5`     | 200k           |
 
-Opus 4.6 and 4.7 always use 1M context (no 200k SKU exists upstream). The explicit `[1m]`-suffixed aliases (`claude-opus-4-7[1m]` / `claude-opus-4-6[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field — this matches Claude Code's default Max-plan state (`lG()` emits `claude-opus-4-7[1m]`) and keeps its `mR()` 1M-context check happy without spuriously enabling extended thinking. Thinking is still opt-in via Sonnet `[1m]` suffix, `Anthropic-Beta: context-1m` header, or `thinking` field.
+Opus 4.6, 4.7, and 4.8 always use 1M context (no 200k SKU exists upstream). The explicit `[1m]`-suffixed aliases (`claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field — this matches Claude Code's default Max-plan state (`lG()` emits `claude-opus-4-8[1m]`) and keeps its `mR()` 1M-context check happy without spuriously enabling extended thinking. Thinking is still opt-in via Sonnet `[1m]` suffix, `Anthropic-Beta: context-1m` header, or `thinking` field.
 
 Unmatched `claude-*` models are passed through as-is. Non-claude models fall back to `claude-sonnet-4.6`.
 
@@ -274,7 +276,7 @@ Unmatched `claude-*` models are passed through as-is. Non-claude models fall bac
 
 The `model` field in `/v1/messages` responses (streaming `message_start`, non-streaming body, and tool-search path) is returned as the **Anthropic-form ID** (e.g. `claude-opus-4-7`), not the Kiro SKU (`claude-opus-4.7`).
 
-When the proxy routes to a **1M context window** (always-1M SKU such as `claude-opus-4.7` / `claude-opus-4.6`, or a model invoked with the `[1m]` suffix or `Anthropic-Beta: context-1m` header), a trailing `[1m]` is appended to the response model ID (e.g. `claude-opus-4-7[1m]`). Claude Code's client-side context-window logic matches `/\[1m\]/i` on the response model to pick the 1M window — without the suffix it defaults to 200k and auto-compacts at ~160k even when upstream actually has 1M of context.
+When the proxy routes to a **1M context window** (always-1M SKU such as `claude-opus-4.8` / `claude-opus-4.7` / `claude-opus-4.6`, or a model invoked with the `[1m]` suffix or `Anthropic-Beta: context-1m` header), a trailing `[1m]` is appended to the response model ID (e.g. `claude-opus-4-8[1m]`). Claude Code's client-side context-window logic matches `/\[1m\]/i` on the response model to pick the 1M window — without the suffix it defaults to 200k and auto-compacts at ~160k even when upstream actually has 1M of context.
 
 Note: `[1m]` has different meanings on request vs. response. On the **request** `model` it is a client-supplied thinking-opt-in signal (and is stripped before upstream routing). On the **response** `model` it is purely a context-window advertisement for Claude Code and does not imply that extended thinking was enabled.
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,8 +27,10 @@ const (
 // Uses exact key matching against both Anthropic and Kiro fields (first match wins).
 // Order matters: specific entries must precede legacy aliases that share the same Kiro value.
 var modelMapOrdered = []Mapping{
+	{Anthropic: "claude-opus-4-8[1m]", Kiro: "claude-opus-4.8", Kiro1M: "claude-opus-4.8"},
 	{Anthropic: "claude-opus-4-7[1m]", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
 	{Anthropic: "claude-opus-4-6[1m]", Kiro: "claude-opus-4.6", Kiro1M: "claude-opus-4.6"},
+	{Anthropic: "claude-opus-4-8", Kiro: "claude-opus-4.8", Kiro1M: "claude-opus-4.8"},
 	{Anthropic: "claude-opus-4-7", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
 	{Anthropic: "claude-sonnet-4-6", Kiro: "claude-sonnet-4.6", Kiro1M: "claude-sonnet-4.6-1m"},
 	{Anthropic: "claude-sonnet-4.5", Kiro: "claude-sonnet-4.5", Kiro1M: "claude-sonnet-4.5-1m"},

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -17,6 +17,37 @@ func TestResolve(t *testing.T) {
 		wantAnthropicModel string
 	}{
 		{
+			name:               "claude-opus-4-8 uses 1m context without thinking",
+			model:              "claude-opus-4-8",
+			wantKiroModel:      "claude-opus-4.8",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-8[1m]",
+		},
+		{
+			name:               "claude-opus-4-8[1m] exact-match preserves suffix without thinking",
+			model:              "claude-opus-4-8[1m]",
+			wantKiroModel:      "claude-opus-4.8",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-8[1m]",
+		},
+		{
+			name:               "claude-opus-4-8 with context1M",
+			model:              "claude-opus-4-8",
+			context1M:          true,
+			wantKiroModel:      "claude-opus-4.8",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-8[1m]",
+		},
+		{
+			name:               "kiro model name claude-opus-4.8 always resolves to 1m",
+			model:              "claude-opus-4.8[1m]",
+			wantKiroModel:      "claude-opus-4.8",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-4-8[1m]",
+		},
+		{
 			name:               "claude-opus-4-7 uses 1m context without thinking",
 			model:              "claude-opus-4-7",
 			wantKiroModel:      "claude-opus-4.7",

--- a/internal/server/e2e_response_model_test.go
+++ b/internal/server/e2e_response_model_test.go
@@ -19,6 +19,18 @@ func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 		wantUpstream string // Kiro SKU sent upstream
 	}{
 		{
+			name:         "opus-4-8 hyphen preserved in response",
+			requestModel: "claude-opus-4-8",
+			wantResponse: "claude-opus-4-8[1m]",
+			wantUpstream: "claude-opus-4.8",
+		},
+		{
+			name:         "opus-4-8[1m] exact-match preserved verbatim",
+			requestModel: "claude-opus-4-8[1m]",
+			wantResponse: "claude-opus-4-8[1m]",
+			wantUpstream: "claude-opus-4.8",
+		},
+		{
 			name:         "opus-4-7 hyphen preserved in response",
 			requestModel: "claude-opus-4-7",
 			wantResponse: "claude-opus-4-7[1m]",
@@ -103,6 +115,16 @@ func TestE2E_ResponseModel_Streaming(t *testing.T) {
 		requestModel string
 		wantResponse string
 	}{
+		{
+			name:         "opus-4-8 hyphen preserved in message_start",
+			requestModel: "claude-opus-4-8",
+			wantResponse: "claude-opus-4-8[1m]",
+		},
+		{
+			name:         "opus-4-8[1m] exact-match preserved verbatim in message_start",
+			requestModel: "claude-opus-4-8[1m]",
+			wantResponse: "claude-opus-4-8[1m]",
+		},
 		{
 			name:         "opus-4-7 hyphen preserved in message_start",
 			requestModel: "claude-opus-4-7",


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-8` and `claude-opus-4-8[1m]` to `modelMapOrdered`, both routed to Kiro SKU `claude-opus-4.8` and pinned to a 1M context window (no 200k SKU exists upstream, mirroring 4.6 / 4.7).
- Cover Resolve and end-to-end response-model behavior with new test cases (bare, `[1m]` exact-match, `context1M`, and Kiro-form input).
- Update the README mapping table and surrounding prose to include 4.8 alongside 4.6 and 4.7.

## Test plan

- [x] `make test` — all 17 packages pass with `-race`
- [x] `make lint` — 0 issues
- [ ] Verify with a real Kiro backend that `claude-opus-4.8` is the correct SKU (only added one based on the 4.7 naming convention)