### PR TITLE
Release v0.5.0

### DIFF
--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -1,0 +1,38 @@
+# Release v0.5.0
+
+## New Features
+
+### Add claude-sonnet-5 model and align wire format with kiro-cli 2.10.0 (#75)
+
+Captured real kiro-cli 2.10.0 traffic and added support for the new **`claude-sonnet-5`** model advertised in its `ListAvailableModels` catalog.
+
+- **claude-sonnet-5 (new):** Sonnet 5 is the **first Sonnet-family model with a 5-value effort enum** (adds `xhigh`; every prior Sonnet was 4-value-or-none). Like Opus 4.6/4.7/4.8, it is **always 1M context with no separate `-1m` SKU**, so it uses the always-1M mapping pattern (`Kiro1M == Kiro`).
+  - `claude-sonnet-5` and `claude-sonnet-5[1m]` both route to the `claude-sonnet-5` Kiro SKU. Bare input resolves to 1M context without enabling thinking; the response `model` gets the `[1m]` context-window suffix so Claude Code selects the 1M window.
+  - `xhigh` effort is honored rather than clamped to `max`.
+  - Verified end-to-end against the real Kiro backend.
+- **User-Agent:** bumped to emulate kiro-cli 2.10.0 (`appVersion-2.10.0`, `codewhispererstreaming/0.1.17593`); `aws-sdk-rust/1.3.15` and `lang/rust/1.92.0` unchanged. The drift-guard test is pinned to the new wire values.
+
+## Documentation
+
+- README model table, effort-level list, and always-1M notes updated for `claude-sonnet-5`; version citations re-based from kiro-cli 2.5.1 to 2.10.0 across comments and docs (#75)
+
+## Code Improvements
+
+- Update `golang.org/x/sync` to v0.21.0 (#73)
+- Update `modernc.org/sqlite` to v1.53.0 (#72)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.5.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.4.0...v0.5.0


### PR DESCRIPTION
## Summary

Release v0.5.0

See `docs/release-notes/v0.5.0.md` for details.

Highlights:
- Add `claude-sonnet-5` model (always-1M, first Sonnet with 5-value effort enum incl. `xhigh`); verified end-to-end against the real Kiro backend (#75)
- Align emulated User-Agent with kiro-cli 2.10.0 (#75)
- Dependency updates: `golang.org/x/sync` v0.21.0 (#73), `modernc.org/sqlite` v1.53.0 (#72)