### PR TITLE
fix(usage): fall back when metadata has no token counts

### DIFF
--- a/internal/respconv/event_accumulator_test.go
+++ b/internal/respconv/event_accumulator_test.go
@@ -114,6 +114,17 @@ func TestAccumulator_MeteringFallback(t *testing.T) {
 	}
 }
 
+func TestAccumulator_EmptyMetadataDoesNotOverrideMetering(t *testing.T) {
+	acc := newAccumulator(200000, nil, 0, 0)
+	acc.ProcessEvent(kiroproto.Event{Type: "meteringEvent", InputTokens: 30, OutputTokens: 10})
+	acc.ProcessEvent(kiroproto.Event{Type: "metadataEvent"})
+
+	input, output := acc.resolvedUsage()
+	if input != 30 || output != 10 {
+		t.Fatalf("resolvedUsage() = (%d, %d), want metering fallback (30, 10)", input, output)
+	}
+}
+
 func TestAccumulator_MeteringCredits(t *testing.T) {
 	var acc responseAccumulator
 

--- a/internal/respconv/event_processor.go
+++ b/internal/respconv/event_processor.go
@@ -66,11 +66,21 @@ func (a *responseAccumulator) ProcessEvent(e kiroproto.Event) EventDelta {
 		a.processToolUseEvent(e, &d)
 
 	case kiroproto.EventMetadata:
-		a.HasMetadata = true
-		a.InputTokens = e.InputTokens
-		a.OutputTokens = e.OutputTokens
-		a.CacheReadInputTokens = e.CacheReadInputTokens
-		a.CacheWriteInputTokens = e.CacheWriteInputTokens
+		// Kiro may emit metadataEvent without tokenUsage. Treat an all-zero
+		// event as missing usage rather than authoritative data; otherwise it
+		// would erase metering counts and suppress the pre-count/context fallback.
+		if hasUsableTokenCounts(e.InputTokens, e.OutputTokens) {
+			a.HasMetadata = true
+			a.InputTokens = max(0, e.InputTokens)
+			a.OutputTokens = max(0, e.OutputTokens)
+			a.CacheReadInputTokens = max(0, e.CacheReadInputTokens)
+			a.CacheWriteInputTokens = max(0, e.CacheWriteInputTokens)
+		} else {
+			// Cache creation may be reported independently of the primary counts.
+			// Preserve it without marking the metadata as usable token usage.
+			a.CacheReadInputTokens = max(a.CacheReadInputTokens, e.CacheReadInputTokens)
+			a.CacheWriteInputTokens = max(a.CacheWriteInputTokens, e.CacheWriteInputTokens)
+		}
 
 	case kiroproto.EventMetering:
 		// Reject NaN/Inf/negative so a malformed upstream payload never
@@ -80,9 +90,9 @@ func (a *responseAccumulator) ProcessEvent(e kiroproto.Event) EventDelta {
 			a.HasCredits = true
 			a.Credits = e.Credits
 		}
-		if !a.HasMetadata {
-			a.InputTokens = e.InputTokens
-			a.OutputTokens = e.OutputTokens
+		if !a.HasMetadata && hasUsableTokenCounts(e.InputTokens, e.OutputTokens) {
+			a.InputTokens = max(0, e.InputTokens)
+			a.OutputTokens = max(0, e.OutputTokens)
 		}
 
 	case kiroproto.EventMessageMetadata:

--- a/internal/respconv/usage.go
+++ b/internal/respconv/usage.go
@@ -10,10 +10,17 @@ func (a *responseAccumulator) estimatedOutputTokens() int {
 	return max(1, a.outputRuneCount/4)
 }
 
+// hasUsableTokenCounts reports whether an upstream event contains primary token
+// usage. Successful requests always consume input tokens, so an all-zero pair is
+// an absent/placeholder measurement and must not suppress fallback estimation.
+func hasUsableTokenCounts(inputTokens, outputTokens int) bool {
+	return inputTokens > 0 || outputTokens > 0
+}
+
 // resolvedUsage returns the best available input and output token counts.
 // Priority: metadata/metering > pre-counted (tiktoken) > contextUsage estimate > 0.
 func (a *responseAccumulator) resolvedUsage() (inputTokens, outputTokens int) {
-	if a.HasMetadata || a.InputTokens > 0 || a.OutputTokens > 0 {
+	if hasUsableTokenCounts(a.InputTokens, a.OutputTokens) {
 		return a.InputTokens, a.OutputTokens
 	}
 	if a.PreCountedInputTokens > 0 {

--- a/internal/server/e2e_response_test.go
+++ b/internal/server/e2e_response_test.go
@@ -266,10 +266,16 @@ func TestE2E_Truncation_Content(t *testing.T) {
 	}
 }
 
-func TestE2E_PreCountedTokens_NonStreaming(t *testing.T) {
+func TestE2E_PreCountedTokens_WithEmptyMetadata_NonStreaming(t *testing.T) {
 	p1 := mustJSON(map[string]string{"content": "hello"})
+	emptyMeta := mustJSON(map[string]any{})
+	contextUsage := mustJSON(map[string]any{"contextUsagePercentage": 0.7})
 	client := &capturingClient{
-		events:       []any{"assistantResponseEvent", p1},
+		events: []any{
+			"assistantResponseEvent", p1,
+			"metadataEvent", emptyMeta,
+			"contextUsageEvent", contextUsage,
+		},
 		promptTokens: 500,
 	}
 
@@ -289,10 +295,16 @@ func TestE2E_PreCountedTokens_NonStreaming(t *testing.T) {
 	}
 }
 
-func TestE2E_PreCountedTokens_Streaming(t *testing.T) {
+func TestE2E_PreCountedTokens_WithEmptyMetadata_Streaming(t *testing.T) {
 	p1 := mustJSON(map[string]string{"content": "hello"})
+	emptyMeta := mustJSON(map[string]any{})
+	contextUsage := mustJSON(map[string]any{"contextUsagePercentage": 0.7})
 	client := &capturingClient{
-		events:       []any{"assistantResponseEvent", p1},
+		events: []any{
+			"assistantResponseEvent", p1,
+			"metadataEvent", emptyMeta,
+			"contextUsageEvent", contextUsage,
+		},
 		promptTokens: 750,
 	}
 
@@ -311,10 +323,16 @@ func TestE2E_PreCountedTokens_Streaming(t *testing.T) {
 	}
 }
 
-func TestE2E_PreCountedTokens_ZeroFallback(t *testing.T) {
+func TestE2E_ContextUsageFallback_WhenPreCountIsZero(t *testing.T) {
 	p1 := mustJSON(map[string]string{"content": "hello"})
+	emptyMeta := mustJSON(map[string]any{})
+	contextUsage := mustJSON(map[string]any{"contextUsagePercentage": 10.0})
 	client := &capturingClient{
-		events:       []any{"assistantResponseEvent", p1},
+		events: []any{
+			"assistantResponseEvent", p1,
+			"metadataEvent", emptyMeta,
+			"contextUsageEvent", contextUsage,
+		},
 		promptTokens: 0, // simulates tokencount failure
 	}
 
@@ -329,8 +347,11 @@ func TestE2E_PreCountedTokens_ZeroFallback(t *testing.T) {
 	var result map[string]any
 	_ = json.UnmarshalRead(resp.Body, &result)
 	usage := result["usage"].(map[string]any)
-	if int(usage["input_tokens"].(float64)) != 0 {
-		t.Fatalf("input_tokens = %v, want 0 (fallback)", usage["input_tokens"])
+	if int(usage["input_tokens"].(float64)) != 19999 {
+		t.Fatalf("input_tokens = %v, want 19999 (context usage fallback)", usage["input_tokens"])
+	}
+	if int(usage["output_tokens"].(float64)) != 1 {
+		t.Fatalf("output_tokens = %v, want 1 (estimated fallback)", usage["output_tokens"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat all-zero metadata token counts as missing instead of authoritative
- preserve valid metering counts when an empty metadata event follows
- allow the existing pre-counted and context-percentage fallbacks to run
- cover accumulator, streaming, and non-streaming response paths

## Root cause

Kiro can emit a successful `metadataEvent` without usable `tokenUsage` values. The accumulator previously set `HasMetadata=true` for every such event and overwrote its token counts with zero. `resolvedUsage` then returned `(0, 0)` solely because metadata had been seen, so neither local prompt counting nor context-percentage estimation could run.

The fix only treats upstream counts as usable when at least one primary count is positive. Exact metadata still takes precedence over metering and all fallback estimates.

## Impact

Anthropic-compatible responses no longer report zero usage merely because Kiro sent placeholder metadata. This restores Claude Code context tracking while retaining the existing caveat that fallback token counts are estimates rather than billing-grade measurements.

## Validation

- `make test` (`go test -race ./...`)
- `make vet`
- `make lint`
- real minimal Messages request through the patched proxy returned `input_tokens=91` and `output_tokens=1` instead of zero

Fixes #83
