### PR TITLE
Release v0.4.0

### DIFF
--- a/docs/release-notes/v0.4.0.md
+++ b/docs/release-notes/v0.4.0.md
@@ -1,0 +1,46 @@
+# Release v0.4.0
+
+## New Features
+
+### Align request wire format with kiro-cli 2.5.1 (#69)
+
+Captured real kiro-cli 2.5.1 traffic and reconciled the proxy's request wire format with it. The headline change: reasoning **effort now travels natively** as `additionalModelRequestFields.output_config.effort` instead of being converted to a thinking-token budget and injected as XML.
+
+- **effort (native):** send `output_config.effort` per each model's advertised enum.
+  - `opus-4.8` / `opus-4.7` allow `xhigh`; the `opus-4.6` / `sonnet-4.6` family caps at `max`; other models omit the field entirely.
+  - `xhigh` on a 4-value model clamps to `max`; unrecognized values are dropped rather than promoted.
+  - Requests that enable reasoning via `thinking.type` / `[1m]` / `context-1m` without an explicit effort fall back to a default (`medium`) so the intent still reaches the backend.
+  - The old thinking-XML injection and budget mapping are removed.
+- **envState (re-added):** regressed in the v2.0.0 alignment. Derived from the Claude Code system-prompt `<env>` block (`darwin`→`macos`), attached only to the current message, with no host fallback. Resolved inside `BuildPayload`.
+- **endpoint:** `GenerateAssistantResponse` now POSTs to `runtime.<region>.kiro.dev`.
+- **User-Agent:** bumped to `aws-sdk-rust/1.3.15`, `codewhispererstreaming/0.1.16551`, `appVersion-2.5.1`, assembled from a single version block with a drift guard test.
+- **amz-sdk-request:** total attempts now match the advertised `max` (3), so the header stays consistent across retries instead of emitting `attempt=4; max=3`.
+
+## Code Improvements
+
+- Remove dead `Event.ModelID` parsing from the eventstream decoder; adopt modern Go idioms (`range`-over-int retry loop, `slices.Contains` enum check) (#69)
+
+## Documentation
+
+- Document native effort wire format and runtime endpoint (#70)
+
+## Breaking Changes
+
+- Reasoning depth is now conveyed entirely through `output_config.effort`. The previous thinking-XML injection (`<thinking_mode>`, `<max_thinking_length>`) and `thinking.budget_tokens` → budget mapping are removed; `thinking.budget_tokens` is still accepted in requests but no longer affects behavior.
+- The Kiro endpoint moved to `runtime.<region>.kiro.dev`.
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.4.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.3.0...v0.4.0


### PR DESCRIPTION
## Summary

Release v0.4.0

See `docs/release-notes/v0.4.0.md` for details.