### PR TITLE
feat(models): add Claude Opus 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Thinking is enabled by any of:
 - `Anthropic-Beta` header containing `context-1m` (e.g., `context-1m-2025-01-01`)
 - `thinking.type` set to `"enabled"` or `"adaptive"` in the request
 
-Exception: the `[1m]` suffix on an **always-1M** model (`claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) is a first-class alias that only advertises the 1M context window — it does **not** enable thinking (see [Model mappings](#model-mappings)). Thinking on those models is still opt-in via the `context-1m` header or the `thinking` field.
+Exception: the `[1m]` suffix on an **always-1M** model (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) is a first-class alias that only advertises the 1M context window — it does **not** enable thinking (see [Model mappings](#model-mappings)). Thinking on those models is still opt-in via the `context-1m` header or the `thinking` field.
 
 The reasoning effort sent to the backend is resolved as follows:
 
@@ -240,7 +240,7 @@ The reasoning effort sent to the backend is resolved as follows:
 
 Per-model allowed effort levels:
 
-- `claude-opus-4.8`, `claude-opus-4.7`, `claude-sonnet-5`: `low`, `medium`, `high`, `xhigh`, `max`
+- `claude-opus-5`, `claude-opus-4.8`, `claude-opus-4.7`, `claude-sonnet-5`: `low`, `medium`, `high`, `xhigh`, `max`
 - `claude-opus-4.6`, `claude-sonnet-4.6` (and their `-1m` variants): `low`, `medium`, `high`, `max` (no `xhigh`; clamps to `max`)
 - All other models omit `additionalModelRequestFields` entirely
 
@@ -269,6 +269,8 @@ Supported query forms:
 
 | Input model             | Kiro model             | Context window |
 | ----------------------- | ---------------------- | -------------- |
+| `claude-opus-5`         | `claude-opus-5`        | 1M             |
+| `claude-opus-5[1m]`     | `claude-opus-5`        | 1M             |
 | `claude-sonnet-5`       | `claude-sonnet-5`      | 1M             |
 | `claude-sonnet-5[1m]`   | `claude-sonnet-5`      | 1M             |
 | `claude-sonnet-4-6`     | `claude-sonnet-4.6`    | 200k           |
@@ -284,7 +286,7 @@ Supported query forms:
 | `claude-opus-4.5`       | `claude-opus-4.5`      | 200k           |
 | `claude-haiku-4.5`      | `claude-haiku-4.5`     | 200k           |
 
-Opus 4.6, 4.7, 4.8, and Sonnet 5 always use 1M context (no 200k SKU exists upstream). Unlike Sonnet 4.6, `claude-sonnet-5` has no separate `-1m` SKU: the single `claude-sonnet-5` SKU is always 1M. The explicit `[1m]`-suffixed aliases (`claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field — this matches Claude Code's default Max-plan state (`lG()` emits `claude-opus-4-8[1m]`) and keeps its `mR()` 1M-context check happy without spuriously enabling extended thinking. Thinking is still opt-in via Sonnet `[1m]` suffix, `Anthropic-Beta: context-1m` header, or `thinking` field.
+Opus 5, Opus 4.6, 4.7, 4.8, and Sonnet 5 always use 1M context (no 200k SKU exists upstream). Unlike Sonnet 4.6, `claude-opus-5` and `claude-sonnet-5` have no separate `-1m` SKU: each single SKU is always 1M. The explicit `[1m]`-suffixed aliases (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field — this matches Claude Code's 1M-context model state and keeps its context-window check happy without spuriously enabling extended thinking. On these always-1M models, thinking remains opt-in via the `context-1m` header or the `thinking` field; the `[1m]` suffix remains a thinking opt-in for models without a first-class always-1M alias.
 
 Unmatched `claude-*` models are passed through as-is. Non-claude models fall back to `claude-sonnet-4.6`.
 
@@ -292,7 +294,7 @@ Unmatched `claude-*` models are passed through as-is. Non-claude models fall bac
 
 The `model` field in `/v1/messages` responses (streaming `message_start`, non-streaming body, and tool-search path) is returned as the **Anthropic-form ID** (e.g. `claude-opus-4-7`), not the Kiro SKU (`claude-opus-4.7`).
 
-When the proxy routes to a **1M context window** (always-1M SKU such as `claude-opus-4.8` / `claude-opus-4.7` / `claude-opus-4.6`, or a model invoked with the `[1m]` suffix or `Anthropic-Beta: context-1m` header), a trailing `[1m]` is appended to the response model ID (e.g. `claude-opus-4-8[1m]`). Claude Code's client-side context-window logic matches `/\[1m\]/i` on the response model to pick the 1M window — without the suffix it defaults to 200k and auto-compacts at ~160k even when upstream actually has 1M of context.
+When the proxy routes to a **1M context window** (always-1M SKU such as `claude-opus-5` / `claude-opus-4.8` / `claude-opus-4.7` / `claude-opus-4.6`, or a model invoked with the `[1m]` suffix or `Anthropic-Beta: context-1m` header), a trailing `[1m]` is appended to the response model ID (e.g. `claude-opus-5[1m]`). Claude Code's client-side context-window logic matches `/\[1m\]/i` on the response model to pick the 1M window — without the suffix it defaults to 200k and auto-compacts at ~160k even when upstream actually has 1M of context.
 
 Note: `[1m]` has different meanings on request vs. response. On the **request** `model` it is a client-supplied thinking-opt-in signal (and is stripped before upstream routing). On the **response** `model` it is purely a context-window advertisement for Claude Code and does not imply that extended thinking was enabled.
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Thinking is enabled by any of:
 
 Exception: the `[1m]` suffix on an **always-1M** model (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) is a first-class alias that only advertises the 1M context window — it does **not** enable thinking (see [Model mappings](#model-mappings)). Thinking on those models is still opt-in via the `context-1m` header or the `thinking` field.
 
+The suffix is matched case-insensitively because Claude Code may emit `[1M]`
+from internal call paths. Responses always use the canonical lowercase `[1m]`.
+
 The reasoning effort sent to the backend is resolved as follows:
 
 1. An explicit, recognized `output_config.effort` wins, validated/clamped to the model's allowed enum (`xhigh` on a 4-value model clamps to `max`; unrecognized strings are dropped).

--- a/internal/app/messages/effort_test.go
+++ b/internal/app/messages/effort_test.go
@@ -17,6 +17,8 @@ func TestResolveEffort(t *testing.T) {
 		want      string
 	}{
 		// Explicit effort passes through (validated against the model enum).
+		{"explicit max on opus-5", "claude-opus-5", "max", false, "max"},
+		{"explicit xhigh on opus-5", "claude-opus-5", "xhigh", true, "xhigh"},
 		{"explicit max on opus-4.8", "claude-opus-4.8", "max", false, "max"},
 		{"explicit xhigh on opus-4.8", "claude-opus-4.8", "xhigh", true, "xhigh"},
 		{"explicit xhigh clamps on sonnet-4.6", "claude-sonnet-4.6", "xhigh", false, "max"},
@@ -29,6 +31,7 @@ func TestResolveEffort(t *testing.T) {
 
 		// No effort but thinking enabled: fall back to the default effort so the
 		// reasoning request still reaches the backend natively.
+		{"thinking only, effort-capable opus-5", "claude-opus-5", "", true, models.EffortMedium},
 		{"thinking only, effort-capable opus-4.8", "claude-opus-4.8", "", true, models.EffortMedium},
 		{"thinking only, effort-capable sonnet-4.6", "claude-sonnet-4.6", "", true, models.EffortMedium},
 

--- a/internal/models/effort.go
+++ b/internal/models/effort.go
@@ -28,6 +28,7 @@ var effortRank = map[string]int{
 // support effort and must omit additionalModelRequestFields entirely.
 var effortEnums = map[string][]string{
 	// 5-value enum (includes xhigh); 128000 max-output models.
+	"claude-opus-5":   {EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 	"claude-opus-4.8": {EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 	"claude-opus-4.7": {EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 	// 5-value enum (includes xhigh); 64000 max-output model.

--- a/internal/models/effort_test.go
+++ b/internal/models/effort_test.go
@@ -9,7 +9,10 @@ func TestResolveEffort(t *testing.T) {
 		requested string
 		want      string
 	}{
-		// opus-4.8 / 4.7 / sonnet-5: full enum including xhigh.
+		// opus-5 / 4.8 / 4.7 / sonnet-5: full enum including xhigh.
+		{"opus-5 xhigh", "claude-opus-5", "xhigh", "xhigh"},
+		{"opus-5 max", "claude-opus-5", "max", "max"},
+		{"opus-5 low", "claude-opus-5", "low", "low"},
 		{"opus-4.8 xhigh", "claude-opus-4.8", "xhigh", "xhigh"},
 		{"opus-4.8 max", "claude-opus-4.8", "max", "max"},
 		{"opus-4.8 low", "claude-opus-4.8", "low", "low"},

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -17,6 +17,21 @@ type Mapping struct {
 
 const ThinkingSuffix = "[1m]"
 
+// normalizeThinkingSuffix canonicalizes the trailing 1M context marker while
+// leaving the model ID itself untouched. Claude Code emits both `[1m]` and
+// `[1M]` depending on the call path; Kiro model IDs are case-sensitive and
+// must never receive either suffix.
+func normalizeThinkingSuffix(model string) string {
+	if len(model) < len(ThinkingSuffix) {
+		return model
+	}
+	suffixStart := len(model) - len(ThinkingSuffix)
+	if strings.EqualFold(model[suffixStart:], ThinkingSuffix) {
+		return model[:suffixStart] + ThinkingSuffix
+	}
+	return model
+}
+
 // Context window sizes.
 const (
 	DefaultContextWindowSize  = 200_000
@@ -119,6 +134,8 @@ func effectiveMappings() []Mapping {
 // Upstream `kiroModel` is never `[1m]`-suffixed — it always comes from
 // mapping tables. KIROCC_MODEL_MAPPINGS env var can override mappings.
 func Resolve(model string, context1M bool) (kiroModel string, thinking bool, contextWindowSize int, anthropicModel string) {
+	model = normalizeThinkingSuffix(model)
+
 	var matchedWindowSize int
 	var matchedKiro1M string
 	var matchedAnthropic string

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,10 +27,12 @@ const (
 // Uses exact key matching against both Anthropic and Kiro fields (first match wins).
 // Order matters: specific entries must precede legacy aliases that share the same Kiro value.
 var modelMapOrdered = []Mapping{
+	{Anthropic: "claude-opus-5[1m]", Kiro: "claude-opus-5", Kiro1M: "claude-opus-5"},
 	{Anthropic: "claude-opus-4-8[1m]", Kiro: "claude-opus-4.8", Kiro1M: "claude-opus-4.8"},
 	{Anthropic: "claude-opus-4-7[1m]", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
 	{Anthropic: "claude-opus-4-6[1m]", Kiro: "claude-opus-4.6", Kiro1M: "claude-opus-4.6"},
 	{Anthropic: "claude-sonnet-5[1m]", Kiro: "claude-sonnet-5", Kiro1M: "claude-sonnet-5"},
+	{Anthropic: "claude-opus-5", Kiro: "claude-opus-5", Kiro1M: "claude-opus-5"},
 	{Anthropic: "claude-opus-4-8", Kiro: "claude-opus-4.8", Kiro1M: "claude-opus-4.8"},
 	{Anthropic: "claude-opus-4-7", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
 	{Anthropic: "claude-sonnet-5", Kiro: "claude-sonnet-5", Kiro1M: "claude-sonnet-5"},

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -17,6 +17,29 @@ func TestResolve(t *testing.T) {
 		wantAnthropicModel string
 	}{
 		{
+			name:               "claude-opus-5 uses 1m context without thinking",
+			model:              "claude-opus-5",
+			wantKiroModel:      "claude-opus-5",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-5[1m]",
+		},
+		{
+			name:               "claude-opus-5[1m] exact-match preserves suffix without thinking",
+			model:              "claude-opus-5[1m]",
+			wantKiroModel:      "claude-opus-5",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-5[1m]",
+		},
+		{
+			name:               "claude-opus-5 with context1M enables thinking",
+			model:              "claude-opus-5",
+			context1M:          true,
+			wantKiroModel:      "claude-opus-5",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-5[1m]",
+		},
+		{
 			name:               "claude-opus-4-8 uses 1m context without thinking",
 			model:              "claude-opus-4-8",
 			wantKiroModel:      "claude-opus-4.8",
@@ -294,6 +317,10 @@ func TestListModels(t *testing.T) {
 		{
 			name:       "claude-sonnet-5 is listed exactly once (both alias rows dedupe to one Kiro value)",
 			checkModel: "claude-sonnet-5",
+		},
+		{
+			name:       "claude-opus-5 is listed exactly once (both alias rows dedupe to one Kiro value)",
+			checkModel: "claude-opus-5",
 		},
 		{
 			name:        "env override model included",

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -31,6 +31,13 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-opus-5[1m]",
 		},
 		{
+			name:               "claude-opus-5 uppercase [1M] is normalized without thinking",
+			model:              "claude-opus-5[1M]",
+			wantKiroModel:      "claude-opus-5",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-5[1m]",
+		},
+		{
 			name:               "claude-opus-5 with context1M enables thinking",
 			model:              "claude-opus-5",
 			context1M:          true,
@@ -139,6 +146,13 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-sonnet-5[1m]",
 		},
 		{
+			name:               "claude-sonnet-5 uppercase [1M] is normalized without thinking",
+			model:              "claude-sonnet-5[1M]",
+			wantKiroModel:      "claude-sonnet-5",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-5[1m]",
+		},
+		{
 			name:               "claude-sonnet-5 with context1M enables thinking",
 			model:              "claude-sonnet-5",
 			context1M:          true,
@@ -164,6 +178,14 @@ func TestResolve(t *testing.T) {
 		{
 			name:               "claude-sonnet-4-6 with thinking suffix",
 			model:              "claude-sonnet-4-6[1m]",
+			wantKiroModel:      "claude-sonnet-4.6-1m",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6[1m]",
+		},
+		{
+			name:               "claude-sonnet-4-6 uppercase [1M] selects 1m SKU",
+			model:              "claude-sonnet-4-6[1M]",
 			wantKiroModel:      "claude-sonnet-4.6-1m",
 			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,

--- a/internal/server/e2e_response_model_test.go
+++ b/internal/server/e2e_response_model_test.go
@@ -19,6 +19,18 @@ func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 		wantUpstream string // Kiro SKU sent upstream
 	}{
 		{
+			name:         "opus-5 gets 1m suffix in response",
+			requestModel: "claude-opus-5",
+			wantResponse: "claude-opus-5[1m]",
+			wantUpstream: "claude-opus-5",
+		},
+		{
+			name:         "opus-5[1m] exact-match preserved verbatim",
+			requestModel: "claude-opus-5[1m]",
+			wantResponse: "claude-opus-5[1m]",
+			wantUpstream: "claude-opus-5",
+		},
+		{
 			name:         "opus-4-8 hyphen preserved in response",
 			requestModel: "claude-opus-4-8",
 			wantResponse: "claude-opus-4-8[1m]",
@@ -127,6 +139,16 @@ func TestE2E_ResponseModel_Streaming(t *testing.T) {
 		requestModel string
 		wantResponse string
 	}{
+		{
+			name:         "opus-5 gets 1m suffix in message_start",
+			requestModel: "claude-opus-5",
+			wantResponse: "claude-opus-5[1m]",
+		},
+		{
+			name:         "opus-5[1m] exact-match preserved verbatim in message_start",
+			requestModel: "claude-opus-5[1m]",
+			wantResponse: "claude-opus-5[1m]",
+		},
 		{
 			name:         "opus-4-8 hyphen preserved in message_start",
 			requestModel: "claude-opus-4-8",

--- a/internal/server/e2e_response_model_test.go
+++ b/internal/server/e2e_response_model_test.go
@@ -31,6 +31,12 @@ func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 			wantUpstream: "claude-opus-5",
 		},
 		{
+			name:         "opus-5 uppercase [1M] normalized",
+			requestModel: "claude-opus-5[1M]",
+			wantResponse: "claude-opus-5[1m]",
+			wantUpstream: "claude-opus-5",
+		},
+		{
 			name:         "opus-4-8 hyphen preserved in response",
 			requestModel: "claude-opus-4-8",
 			wantResponse: "claude-opus-4-8[1m]",
@@ -69,6 +75,12 @@ func TestE2E_ResponseModel_NonStreaming(t *testing.T) {
 		{
 			name:         "sonnet-5[1m] exact-match preserved verbatim",
 			requestModel: "claude-sonnet-5[1m]",
+			wantResponse: "claude-sonnet-5[1m]",
+			wantUpstream: "claude-sonnet-5",
+		},
+		{
+			name:         "sonnet-5 uppercase [1M] normalized",
+			requestModel: "claude-sonnet-5[1M]",
 			wantResponse: "claude-sonnet-5[1m]",
 			wantUpstream: "claude-sonnet-5",
 		},
@@ -150,6 +162,11 @@ func TestE2E_ResponseModel_Streaming(t *testing.T) {
 			wantResponse: "claude-opus-5[1m]",
 		},
 		{
+			name:         "opus-5 uppercase [1M] normalized in message_start",
+			requestModel: "claude-opus-5[1M]",
+			wantResponse: "claude-opus-5[1m]",
+		},
+		{
 			name:         "opus-4-8 hyphen preserved in message_start",
 			requestModel: "claude-opus-4-8",
 			wantResponse: "claude-opus-4-8[1m]",
@@ -177,6 +194,11 @@ func TestE2E_ResponseModel_Streaming(t *testing.T) {
 		{
 			name:         "sonnet-5 always-1M gets [1m] suffix in message_start",
 			requestModel: "claude-sonnet-5",
+			wantResponse: "claude-sonnet-5[1m]",
+		},
+		{
+			name:         "sonnet-5 uppercase [1M] normalized in message_start",
+			requestModel: "claude-sonnet-5[1M]",
 			wantResponse: "claude-sonnet-5[1m]",
 		},
 	}


### PR DESCRIPTION
## Summary

- add first-class `claude-opus-5` and `claude-opus-5[1m]` model mappings
- advertise Opus 5 as an always-1M model in Anthropic-compatible responses
- enable the full `low` through `max` effort enum, including `xhigh`
- normalize trailing `[1m]` case-insensitively before upstream routing
- cover model listing, routing, effort, and streaming/non-streaming response IDs

## Why

Kiro now exposes the `claude-opus-5` SKU. Without an explicit mapping, kirocc cannot advertise its always-1M context behavior consistently to Claude Code or validate the model's effort levels.

Claude Code also emits both `[1m]` and `[1M]` from different internal call paths. Kiro model IDs are case-sensitive, so the suffix must be removed before routing and canonicalized to lowercase in the response. This prevents requests such as `claude-opus-5[1M]` from reaching Kiro as an invalid model ID.

## Behavior

| Request model | Kiro model | Response model | Context |
| --- | --- | --- | --- |
| `claude-opus-5` | `claude-opus-5` | `claude-opus-5[1m]` | 1M |
| `claude-opus-5[1m]` | `claude-opus-5` | `claude-opus-5[1m]` | 1M |
| `claude-opus-5[1M]` | `claude-opus-5` | `claude-opus-5[1m]` | 1M |

The `[1m]` alias only advertises the context window for this always-1M model; thinking remains controlled by the existing header or `thinking` request field.

## Validation

- `make test` (`go test -race ./...`)
- `make vet`
- `make lint`
- `make build`
- real Opus 5 requests through the patched proxy returned HTTP 200 with upstream model `claude-opus-5` and a 1M response model ID

Fixes #74
