### PR TITLE
feat: SSE keep-alive heartbeat and usage fallback fix

### DIFF
--- a/.claude/skills/kiro-capture/SKILL.md
+++ b/.claude/skills/kiro-capture/SKILL.md
@@ -161,19 +161,27 @@ For each request/response pair, extract:
    - `AmazonCodeWhispererService.ListAvailableModels` (JSON)
    - `ToolkitTelemetry.ClientTelemetryMetrics` (JSON)
    - `AmazonCodeWhispererService.GetProfile` (JSON)
-   - `AmazonCodeWhispererService.GetUsageLimits` (JSON, **403 is expected/normal**)
+   - `AmazonCodeWhispererService.GetUsageLimits` (JSON, **403 is expected/normal**; may be absent in a session)
    - `AmazonCodeWhispererService.SendTelemetryEvent` (JSON)
-   - If no `x-amz-target`, infer from URL path
+   - `AWSCognitoIdentityService.GetCredentialsForIdentity` (JSON; cognito-identity host — returns temporary AWS creds used to SigV4-sign the telemetry calls)
+   - If no `x-amz-target`, infer from URL path/host:
+     - `oidc.*.amazonaws.com/token` → `SSOOIDC.CreateToken` (JSON; `grantType: refresh_token` rotates the Bearer token mid-session)
+     - `client-telemetry.*.amazonaws.com/metrics` → `ToolkitTelemetry.ClientTelemetryMetrics`
 3. **Request URL**
 4. **Request headers** — all headers, but redact:
-   - `authorization` header value → `[REDACTED]`
+   - `authorization` header value → `[REDACTED]` (covers both `Bearer <token>` and `AWS4-HMAC-SHA256 ... Signature=...`)
    - `x-amz-security-token` header value → `[REDACTED]`
-5. **Request body** — extract JSON as-is
+5. **Request body** — extract JSON as-is, but redact secret **values** in these bodies:
+   - `CreateToken` request: `refreshToken`, `clientSecret` → `[REDACTED]`
 6. **Response status** — from `<< STATUS SIZE` line
 7. **Response headers**
 8. **Response body**:
-   - JSON → extract as-is
+   - JSON → extract as-is, but redact secret **values**:
+     - `GetCredentialsForIdentity` response: `AccessKeyId`, `SecretKey`, `SessionToken` → `[REDACTED]`
+     - `CreateToken` response: `accessToken`, `refreshToken` → `[REDACTED]`
    - EventStream (`application/vnd.amazon.eventstream`) → apply EventStream parsing below
+
+**Redaction rule:** secret values may only ever appear in `raw.log` (the mitmdump input). Every generated `.md` must contain `[REDACTED]` in their place. After generating files, verify no secret fragment (AWS `ASIA...` access key IDs, `Bearer aoa...`/`aor...` tokens, `AWS4-HMAC ... Signature=<hex>`, Cognito `IQoJ...` session tokens) leaks into any `.md` — including `report.md` prose.
 
 ### EventStream response parsing
 
@@ -184,11 +192,17 @@ Parsing steps:
 1. Identify event boundaries by `:event-type` markers
 2. Extract JSON objects (`{...}`) from each event segment
 3. Classify events:
+   - `initial-response` — stream preamble (`{"conversationId":""}`)
+   - `reasoningContentEvent` — native reasoning/thinking stream: `text` deltas followed by a final `signature` field. Concatenate the `text` deltas; note the `signature` exists but show it as `[present]` (do not dump the full value)
    - `assistantResponseEvent` — assistant response text (delta `content` field)
    - `toolUseEvent` — tool call (`name`, `toolUseId`, `input` fields)
+   - `metadataEvent` — turn end (`stopReason`, e.g. `END_TURN`)
    - `contextUsageEvent` — context usage (`contextUsagePercentage` field)
+   - `meteringEvent` — credit consumption (`{"unit":"credit","usage":...}`)
 4. Merge events sharing the same `toolUseId` to reconstruct complete tool calls
-5. Concatenate `assistantResponseEvent` `content` fields to reconstruct full response text
+5. Concatenate `assistantResponseEvent` `content` fields to reconstruct full response text; concatenate `reasoningContentEvent` `text` fields to reconstruct the reasoning trace
+
+> Note: `reasoningContentEvent` and `meteringEvent` are emitted by kiro-cli 2.10.0. Reasoning is now **native** (a `reasoningContentEvent` stream), not a `thinking` tool in the tools array.
 
 ### Step 10 — Generate individual API call files
 
@@ -249,11 +263,21 @@ Content-Type: `application/vnd.amazon.eventstream`
 
 **Events:**
 
-| #   | Event Type             | Summary                       |
-| --- | ---------------------- | ----------------------------- |
-| 1   | assistantResponseEvent | {first 80 chars}              |
-| 2   | toolUseEvent           | {tool name}: {first 80 chars} |
-| 3   | contextUsageEvent      | {percentage}%                 |
+| #   | Event Type             | Summary                          |
+| --- | ---------------------- | -------------------------------- |
+| 1   | initial-response       | conversationId ""                |
+| 2   | reasoningContentEvent  | {text delta / signature present} |
+| 3   | assistantResponseEvent | {first 80 chars}                 |
+| 4   | toolUseEvent           | {tool name}: {first 80 chars}    |
+| 5   | metadataEvent          | stopReason {value}               |
+| 6   | contextUsageEvent      | {percentage}%                    |
+| 7   | meteringEvent          | {usage} credits                  |
+
+**Full reasoning text:** (if any reasoningContentEvent)
+
+\`\`\`
+{concatenated reasoning text}
+\`\`\`
 
 **Full assistant response:**
 
@@ -261,11 +285,13 @@ Content-Type: `application/vnd.amazon.eventstream`
 {concatenated full text}
 \`\`\`
 
-**Tool calls:**
+**Tool calls:** (if any toolUseEvent)
 
 \`\`\`json
 [{reconstructed tool call objects}]
 \`\`\`
+
+**Metering:** {unit}, usage {value}
 ```
 
 ### Step 11 — Generate analysis report
@@ -304,11 +330,16 @@ Template:
 | CodeWhispererStreamingService | {n}   | GenerateAssistantResponse                                           |
 | CodeWhispererService          | {n}   | GetProfile, ListAvailableModels, GetUsageLimits, SendTelemetryEvent |
 | ToolkitTelemetry              | {n}   | ClientTelemetryMetrics                                              |
+| AWSCognitoIdentityService     | {n}   | GetCredentialsForIdentity                                           |
+| SSOOIDC                       | {n}   | CreateToken                                                         |
+
+(Omit categories with count 0.)
 
 ## Authentication
 
-1. **Bearer Token** (`authorization: Bearer <token>`): CodeWhisperer API
+1. **Bearer Token** (`authorization: Bearer <token>`): CodeWhisperer / kiro.dev API
 2. **AWS Signature V4** (`authorization: AWS4-HMAC-SHA256 ...`): Telemetry API
+3. **Cognito + OIDC**: `GetCredentialsForIdentity` yields the temporary AWS creds that SigV4-sign the telemetry calls; `CreateToken` (`grantType: refresh_token`) refreshes the Bearer token mid-session (note if/when the token rotates)
 
 ## Conversation Flow
 
@@ -341,7 +372,7 @@ Group requests by conversationId and agentContinuationId. Render as ASCII tree:
 ## Model Info
 
 - Model ID: {modelId}
-- Thinking: {enabled/disabled — check if tools array contains thinking tool}
+- Reasoning/thinking: {active/inactive — active if the response has a `reasoningContentEvent` stream. kiro-cli 2.10.0 uses native reasoning, so there is no `thinking` tool in the tools array}
 - Tool count: {length of tools array}
 
 ## Tool Usage Patterns
@@ -349,6 +380,18 @@ Group requests by conversationId and agentContinuationId. Render as ASCII tree:
 | Tool name                     | Invocation count |
 | ----------------------------- | ---------------- |
 | {tool name from toolUseEvent} | {count}          |
+
+(If no toolUseEvent occurred, report `(none) | 0` and note the turns were plain text.)
+
+## Notable Findings
+
+Bullet list of anything noteworthy vs. prior captures, e.g.:
+
+- New event types or APIs observed (e.g. `reasoningContentEvent`, `meteringEvent`)
+- Bearer token refresh / rotation via OIDC `CreateToken`
+- Model-catalog specifics from `ListAvailableModels` (rateMultiplier, maxOutputTokens, context window, thinking.type enum)
+- APIs that were expected but absent (e.g. `GetUsageLimits`)
+- Metering / credit usage per turn
 ```
 
 ### Step 12 — Update state.json

--- a/cmd/kirocc/main.go
+++ b/cmd/kirocc/main.go
@@ -105,6 +105,7 @@ func parseFlags(args []string) (config.Config, error) {
 	fs.BoolVar(&cfg.Debug, "debug", false, "enable debug logging with OTel JSON Lines output")
 	fs.BoolVar(&cfg.OTel, "otel", false, "enable OpenTelemetry tracing (OTLP HTTP exporter)")
 	fs.IntVar(&cfg.OTelBodyLimit, "otel-body-limit", config.DefaultOTelBodyLimit, "max bytes of request body to capture in OTel spans (0 = unlimited)")
+	fs.DurationVar(&cfg.KeepAliveInterval, "keepalive-interval", config.DefaultKeepAliveInterval, "SSE idle keep-alive interval (0 = disabled)")
 	fs.StringVar(&cfg.LogFile.Path, "log-file", "", "write logs to file with rotation (for agent debugging)")
 	fs.IntVar(&cfg.LogFile.MaxSize, "log-max-size", logging.DefaultLogMaxSize, "max log file size in MB before rotation")
 	fs.IntVar(&cfg.LogFile.MaxBackups, "log-max-backups", logging.DefaultLogMaxBackups, "max number of old log files to retain")
@@ -138,7 +139,7 @@ func buildKiroClient(authMgr *auth.AuthManager, cfg config.Config) kiroclient.Cl
 }
 
 func buildServer(authMgr *auth.AuthManager, client kiroclient.Client, cfg config.Config) *server.Server {
-	var opts []server.ServerOption
+	opts := []server.ServerOption{server.WithKeepAliveInterval(cfg.KeepAliveInterval)}
 	if cfg.OTel {
 		opts = append(opts, server.WithOTel(cfg.OTelBodyLimit))
 	}

--- a/cmd/kirocc/main_test.go
+++ b/cmd/kirocc/main_test.go
@@ -3,10 +3,35 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/d-kuro/kirocc/internal/config"
 )
 
 func TestRun_HelpFlagReturnsNoError(t *testing.T) {
 	if err := run(context.Background(), []string{"-h"}); err != nil {
 		t.Errorf("run with -h: got err %v; want nil", err)
 	}
+}
+
+func TestParseFlags_KeepAliveInterval(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg, err := parseFlags(nil)
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.KeepAliveInterval != config.DefaultKeepAliveInterval {
+			t.Fatalf("KeepAliveInterval = %v, want %v", cfg.KeepAliveInterval, config.DefaultKeepAliveInterval)
+		}
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		cfg, err := parseFlags([]string{"-keepalive-interval", "30s"})
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.KeepAliveInterval != 30*time.Second {
+			t.Fatalf("KeepAliveInterval = %v, want 30s", cfg.KeepAliveInterval)
+		}
+	})
 }

--- a/internal/app/messages/errors.go
+++ b/internal/app/messages/errors.go
@@ -26,18 +26,55 @@ var retryableInvalidStateReasons = map[string]struct{}{
 	"STALE_CONVERSATION":               {},
 }
 
-// handleUpstreamError writes the appropriate error response for upstream failures.
-// Returns a non-empty reason string if the error is retryable, or "" if a final error was written.
-func handleUpstreamError(w http.ResponseWriter, isException bool, invalidReason string) string {
+type upstreamErrorClassification struct {
+	retryReason string
+	final       streamFinalError
+}
+
+type streamFinalError struct {
+	status      int
+	jsonType    string
+	jsonMessage string
+	sseType     string
+	sseMessage  string
+}
+
+func newStreamFinalError(status int, errType, message string) streamFinalError {
+	return streamFinalError{
+		status:      status,
+		jsonType:    errType,
+		jsonMessage: message,
+		sseType:     errType,
+		sseMessage:  message,
+	}
+}
+
+// classifyUpstreamError separates upstream event classification from response
+// writing so streaming callers can choose JSON or SSE based on session state.
+func classifyUpstreamError(isException bool, invalidReason, upstreamMessage string) upstreamErrorClassification {
 	if isException {
-		httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream exception")
-		return ""
+		final := newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream exception")
+		if upstreamMessage != "" {
+			final.sseMessage = upstreamMessage
+		}
+		return upstreamErrorClassification{final: final}
+	}
+	final := newStreamFinalError(
+		http.StatusBadRequest,
+		errTypeInvalidRequest,
+		"invalid state: request rejected by upstream",
+	)
+	final.sseType = "invalid_state"
+	if upstreamMessage != "" {
+		final.sseMessage = upstreamMessage
+	}
+	classification := upstreamErrorClassification{
+		final: final,
 	}
 	if _, ok := retryableInvalidStateReasons[invalidReason]; ok {
-		return invalidReason
+		classification.retryReason = invalidReason
 	}
-	httpx.WriteError(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: request rejected by upstream")
-	return ""
+	return classification
 }
 
 // logUpstreamError logs a "kiro api error" with structured attributes when the

--- a/internal/app/messages/execute.go
+++ b/internal/app/messages/execute.go
@@ -27,15 +27,20 @@ type invocation struct {
 
 // callAndHandle performs one upstream call for the invocation and streams or
 // buffers the response to w. Returns a non-empty reason if the request failed
-// with a retryable invalidStateEvent before any bytes were written to w.
-func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, inv *invocation, attempt int) string {
+// before semantic output was promoted. Transport keep-alives do not prevent
+// that transparent retry.
+func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, session *streamSession, inv *invocation, attempt int) string {
 	_, short := logging.TraceIDs(ctx)
 	capture := newUpstreamAttemptCapture(ctx, s.captureEnabled, inv.payload, inv.model, inv.thinking, inv.req.Stream, attempt)
 
 	apiResp, err := s.client.GenerateAssistantResponse(ctx, inv.creds.AccessToken, inv.payload, inv.creds.Region)
 	if err != nil {
 		logUpstreamError(ctx, short, err)
-		httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream API error")
+		if session != nil {
+			_ = session.WriteFinalError(newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream API error"), nil)
+		} else {
+			httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream API error")
+		}
 		return ""
 	}
 	body := apiResp.Body
@@ -46,7 +51,7 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, inv 
 
 	var reason string
 	if inv.req.Stream {
-		reason = s.handleStreamingResponse(ctx, w, apiResp, inv.responseModel, inv.contextWindowSize, inv.req.StopSequences, inv.req.MaxTokens, apiResp.PromptTokens, capture, inv.toolNameMap)
+		reason = s.handleStreamingResponse(ctx, session, apiResp, inv.responseModel, inv.contextWindowSize, inv.req.StopSequences, inv.req.MaxTokens, apiResp.PromptTokens, capture, inv.toolNameMap)
 	} else {
 		reason = s.handleNonStreamingResponse(ctx, w, apiResp, inv.responseModel, inv.contextWindowSize, inv.req.StopSequences, inv.req.MaxTokens, apiResp.PromptTokens, capture, inv.toolNameMap)
 	}
@@ -60,9 +65,19 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, inv 
 // responses by clearing ConversationID and attempting once more. Terminal error
 // responses are written to w and the function returns.
 func (s *Service) executeWithRetry(ctx context.Context, w http.ResponseWriter, inv *invocation) {
+	if inv.req.Stream {
+		session := newStreamSession(ctx, w, s.keepAliveInterval)
+		defer session.Stop()
+		s.executeRetry(session.Context(), session, session, inv)
+		return
+	}
+	s.executeRetry(ctx, w, nil, inv)
+}
+
+func (s *Service) executeRetry(ctx context.Context, w http.ResponseWriter, session *streamSession, inv *invocation) {
 	_, short := logging.TraceIDs(ctx)
 
-	reason := s.callAndHandle(ctx, w, inv, 1)
+	reason := s.callAndHandle(ctx, w, session, inv, 1)
 	if reason == "" {
 		return
 	}
@@ -75,18 +90,26 @@ func (s *Service) executeWithRetry(ctx context.Context, w http.ResponseWriter, i
 	// or retryable invalidStateEvent like CONTENT_LENGTH_EXCEEDS_THRESHOLD).
 	inv.payload.ConversationState.ConversationID = ""
 
-	reason2 := s.callAndHandle(ctx, w, inv, 2)
+	reason2 := s.callAndHandle(ctx, w, session, inv, 2)
 	if reason2 == "" {
 		return
 	}
 	if reason2 == retryReasonEmptyVisibleEndTurn {
 		slog.ErrorContext(ctx, "retry also returned empty visible end_turn",
 			"trace_id", short, "reason", reason2)
-		httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream returned empty response")
+		if session != nil {
+			_ = session.WriteFinalError(newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream returned empty response"), nil)
+		} else {
+			httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream returned empty response")
+		}
 		return
 	}
 	// Retry ended with a different (final) error — report it as invalid state.
 	slog.ErrorContext(ctx, "retry failed",
 		"trace_id", short, "first_reason", reason, "second_reason", reason2)
-	httpx.WriteError(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: "+reason2)
+	if session != nil {
+		_ = session.WriteFinalError(newStreamFinalError(http.StatusBadRequest, errTypeInvalidRequest, "invalid state: "+reason2), nil)
+	} else {
+		httpx.WriteError(w, http.StatusBadRequest, errTypeInvalidRequest, "invalid state: "+reason2)
+	}
 }

--- a/internal/app/messages/gate_writer.go
+++ b/internal/app/messages/gate_writer.go
@@ -1,85 +1,169 @@
 package messages
 
 import (
-	"bytes"
+	"io"
 	"net/http"
+	"time"
 )
 
-// GateWriter wraps an http.ResponseWriter and buffers all writes until Promote
-// is called. This allows the server to discard buffered SSE events (e.g. on
-// empty visible end_turn) and retry the upstream request transparently.
-type GateWriter struct {
-	w          http.ResponseWriter
-	buf        bytes.Buffer
-	promoted   bool
-	statusCode int // deferred status code (0 = not set)
+// Header returns the underlying ResponseWriter's header map. Callers must set
+// headers before Start, when the heartbeat can begin committing the response.
+func (s *streamSession) Header() http.Header {
+	return s.w.Header()
 }
 
-// NewGateWriter creates a GateWriter that buffers writes to w.
-func NewGateWriter(w http.ResponseWriter) *GateWriter {
-	return &GateWriter{w: w}
-}
-
-// Header returns the underlying ResponseWriter's header map.
-func (g *GateWriter) Header() http.Header {
-	return g.w.Header()
-}
-
-// WriteHeader captures the status code. In buffered mode it defers the actual
-// call until Promote; in promoted mode it delegates immediately.
-func (g *GateWriter) WriteHeader(statusCode int) {
-	if g.promoted {
-		g.w.WriteHeader(statusCode)
+// SetSSEHeaders installs transport headers once under the same mutex used by
+// heartbeat writes. Retry attempts therefore never mutate the header map after
+// the response may have been committed.
+func (s *streamSession) SetSSEHeaders() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.headersSet || s.committed || s.finalized {
 		return
 	}
-	g.statusCode = statusCode
+	h := s.w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	s.headersSet = true
 }
 
-// Write buffers data before promotion, or writes directly after.
-func (g *GateWriter) Write(p []byte) (int, error) {
-	if g.promoted {
-		return g.w.Write(p)
-	}
-	return g.buf.Write(p)
-}
-
-// Flush delegates to the underlying Flusher if promoted.
-func (g *GateWriter) Flush() {
-	if !g.promoted {
+// WriteHeader defers the status until promotion while semantic events are
+// buffered. Once promoted, it delegates to the real writer.
+func (s *streamSession) WriteHeader(statusCode int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.firstErr != nil || s.stopped || s.finalized {
 		return
 	}
-	if f, ok := g.w.(http.Flusher); ok {
-		f.Flush()
-	}
-}
-
-// Promote flushes the buffer to the real ResponseWriter and switches to
-// direct-write mode. All subsequent Write calls go straight through.
-func (g *GateWriter) Promote() {
-	if g.promoted {
+	if s.promoted {
+		s.w.WriteHeader(statusCode)
 		return
 	}
-	g.promoted = true
-	if g.statusCode != 0 {
-		g.w.WriteHeader(g.statusCode)
-	}
-	if g.buf.Len() > 0 {
-		_, _ = g.w.Write(g.buf.Bytes())
-		g.buf.Reset()
-	}
-	if f, ok := g.w.(http.Flusher); ok {
-		f.Flush()
-	}
+	s.statusCode = statusCode
 }
 
-// Discard drops the buffered data without writing it to the client.
-// Must only be called before Promote.
-func (g *GateWriter) Discard() {
-	g.buf.Reset()
-	g.statusCode = 0
+// Write buffers semantic SSE bytes before promotion and writes directly after
+// promotion. Transport keep-alives bypass this method's buffer.
+func (s *streamSession) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.unavailableLocked(); err != nil {
+		return 0, err
+	}
+	if !s.promoted {
+		return s.buf.Write(p)
+	}
+	return s.writeSocketLocked(p)
 }
 
-// IsPromoted reports whether the writer has been promoted to direct mode.
-func (g *GateWriter) IsPromoted() bool {
-	return g.promoted
+// Flush implements http.Flusher. Pre-promotion semantic writes are not flushed.
+// Flush errors are retained by Err so SSEWriter can observe them.
+func (s *streamSession) Flush() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.promoted || s.firstErr != nil || s.stopped || s.finalized {
+		return
+	}
+	_ = s.flushSocketLocked()
+}
+
+// Promote flushes buffered semantic events and switches to direct mode.
+func (s *streamSession) Promote() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.unavailableLocked(); err != nil {
+		return err
+	}
+	if s.promoted {
+		return s.firstErr
+	}
+
+	s.promoted = true
+	hadOutput := s.statusCode != 0 || s.buf.Len() > 0
+	if s.statusCode != 0 {
+		s.w.WriteHeader(s.statusCode)
+	}
+	if s.buf.Len() > 0 {
+		data := append([]byte(nil), s.buf.Bytes()...)
+		if _, err := s.writeSocketLocked(data); err != nil {
+			return err
+		}
+		s.buf.Reset()
+	}
+	if err := s.flushSocketLocked(); err != nil {
+		return err
+	}
+	if hadOutput {
+		s.committed = true
+	}
+	return nil
+}
+
+// Discard drops only buffered semantic data. A keep-alive may already have
+// committed HTTP 200; that transport state intentionally remains unchanged.
+func (s *streamSession) Discard() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.promoted {
+		return
+	}
+	s.buf.Reset()
+	s.statusCode = 0
+}
+
+// IsPromoted reports whether semantic events are writing directly downstream.
+func (s *streamSession) IsPromoted() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.promoted
+}
+
+// Committed reports whether bytes have reached the downstream response.
+func (s *streamSession) Committed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.committed
+}
+
+// Err returns the first downstream write or flush error.
+func (s *streamSession) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.firstErr
+}
+
+func (s *streamSession) writeSocketLocked(p []byte) (int, error) {
+	n, err := s.w.Write(p)
+	if n > 0 {
+		s.committed = true
+	}
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		s.storeErrorLocked(err)
+		return n, s.firstErr
+	}
+	s.pendingFlush = true
+	return n, nil
+}
+
+func (s *streamSession) flushSocketLocked() error {
+	if s.firstErr != nil {
+		return s.firstErr
+	}
+	if err := s.rc.Flush(); err != nil {
+		s.storeErrorLocked(err)
+		return s.firstErr
+	}
+	if s.pendingFlush {
+		s.pendingFlush = false
+		s.lastActivity = time.Now()
+		select {
+		case s.activity <- struct{}{}:
+		default:
+		}
+	}
+	return nil
 }

--- a/internal/app/messages/gate_writer.go
+++ b/internal/app/messages/gate_writer.go
@@ -134,6 +134,7 @@ func (s *streamSession) Err() error {
 }
 
 func (s *streamSession) writeSocketLocked(p []byte) (int, error) {
+	s.armWriteDeadlineLocked()
 	n, err := s.w.Write(p)
 	if n > 0 {
 		s.committed = true
@@ -153,6 +154,7 @@ func (s *streamSession) flushSocketLocked() error {
 	if s.firstErr != nil {
 		return s.firstErr
 	}
+	s.armWriteDeadlineLocked()
 	if err := s.rc.Flush(); err != nil {
 		s.storeErrorLocked(err)
 		return s.firstErr
@@ -166,4 +168,12 @@ func (s *streamSession) flushSocketLocked() error {
 		}
 	}
 	return nil
+}
+
+// armWriteDeadlineLocked bounds the next socket write/flush so a client that
+// stops reading cannot block the session mutex (and Stop) indefinitely.
+// Unsupported transports (http.ErrNotSupported) are ignored: recorder-style
+// writers in tests and exotic wrappers simply keep the unbounded behavior.
+func (s *streamSession) armWriteDeadlineLocked() {
+	_ = s.rc.SetWriteDeadline(time.Now().Add(socketWriteTimeout))
 }

--- a/internal/app/messages/gate_writer_test.go
+++ b/internal/app/messages/gate_writer_test.go
@@ -1,84 +1,125 @@
 package messages
 
 import (
+	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
-func TestGateWriter_Promote(t *testing.T) {
+func TestStreamSession_Promote(t *testing.T) {
 	w := httptest.NewRecorder()
-	gw := NewGateWriter(w)
+	session := newStreamSession(context.Background(), w, 0)
 
-	// Write before promote — should buffer.
-	_, _ = gw.Write([]byte("buffered"))
+	if _, err := session.Write([]byte("buffered")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
 	if w.Body.Len() != 0 {
 		t.Fatalf("expected no data written before promote, got %d bytes", w.Body.Len())
 	}
-	if gw.IsPromoted() {
+	if session.IsPromoted() {
 		t.Fatal("should not be promoted yet")
 	}
 
-	// Promote — should flush buffer.
-	gw.Promote()
-	if !gw.IsPromoted() {
+	if err := session.Promote(); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if !session.IsPromoted() {
 		t.Fatal("should be promoted after Promote()")
+	}
+	if !session.Committed() {
+		t.Fatal("promoted bytes should commit the response")
 	}
 	if w.Body.String() != "buffered" {
 		t.Fatalf("expected 'buffered', got %q", w.Body.String())
 	}
 
-	// Write after promote — should go directly.
-	_, _ = gw.Write([]byte(" direct"))
+	if _, err := session.Write([]byte(" direct")); err != nil {
+		t.Fatalf("direct Write: %v", err)
+	}
 	if w.Body.String() != "buffered direct" {
 		t.Fatalf("expected 'buffered direct', got %q", w.Body.String())
 	}
 }
 
-func TestGateWriter_Discard(t *testing.T) {
+func TestStreamSession_DiscardOnlyClearsSemanticBuffer(t *testing.T) {
 	w := httptest.NewRecorder()
-	gw := NewGateWriter(w)
+	session := newStreamSession(context.Background(), w, 0)
 
-	_, _ = gw.Write([]byte("to be discarded"))
-	gw.Discard()
+	if _, err := session.Write([]byte("to be discarded")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	session.Discard()
 
 	if w.Body.Len() != 0 {
 		t.Fatalf("expected no data after discard, got %d bytes", w.Body.Len())
 	}
-	if gw.IsPromoted() {
+	if session.IsPromoted() {
 		t.Fatal("should not be promoted after discard")
+	}
+
+	if err := session.WriteKeepAlive(); err != nil {
+		t.Fatalf("WriteKeepAlive: %v", err)
+	}
+	if !session.Committed() || session.IsPromoted() {
+		t.Fatalf("state after keep-alive = committed %v, promoted %v; want true, false", session.Committed(), session.IsPromoted())
+	}
+	if _, err := session.Write([]byte("second attempt")); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+	session.Discard()
+	if got := w.Body.String(); got != keepAliveComment {
+		t.Fatalf("Discard removed transport bytes: got %q, want %q", got, keepAliveComment)
 	}
 }
 
-func TestGateWriter_DoublePromote(t *testing.T) {
+func TestStreamSession_DoublePromote(t *testing.T) {
 	w := httptest.NewRecorder()
-	gw := NewGateWriter(w)
+	session := newStreamSession(context.Background(), w, 0)
 
-	_, _ = gw.Write([]byte("data"))
-	gw.Promote()
-	gw.Promote() // second promote should be no-op
+	_, _ = session.Write([]byte("data"))
+	if err := session.Promote(); err != nil {
+		t.Fatalf("first Promote: %v", err)
+	}
+	if err := session.Promote(); err != nil {
+		t.Fatalf("second Promote: %v", err)
+	}
 
 	if w.Body.String() != "data" {
 		t.Fatalf("expected 'data', got %q", w.Body.String())
 	}
 }
 
-func TestGateWriter_FlushBeforePromote(t *testing.T) {
+func TestStreamSession_FlushBeforePromote(t *testing.T) {
 	w := httptest.NewRecorder()
-	gw := NewGateWriter(w)
+	session := newStreamSession(context.Background(), w, 0)
 
-	// Flush before promote should be no-op (not panic).
-	gw.Flush()
+	session.Flush()
 	if w.Body.Len() != 0 {
 		t.Fatal("flush before promote should not write anything")
 	}
 }
 
-func TestGateWriter_Header(t *testing.T) {
+func TestStreamSession_Header(t *testing.T) {
 	w := httptest.NewRecorder()
-	gw := NewGateWriter(w)
+	session := newStreamSession(context.Background(), w, 0)
 
-	gw.Header().Set("Content-Type", "text/event-stream")
+	session.Header().Set("Content-Type", "text/event-stream")
 	if w.Header().Get("Content-Type") != "text/event-stream" {
 		t.Fatal("header should be set on underlying writer")
+	}
+}
+
+func TestStreamSession_DeferredStatusIsWrittenOnPromote(t *testing.T) {
+	w := httptest.NewRecorder()
+	session := newStreamSession(context.Background(), w, 0)
+	session.WriteHeader(http.StatusAccepted)
+	_, _ = session.Write([]byte("semantic"))
+
+	if err := session.Promote(); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
 	}
 }

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -132,13 +132,27 @@ func (s *Service) runToolSearch(ctx context.Context, w http.ResponseWriter, req 
 		contextWindowSize: contextWindowSize,
 		responseModel:     responseModel,
 	}
-	reason := orch.run(ctx, w)
+	if req.Stream {
+		session := newStreamSession(ctx, w, s.keepAliveInterval)
+		defer session.Stop()
+		s.runToolSearchWithRetry(session.Context(), session, session, orch, short)
+		return
+	}
+	s.runToolSearchWithRetry(ctx, w, nil, orch, short)
+}
+
+func (s *Service) runToolSearchWithRetry(ctx context.Context, w http.ResponseWriter, session *streamSession, orch *toolSearchOrchestrator, short string) {
+	reason := orch.run(ctx, w, session)
 	if reason != retryReasonEmptyVisibleEndTurn {
 		return
 	}
 	slog.WarnContext(ctx, "retrying tool search after empty visible end_turn", "trace_id", short)
-	if r2 := orch.run(ctx, w); r2 == retryReasonEmptyVisibleEndTurn {
+	if r2 := orch.run(ctx, w, session); r2 == retryReasonEmptyVisibleEndTurn {
 		slog.ErrorContext(ctx, "tool search retry also returned empty visible end_turn", "trace_id", short)
-		httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream returned empty response")
+		if session != nil {
+			_ = session.WriteFinalError(newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream returned empty response"), nil)
+		} else {
+			httpx.WriteError(w, http.StatusBadGateway, errTypeAPI, "upstream returned empty response")
+		}
 	}
 }

--- a/internal/app/messages/response.go
+++ b/internal/app/messages/response.go
@@ -28,30 +28,34 @@ func roundCredits(c float64) float64 {
 
 const retryReasonEmptyVisibleEndTurn = "empty_visible_end_turn"
 
-func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWriter, apiResp *kiroclient.Response, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture, toolNameMap map[string]string) string {
+func (s *Service) handleStreamingResponse(ctx context.Context, session *streamSession, apiResp *kiroclient.Response, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture, toolNameMap map[string]string) string {
 	traceID, short := logging.TraceIDs(ctx)
 
-	gw := NewGateWriter(w)
-	sw := respconv.NewSSEWriter(ctx, gw, model, contextWindowSize, stopSequences, maxTokens, preCountedInputTokens)
-	sw.OnVisibleOutput = func() { gw.Promote() }
+	sw := respconv.NewSSEWriter(ctx, session, model, contextWindowSize, stopSequences, maxTokens, preCountedInputTokens)
+	sw.OnVisibleOutput = session.Promote
 	sw.SetToolNameMap(toolNameMap)
+	// The kiro client has already confirmed HTTP 200 + event-stream at this
+	// point, and NewSSEWriter has installed downstream SSE headers.
+	session.Start()
 
 	var streamErr bool
 	var localStop bool
 	var invalidReason string
 	var isException bool
+	var upstreamMessage string
 	err := kiroproto.ParseStream(ctx, apiResp.Body, func(e kiroproto.Event) bool {
 		capture.recordEvent(e)
 		if streamErr || localStop {
 			return true
 		}
 		// Stop early if the client disconnected (write failed).
-		if sw.WriteErr() {
+		if sw.WriteErr() != nil || session.Err() != nil {
 			streamErr = true
 			return true
 		}
 		if e.Type == kiroproto.EventInvalidState {
 			invalidReason = e.InvalidStateReason
+			upstreamMessage = e.ErrorText()
 			slog.ErrorContext(ctx, "invalid state",
 				"trace_id", short,
 				"reason", e.InvalidStateReason,
@@ -60,6 +64,7 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 		}
 		if e.Type == kiroproto.EventException {
 			isException = true
+			upstreamMessage = e.ErrorText()
 			slog.ErrorContext(ctx, "upstream exception",
 				"trace_id", short,
 				"reason", e.InvalidStateReason,
@@ -67,7 +72,7 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 			)
 		}
 		shouldStop := sw.HandleEvent(e)
-		if sw.WriteErr() {
+		if sw.WriteErr() != nil || session.Err() != nil {
 			streamErr = true
 			return true
 		}
@@ -85,31 +90,44 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 		return true
 	})
 
-	if streamErr && !sw.Started() {
-		return handleUpstreamError(w, isException, invalidReason)
+	if sw.WriteErr() != nil || session.Err() != nil || ctx.Err() != nil {
+		return ""
 	}
 
-	// If the stream started (thinking events) but GateWriter was never promoted
-	// (no visible output reached the client), we can still discard and write error JSON.
-	if streamErr && sw.Started() && !gw.IsPromoted() {
-		gw.Discard()
-		return handleUpstreamError(w, isException, invalidReason)
+	if streamErr {
+		classification := classifyUpstreamError(isException, invalidReason, upstreamMessage)
+		if classification.retryReason != "" && !session.IsPromoted() {
+			session.Discard()
+			return classification.retryReason
+		}
+		_ = session.WriteFinalError(classification.final, func() error {
+			return sw.WriteError(classification.final.sseType, classification.final.sseMessage)
+		})
+		return ""
 	}
 
 	if err != nil {
 		slog.ErrorContext(ctx, "stream error", "trace_id", short, "err", err)
-		writeStreamingOrJSONError(gw, sw, w, http.StatusBadGateway, errTypeStreamError, "upstream stream error")
+		if ctx.Err() == nil && session.Err() == nil {
+			final := newStreamFinalError(http.StatusBadGateway, errTypeStreamError, "upstream stream error")
+			_ = session.WriteFinalError(final, func() error {
+				return sw.WriteError(errTypeStreamError, "upstream stream error")
+			})
+		}
 		return ""
 	}
 
 	if !streamErr && !localStop {
-		sw.Finish()
+		if err := sw.Finish(); err != nil {
+			return ""
+		}
 	}
 
 	// Detect empty visible end_turn (thinking-only response with no visible text).
-	// If the GateWriter hasn't been promoted yet, we can safely discard and retry.
-	if !streamErr && !localStop && sw.IsEmptyVisibleEndTurn() && !gw.IsPromoted() {
-		gw.Discard()
+	// Keep retry eligibility on semantic promotion, not HTTP commitment: a
+	// previously sent keep-alive is harmless to the second attempt.
+	if !streamErr && !localStop && sw.IsEmptyVisibleEndTurn() && !session.IsPromoted() {
+		session.Discard()
 		args := []any{
 			"trace_id", short,
 			"thinking_chars", sw.ThinkingLen(),
@@ -123,13 +141,18 @@ func (s *Service) handleStreamingResponse(ctx context.Context, w http.ResponseWr
 		}
 		return retryReasonEmptyVisibleEndTurn
 	}
+	if !session.IsPromoted() {
+		if err := session.Promote(); err != nil {
+			return ""
+		}
+	}
 
 	// Log response completion (only on success).
 	if !streamErr {
 		slog.DebugContext(ctx, "client response headers",
 			"trace_id", traceID,
 			"session_id", logging.SessionIDFromContext(ctx),
-			"headers", logging.SafeHeaders{H: gw.Header()},
+			"headers", logging.SafeHeaders{H: session.Header()},
 		)
 		inputTokens, outputTokens := sw.Usage()
 		credits, hasCredits := sw.Credits()
@@ -146,11 +169,13 @@ func (s *Service) handleNonStreamingResponse(ctx context.Context, w http.Respons
 	var invalidReason string
 	var hasError bool
 	var isException bool
+	var upstreamMessage string
 	err := kiroproto.ParseStream(ctx, apiResp.Body, func(e kiroproto.Event) bool {
 		capture.recordEvent(e)
 		d := acc.ProcessEvent(e)
 		if d.IsError {
 			hasError = true
+			upstreamMessage = e.ErrorText()
 			switch e.Type {
 			case kiroproto.EventException:
 				isException = true
@@ -178,7 +203,12 @@ func (s *Service) handleNonStreamingResponse(ctx context.Context, w http.Respons
 	}
 
 	if hasError {
-		return handleUpstreamError(w, isException, invalidReason)
+		classification := classifyUpstreamError(isException, invalidReason, upstreamMessage)
+		if classification.retryReason != "" {
+			return classification.retryReason
+		}
+		httpx.WriteError(w, classification.final.status, classification.final.jsonType, classification.final.jsonMessage)
+		return ""
 	}
 
 	resp, stats := acc.BuildResponse(model)

--- a/internal/app/messages/service.go
+++ b/internal/app/messages/service.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"context"
+	"time"
 
 	"github.com/d-kuro/kirocc/internal/auth"
 	"github.com/d-kuro/kirocc/internal/kiroclient"
@@ -14,9 +15,10 @@ type TokenGetter interface {
 
 // Service owns message execution and token counting flows.
 type Service struct {
-	auth           TokenGetter
-	client         kiroclient.Client
-	captureEnabled bool
+	auth              TokenGetter
+	client            kiroclient.Client
+	captureEnabled    bool
+	keepAliveInterval time.Duration
 }
 
 // Option configures a Service.
@@ -27,6 +29,12 @@ type Option func(*Service)
 // when debug logging is on.
 func WithCapture(enabled bool) Option {
 	return func(s *Service) { s.captureEnabled = enabled }
+}
+
+// WithKeepAliveInterval sets the idle interval for SSE keep-alive comments.
+// A zero duration disables the heartbeat.
+func WithKeepAliveInterval(interval time.Duration) Option {
+	return func(s *Service) { s.keepAliveInterval = interval }
 }
 
 // New constructs a message service.

--- a/internal/app/messages/stream_session.go
+++ b/internal/app/messages/stream_session.go
@@ -1,0 +1,251 @@
+package messages
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const keepAliveComment = ": keep-alive\n\n"
+
+// streamSession owns every downstream write for one streaming /v1/messages
+// request, including transparent retries and tool-search rounds.
+type streamSession struct {
+	w      http.ResponseWriter
+	rc     *http.ResponseController
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	interval  time.Duration
+	activity  chan struct{}
+	stopCh    chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+	wg        sync.WaitGroup
+
+	mu           sync.Mutex
+	buf          bytes.Buffer
+	statusCode   int
+	promoted     bool
+	committed    bool
+	pendingFlush bool
+	firstErr     error
+	lastActivity time.Time
+	stopped      bool
+	headersSet   bool
+	finalizing   bool
+	finalized    bool
+}
+
+func newStreamSession(parent context.Context, w http.ResponseWriter, interval time.Duration) *streamSession {
+	ctx, cancel := context.WithCancel(parent)
+	return &streamSession{
+		w:        w,
+		rc:       http.NewResponseController(w),
+		ctx:      ctx,
+		cancel:   cancel,
+		interval: interval,
+		activity: make(chan struct{}, 1),
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Context returns the derived upstream context. A downstream transport failure
+// cancels it immediately.
+func (s *streamSession) Context() context.Context {
+	return s.ctx
+}
+
+// Start begins idle heartbeat generation. It is idempotent and intentionally
+// does nothing when the interval is zero.
+func (s *streamSession) Start() {
+	s.startOnce.Do(func() {
+		if s.interval <= 0 {
+			return
+		}
+		s.mu.Lock()
+		s.lastActivity = time.Now()
+		stopped := s.stopped
+		s.mu.Unlock()
+		if stopped {
+			return
+		}
+		s.wg.Add(1)
+		go s.runHeartbeat()
+	})
+}
+
+// Stop terminates and joins the heartbeat goroutine. Once it returns, the
+// session cannot write additional downstream bytes.
+func (s *streamSession) Stop() {
+	s.stopOnce.Do(func() {
+		s.mu.Lock()
+		s.stopped = true
+		s.mu.Unlock()
+		close(s.stopCh)
+		s.cancel()
+	})
+	s.wg.Wait()
+}
+
+func (s *streamSession) runHeartbeat() {
+	defer s.wg.Done()
+	for {
+		s.mu.Lock()
+		if s.stopped || s.firstErr != nil || s.finalizing || s.finalized {
+			s.mu.Unlock()
+			return
+		}
+		wait := time.Until(s.lastActivity.Add(s.interval))
+		s.mu.Unlock()
+		if wait < 0 {
+			wait = 0
+		}
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-timer.C:
+			if err := s.WriteKeepAlive(); err != nil {
+				return
+			}
+		case <-s.activity:
+			stopAndDrainTimer(timer)
+		case <-s.stopCh:
+			stopAndDrainTimer(timer)
+			return
+		case <-s.ctx.Done():
+			stopAndDrainTimer(timer)
+			return
+		}
+	}
+}
+
+func stopAndDrainTimer(timer *time.Timer) {
+	if timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+// WriteKeepAlive writes and flushes one bare SSE comment directly to the real
+// socket without promoting or disturbing buffered semantic events.
+func (s *streamSession) WriteKeepAlive() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.finalizing || s.finalized {
+		return context.Canceled
+	}
+	if err := s.unavailableLocked(); err != nil {
+		return err
+	}
+	if _, err := s.writeSocketLocked([]byte(keepAliveComment)); err != nil {
+		return err
+	}
+	return s.flushSocketLocked()
+}
+
+// WriteFinalError applies the committed × promoted decision table. The
+// callback is used only for a promoted semantic stream so SSEWriter can close
+// its active content block before emitting the error event.
+func (s *streamSession) WriteFinalError(final streamFinalError, writePromoted func() error) error {
+	s.mu.Lock()
+	if err := s.unavailableLocked(); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	if s.promoted {
+		if writePromoted != nil {
+			s.finalizing = true
+			s.mu.Unlock()
+			err := writePromoted()
+			s.mu.Lock()
+			s.finalizing = false
+			s.finalized = true
+			s.mu.Unlock()
+			return err
+		}
+		err := s.writeDirectSSEErrorLocked(final.sseType, final.sseMessage)
+		s.finalized = true
+		s.mu.Unlock()
+		return err
+	}
+
+	s.buf.Reset()
+	s.statusCode = 0
+	if s.committed {
+		err := s.writeDirectSSEErrorLocked(final.sseType, final.sseMessage)
+		s.finalized = true
+		s.mu.Unlock()
+		return err
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    final.jsonType,
+			"message": final.jsonMessage,
+		},
+	})
+	if err != nil {
+		s.mu.Unlock()
+		return fmt.Errorf("marshal downstream error: %w", err)
+	}
+	body = append(body, '\n')
+	s.w.Header().Set("Content-Type", "application/json")
+	s.w.WriteHeader(final.status)
+	_, writeErr := s.writeSocketLocked(body)
+	s.finalized = true
+	s.mu.Unlock()
+	return writeErr
+}
+
+func (s *streamSession) writeDirectSSEErrorLocked(errType, message string) error {
+	data, err := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    errType,
+			"message": message,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal downstream SSE error: %w", err)
+	}
+	payload := []byte("event: error\ndata: ")
+	payload = append(payload, data...)
+	payload = append(payload, '\n', '\n')
+	if _, err := s.writeSocketLocked(payload); err != nil {
+		return err
+	}
+	return s.flushSocketLocked()
+}
+
+func (s *streamSession) unavailableLocked() error {
+	if s.firstErr != nil {
+		return s.firstErr
+	}
+	if s.stopped {
+		return context.Canceled
+	}
+	if s.finalized {
+		return context.Canceled
+	}
+	if err := s.ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *streamSession) storeErrorLocked(err error) {
+	if err == nil || s.firstErr != nil {
+		return
+	}
+	s.firstErr = err
+	s.cancel()
+}

--- a/internal/app/messages/stream_session.go
+++ b/internal/app/messages/stream_session.go
@@ -12,6 +12,12 @@ import (
 
 const keepAliveComment = ": keep-alive\n\n"
 
+// socketWriteTimeout bounds each downstream write/flush. Without it a client
+// that stops reading (without closing) would block the session mutex forever,
+// wedging Stop, Promote and WriteFinalError. The server deliberately sets no
+// global WriteTimeout, so this per-write deadline is the only bound.
+const socketWriteTimeout = 30 * time.Second
+
 // streamSession owns every downstream write for one streaming /v1/messages
 // request, including transparent retries and tool-search rounds.
 type streamSession struct {
@@ -67,13 +73,15 @@ func (s *streamSession) Start() {
 		if s.interval <= 0 {
 			return
 		}
+		// The stopped-check and wg.Add must share one critical section:
+		// otherwise Stop can observe wg counter zero, return, and only then
+		// have Start launch a heartbeat that outlives Stop's join guarantee.
 		s.mu.Lock()
-		s.lastActivity = time.Now()
-		stopped := s.stopped
-		s.mu.Unlock()
-		if stopped {
+		defer s.mu.Unlock()
+		if s.stopped {
 			return
 		}
+		s.lastActivity = time.Now()
 		s.wg.Add(1)
 		go s.runHeartbeat()
 	})

--- a/internal/app/messages/stream_session_test.go
+++ b/internal/app/messages/stream_session_test.go
@@ -1,0 +1,324 @@
+package messages
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type sessionResponseWriter struct {
+	mu       sync.Mutex
+	header   http.Header
+	writes   chan string
+	writeErr error
+	flushErr error
+	count    int
+}
+
+func newSessionResponseWriter() *sessionResponseWriter {
+	return &sessionResponseWriter{
+		header: make(http.Header),
+		writes: make(chan string, 256),
+	}
+}
+
+func (w *sessionResponseWriter) Header() http.Header { return w.header }
+
+func (w *sessionResponseWriter) WriteHeader(int) {}
+
+func (w *sessionResponseWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.count++
+	err := w.writeErr
+	w.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	w.writes <- string(append([]byte(nil), p...))
+	return len(p), nil
+}
+
+func (w *sessionResponseWriter) FlushError() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.flushErr
+}
+
+func (w *sessionResponseWriter) setWriteError(err error) {
+	w.mu.Lock()
+	w.writeErr = err
+	w.mu.Unlock()
+}
+
+func (w *sessionResponseWriter) setFlushError(err error) {
+	w.mu.Lock()
+	w.flushErr = err
+	w.mu.Unlock()
+}
+
+func (w *sessionResponseWriter) writeCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.count
+}
+
+func receiveSessionWrite(t *testing.T, writes <-chan string) string {
+	t.Helper()
+	select {
+	case got := <-writes:
+		return got
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for downstream write")
+		return ""
+	}
+}
+
+func TestStreamSession_HeartbeatThenPromotedResponse(t *testing.T) {
+	w := newSessionResponseWriter()
+	session := newStreamSession(t.Context(), w, 10*time.Millisecond)
+	session.Header().Set("Content-Type", "text/event-stream")
+	session.Start()
+	t.Cleanup(session.Stop)
+
+	if got := receiveSessionWrite(t, w.writes); got != keepAliveComment {
+		t.Fatalf("first write = %q, want %q", got, keepAliveComment)
+	}
+	if !session.Committed() || session.IsPromoted() {
+		t.Fatalf("state = committed %v, promoted %v; want true, false", session.Committed(), session.IsPromoted())
+	}
+
+	const semantic = "event: message_start\ndata: {}\n\n"
+	if _, err := session.Write([]byte(semantic)); err != nil {
+		t.Fatalf("Write semantic event: %v", err)
+	}
+	if err := session.Promote(); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if got := receiveSessionWrite(t, w.writes); got != semantic {
+		t.Fatalf("promoted write = %q, want %q", got, semantic)
+	}
+}
+
+func TestStreamSession_FinalErrorAfterKeepAliveIsSSE(t *testing.T) {
+	w := newSessionResponseWriter()
+	session := newStreamSession(t.Context(), w, 0)
+	session.Header().Set("Content-Type", "text/event-stream")
+
+	if err := session.WriteKeepAlive(); err != nil {
+		t.Fatalf("WriteKeepAlive: %v", err)
+	}
+	_ = receiveSessionWrite(t, w.writes)
+
+	if err := session.WriteFinalError(newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream failed"), nil); err != nil {
+		t.Fatalf("WriteFinalError: %v", err)
+	}
+	got := receiveSessionWrite(t, w.writes)
+	if !strings.HasPrefix(got, "event: error\n") || !strings.Contains(got, `"type":"api_error"`) {
+		t.Fatalf("final error is not SSE: %q", got)
+	}
+	if strings.HasPrefix(got, `{"type":"error"`) {
+		t.Fatalf("JSON error was injected into committed SSE: %q", got)
+	}
+}
+
+func TestStreamSession_FinalErrorBeforeCommitIsJSON(t *testing.T) {
+	w := newSessionResponseWriter()
+	session := newStreamSession(t.Context(), w, 0)
+
+	if err := session.WriteFinalError(newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream failed"), nil); err != nil {
+		t.Fatalf("WriteFinalError: %v", err)
+	}
+	got := receiveSessionWrite(t, w.writes)
+	if !strings.HasPrefix(got, "{") || !strings.Contains(got, `"type":"error"`) || !strings.Contains(got, `"type":"api_error"`) {
+		t.Fatalf("final error is not JSON: %q", got)
+	}
+	if contentType := w.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", contentType)
+	}
+}
+
+func TestStreamSession_HeartbeatDisabled(t *testing.T) {
+	w := newSessionResponseWriter()
+	session := newStreamSession(t.Context(), w, 0)
+	session.Start()
+	t.Cleanup(session.Stop)
+
+	select {
+	case got := <-w.writes:
+		t.Fatalf("disabled heartbeat wrote %q", got)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if session.Committed() {
+		t.Fatal("disabled heartbeat committed the response")
+	}
+}
+
+func TestStreamSession_KeepAliveFailureCancelsUpstreamAndSuppressesFinalError(t *testing.T) {
+	disconnectErr := errors.New("client disconnected")
+	w := newSessionResponseWriter()
+	w.setWriteError(disconnectErr)
+	session := newStreamSession(t.Context(), w, time.Millisecond)
+	session.Start()
+	t.Cleanup(session.Stop)
+
+	select {
+	case <-session.Context().Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("upstream context was not canceled after keep-alive failure")
+	}
+	if !errors.Is(session.Err(), disconnectErr) {
+		t.Fatalf("Err() = %v, want %v", session.Err(), disconnectErr)
+	}
+	writesBefore := w.writeCount()
+	if err := session.WriteFinalError(newStreamFinalError(http.StatusBadGateway, errTypeAPI, "must not be written"), nil); !errors.Is(err, disconnectErr) {
+		t.Fatalf("WriteFinalError err = %v, want %v", err, disconnectErr)
+	}
+	if got := w.writeCount(); got != writesBefore {
+		t.Fatalf("writes after disconnect = %d, want %d", got, writesBefore)
+	}
+}
+
+func TestStreamSession_StoresFirstFlushError(t *testing.T) {
+	firstErr := errors.New("flush failed")
+	secondErr := errors.New("write failed")
+	w := newSessionResponseWriter()
+	w.setFlushError(firstErr)
+	session := newStreamSession(t.Context(), w, 0)
+
+	if err := session.WriteKeepAlive(); !errors.Is(err, firstErr) {
+		t.Fatalf("WriteKeepAlive err = %v, want %v", err, firstErr)
+	}
+	w.setWriteError(secondErr)
+	if err := session.WriteKeepAlive(); !errors.Is(err, firstErr) {
+		t.Fatalf("second WriteKeepAlive err = %v, want first error %v", err, firstErr)
+	}
+	if !errors.Is(session.Err(), firstErr) {
+		t.Fatalf("Err() = %v, want first error %v", session.Err(), firstErr)
+	}
+	select {
+	case <-session.Context().Done():
+	default:
+		t.Fatal("flush failure did not cancel upstream context")
+	}
+}
+
+func TestStreamSession_PromoteReturnsFlushError(t *testing.T) {
+	wantErr := errors.New("promote flush failed")
+	w := newSessionResponseWriter()
+	w.setFlushError(wantErr)
+	session := newStreamSession(t.Context(), w, 0)
+	if _, err := session.Write([]byte("semantic")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := session.Promote(); !errors.Is(err, wantErr) {
+		t.Fatalf("Promote() err = %v, want %v", err, wantErr)
+	}
+	if !errors.Is(session.Err(), wantErr) {
+		t.Fatalf("Err() = %v, want %v", session.Err(), wantErr)
+	}
+}
+
+func TestStreamSession_StopJoinsHeartbeat(t *testing.T) {
+	w := newSessionResponseWriter()
+	session := newStreamSession(context.Background(), w, time.Millisecond)
+	session.Start()
+	_ = receiveSessionWrite(t, w.writes)
+
+	session.Stop()
+	writesAfterStop := w.writeCount()
+	select {
+	case got := <-w.writes:
+		t.Fatalf("heartbeat wrote %q after Stop returned", got)
+	case <-time.After(5 * time.Millisecond):
+	}
+	if got := w.writeCount(); got != writesAfterStop {
+		t.Fatalf("write count after Stop = %d, want %d", got, writesAfterStop)
+	}
+}
+
+func TestStreamSession_HeartbeatAndPromoteAreRaceSafe(t *testing.T) {
+	for range 100 {
+		w := newSessionResponseWriter()
+		session := newStreamSession(context.Background(), w, 0)
+		if _, err := session.Write([]byte("semantic")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = session.WriteKeepAlive()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = session.Promote()
+		}()
+		close(start)
+		wg.Wait()
+
+		if err := session.Err(); err != nil {
+			t.Fatalf("session Err: %v", err)
+		}
+		if !session.Committed() || !session.IsPromoted() {
+			t.Fatalf("state = committed %v, promoted %v; want true, true", session.Committed(), session.IsPromoted())
+		}
+	}
+}
+
+func TestStreamSession_HeartbeatAndFinalErrorCannotMixJSONAndSSE(t *testing.T) {
+	for range 100 {
+		w := newSessionResponseWriter()
+		session := newStreamSession(context.Background(), w, 0)
+		session.SetSSEHeaders()
+		final := newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream failed")
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = session.WriteKeepAlive()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = session.WriteFinalError(final, nil)
+		}()
+		close(start)
+		wg.Wait()
+
+		var body strings.Builder
+		for {
+			select {
+			case chunk := <-w.writes:
+				body.WriteString(chunk)
+			default:
+				goto drained
+			}
+		}
+	drained:
+		got := body.String()
+		switch {
+		case strings.HasPrefix(got, "{"):
+			if strings.Contains(got, keepAliveComment) || strings.Contains(got, "event: error") {
+				t.Fatalf("heartbeat/SSE appended to JSON final error: %q", got)
+			}
+		case strings.HasPrefix(got, keepAliveComment):
+			if !strings.Contains(got, "event: error") || strings.Contains(got, "\n{\"type\":\"error\"") {
+				t.Fatalf("committed SSE contains invalid final error: %q", got)
+			}
+		default:
+			t.Fatalf("unexpected downstream output: %q", got)
+		}
+	}
+}

--- a/internal/app/messages/stream_session_test.go
+++ b/internal/app/messages/stream_session_test.go
@@ -11,12 +11,13 @@ import (
 )
 
 type sessionResponseWriter struct {
-	mu       sync.Mutex
-	header   http.Header
-	writes   chan string
-	writeErr error
-	flushErr error
-	count    int
+	mu        sync.Mutex
+	header    http.Header
+	writes    chan string
+	writeErr  error
+	flushErr  error
+	count     int
+	deadlines int
 }
 
 func newSessionResponseWriter() *sessionResponseWriter {
@@ -46,6 +47,19 @@ func (w *sessionResponseWriter) FlushError() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.flushErr
+}
+
+func (w *sessionResponseWriter) SetWriteDeadline(time.Time) error {
+	w.mu.Lock()
+	w.deadlines++
+	w.mu.Unlock()
+	return nil
+}
+
+func (w *sessionResponseWriter) deadlineCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.deadlines
 }
 
 func (w *sessionResponseWriter) setWriteError(err error) {
@@ -238,6 +252,67 @@ func TestStreamSession_StopJoinsHeartbeat(t *testing.T) {
 	}
 	if got := w.writeCount(); got != writesAfterStop {
 		t.Fatalf("write count after Stop = %d, want %d", got, writesAfterStop)
+	}
+}
+
+func TestStreamSession_ConcurrentStartStopNeverLeaksHeartbeat(t *testing.T) {
+	// Start's stopped-check and wg.Add must be one atomic section: if Stop
+	// wins the race, Start must not launch a heartbeat that outlives Stop.
+	for range 200 {
+		w := newSessionResponseWriter()
+		session := newStreamSession(context.Background(), w, time.Millisecond)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			session.Start()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			session.Stop()
+		}()
+		close(start)
+		wg.Wait()
+
+		// Stop has returned (possibly before Start). A second Stop must also
+		// join any goroutine Start may have launched.
+		session.Stop()
+		writesAfterStop := w.writeCount()
+		time.Sleep(3 * time.Millisecond)
+		if got := w.writeCount(); got != writesAfterStop {
+			t.Fatalf("heartbeat wrote after Stop returned: %d -> %d", writesAfterStop, got)
+		}
+	}
+}
+
+func TestStreamSession_SocketWritesSetWriteDeadline(t *testing.T) {
+	// Every socket write/flush must be preceded by a write deadline so a
+	// stalled client cannot block the session mutex (and thus Stop) forever.
+	w := newSessionResponseWriter()
+	session := newStreamSession(t.Context(), w, 0)
+
+	if err := session.WriteKeepAlive(); err != nil {
+		t.Fatalf("WriteKeepAlive: %v", err)
+	}
+	_ = receiveSessionWrite(t, w.writes)
+	if got := w.deadlineCount(); got == 0 {
+		t.Fatal("WriteKeepAlive did not set a write deadline before writing")
+	}
+
+	before := w.deadlineCount()
+	if _, err := session.Write([]byte("semantic")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := session.Promote(); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	_ = receiveSessionWrite(t, w.writes)
+	if got := w.deadlineCount(); got <= before {
+		t.Fatal("Promote did not set a write deadline before flushing buffered output")
 	}
 }
 

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -70,19 +70,18 @@ type toolSearchOrchestrator struct {
 // run dispatches to the streaming or non-streaming implementation based on
 // req.Stream. Returns retryReasonEmptyVisibleEndTurn when the upstream
 // produced thinking-only output and the call site should retry.
-func (o *toolSearchOrchestrator) run(ctx context.Context, w http.ResponseWriter) string {
+func (o *toolSearchOrchestrator) run(ctx context.Context, w http.ResponseWriter, session *streamSession) string {
 	if o.req.Stream {
-		return o.handleStreaming(ctx, w)
+		return o.handleStreaming(ctx, session)
 	}
 	return o.handleNonStreaming(ctx, w)
 }
 
-func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.ResponseWriter) string {
+func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, session *streamSession) string {
 	_, short := logging.TraceIDs(ctx)
 
-	gw := NewGateWriter(w)
-	sw := respconv.NewSSEWriter(ctx, gw, o.responseModel, o.contextWindowSize, o.req.StopSequences, o.req.MaxTokens, 0)
-	sw.OnVisibleOutput = func() { gw.Promote() }
+	sw := respconv.NewSSEWriter(ctx, session, o.responseModel, o.contextWindowSize, o.req.StopSequences, o.req.MaxTokens, 0)
+	sw.OnVisibleOutput = session.Promote
 
 	msgs := slices.Clone(o.req.Messages)
 
@@ -92,7 +91,10 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		payload, nameMap, err := o.buildPayload(msgs)
 		if err != nil {
 			slog.WarnContext(ctx, "tool search payload build error", "trace_id", short, "err", err)
-			writeStreamingOrJSONError(gw, sw, w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
+			final := newStreamFinalError(http.StatusBadRequest, errTypeInvalidRequest, err.Error())
+			_ = session.WriteFinalError(final, func() error {
+				return sw.WriteError(errTypeInvalidRequest, err.Error())
+			})
 			return ""
 		}
 		sw.SetToolNameMap(nameMap.ReverseMap())
@@ -100,9 +102,13 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		apiResp, err := o.service.client.GenerateAssistantResponse(ctx, o.creds.AccessToken, payload, o.creds.Region)
 		if err != nil {
 			logUpstreamError(ctx, short, err, "round", round+1)
-			writeStreamingOrJSONError(gw, sw, w, http.StatusBadGateway, errTypeAPI, "upstream API error")
+			final := newStreamFinalError(http.StatusBadGateway, errTypeAPI, "upstream API error")
+			_ = session.WriteFinalError(final, func() error {
+				return sw.WriteError(errTypeAPI, "upstream API error")
+			})
 			return ""
 		}
+		session.Start()
 
 		if round > 0 {
 			// Accumulate usage from previous round before resetting.
@@ -116,6 +122,9 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		var foundToolSearch bool
 		var toolSearchInput string
 		var streamErr, localStop bool
+		var invalidReason string
+		var isException bool
+		var upstreamMessage string
 
 		err = kiroproto.ParseStream(ctx, apiResp.Body, func(e kiroproto.Event) bool {
 			if streamErr || localStop {
@@ -126,13 +135,16 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 			// Upstream errors in the tail must still abort the round.
 			if foundToolSearch {
 				if e.Type == kiroproto.EventException || e.Type == kiroproto.EventInvalidState {
+					isException = e.Type == kiroproto.EventException
+					invalidReason = e.InvalidStateReason
+					upstreamMessage = e.ErrorText()
 					streamErr = true
 					return true
 				}
 				sw.RecordTail(e)
 				return false
 			}
-			if sw.WriteErr() {
+			if sw.WriteErr() != nil || session.Err() != nil {
 				streamErr = true
 				return true
 			}
@@ -141,8 +153,13 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 				toolSearchInput = e.ToolInput
 				return false
 			}
+			if e.Type == kiroproto.EventException || e.Type == kiroproto.EventInvalidState {
+				isException = e.Type == kiroproto.EventException
+				invalidReason = e.InvalidStateReason
+				upstreamMessage = e.ErrorText()
+			}
 			shouldStop := sw.HandleEvent(e)
-			if sw.WriteErr() {
+			if sw.WriteErr() != nil || session.Err() != nil {
 				streamErr = true
 				return true
 			}
@@ -158,35 +175,48 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		})
 		_ = apiResp.Body.Close()
 
+		if sw.WriteErr() != nil || session.Err() != nil || ctx.Err() != nil {
+			return ""
+		}
+
 		// A parse error or upstream error frame in the tail must abort the
 		// orchestrator even when the tool-search frame was already observed.
-		if err != nil || streamErr {
-			if err != nil {
-				slog.ErrorContext(ctx, "stream error", "trace_id", short, "round", round+1, "err", err)
-			}
-			// If the stream is already promoted, sw.HandleEvent has already
-			// emitted an SSE error event for invalidStateEvent/exception;
-			// emitting another would produce duplicate/conflicting frames.
-			if sw.Started() && gw.IsPromoted() {
-				return ""
-			}
-			writeStreamingOrJSONError(gw, sw, w, http.StatusBadGateway, errTypeAPI, "upstream stream error")
+		if streamErr {
+			classification := classifyUpstreamError(isException, invalidReason, upstreamMessage)
+			_ = session.WriteFinalError(classification.final, func() error {
+				return sw.WriteError(classification.final.sseType, classification.final.sseMessage)
+			})
+			return ""
+		}
+		if err != nil {
+			slog.ErrorContext(ctx, "stream error", "trace_id", short, "round", round+1, "err", err)
+			final := newStreamFinalError(http.StatusBadGateway, errTypeStreamError, "upstream stream error")
+			_ = session.WriteFinalError(final, func() error {
+				return sw.WriteError(errTypeStreamError, "upstream stream error")
+			})
 			return ""
 		}
 
 		if !foundToolSearch {
 			// streamErr was already handled above; only success/localStop reach here.
 			if !localStop {
-				sw.Finish()
+				if err := sw.Finish(); err != nil {
+					return ""
+				}
 			}
 			// Detect empty visible end_turn (thinking-only response) and signal retry.
-			if !localStop && sw.IsEmptyVisibleEndTurn() && !gw.IsPromoted() {
-				gw.Discard()
+			if !localStop && sw.IsEmptyVisibleEndTurn() && !session.IsPromoted() {
+				session.Discard()
 				slog.WarnContext(ctx, "empty visible end_turn detected in tool search", "trace_id", short)
 				if credits, ok := totals.creditsWith(sw.Credits()); ok {
 					logAbortedAttemptCredits(ctx, short, credits, retryReasonEmptyVisibleEndTurn)
 				}
 				return retryReasonEmptyVisibleEndTurn
+			}
+			if !session.IsPromoted() {
+				if err := session.Promote(); err != nil {
+					return ""
+				}
 			}
 			in, out := sw.Usage()
 			credits, hasCredits := sw.Credits()
@@ -199,7 +229,10 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		query, maxResults, parseErr := parseToolSearchInput(toolSearchInput)
 		if parseErr != nil {
 			slog.WarnContext(ctx, "tool search input parse error", "trace_id", short, "err", parseErr)
-			writeStreamingOrJSONError(gw, sw, w, http.StatusBadRequest, errTypeInvalidRequest, parseErr.Error())
+			final := newStreamFinalError(http.StatusBadRequest, errTypeInvalidRequest, parseErr.Error())
+			_ = session.WriteFinalError(final, func() error {
+				return sw.WriteError(errTypeInvalidRequest, parseErr.Error())
+			})
 			return ""
 		}
 		srvToolUseID := "srvtoolu_" + uuid.New().String()[:24]
@@ -214,13 +247,23 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, w http.Res
 		} else {
 			sw.WriteToolSearchResult(srvToolUseID, results)
 		}
+		if sw.WriteErr() != nil || session.Err() != nil {
+			return ""
+		}
 
 		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr, nameMap)
 	}
 
 	// Max rounds reached without normal completion.
 	slog.WarnContext(ctx, "tool search max rounds reached", "trace_id", short, "max_rounds", maxToolSearchRounds)
-	sw.Finish()
+	if err := sw.Finish(); err != nil {
+		return ""
+	}
+	if !session.IsPromoted() {
+		if err := session.Promote(); err != nil {
+			return ""
+		}
+	}
 	in, out := sw.Usage()
 	credits, hasCredits := sw.Credits()
 	totalIn, totalOut, totalCredits, totalHasCredits := totals.withCurrent(in, out, credits, hasCredits)
@@ -437,18 +480,6 @@ func (o *toolSearchOrchestrator) buildPayload(msgs []anthropic.Message) (*kiropr
 	tmpReq := *o.req
 	tmpReq.Messages = msgs
 	return reqconv.BuildPayload(&tmpReq, o.buildOpts)
-}
-
-// writeStreamingOrJSONError writes an error via SSE if the stream is promoted, otherwise via JSON.
-func writeStreamingOrJSONError(gw *GateWriter, sw *respconv.SSEWriter, w http.ResponseWriter, status int, errType, message string) {
-	if sw.Started() && gw.IsPromoted() {
-		sw.WriteError(errType, message)
-		return
-	}
-	if !gw.IsPromoted() {
-		gw.Discard()
-	}
-	httpx.WriteError(w, status, errType, message)
 }
 
 // parseToolSearchInput extracts query and max_results from the ToolSearch tool input JSON.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,23 +6,29 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/d-kuro/kirocc/internal/logging"
 )
 
-// DefaultOTelBodyLimit is the default max bytes of request body to capture in OTel spans.
-const DefaultOTelBodyLimit = 32 * 1024
+const (
+	// DefaultOTelBodyLimit is the default max bytes of request body to capture in OTel spans.
+	DefaultOTelBodyLimit = 32 * 1024
+	// DefaultKeepAliveInterval is the default idle time between SSE keep-alive comments.
+	DefaultKeepAliveInterval = 15 * time.Second
+)
 
 // Config is the runtime configuration for kirocc.
 type Config struct {
-	Port          int
-	Host          string
-	DBPath        string
-	APIKey        string
-	Debug         bool
-	OTel          bool
-	OTelBodyLimit int
-	LogFile       logging.LogFileConfig
+	Port              int
+	Host              string
+	DBPath            string
+	APIKey            string
+	Debug             bool
+	OTel              bool
+	OTelBodyLimit     int
+	KeepAliveInterval time.Duration
+	LogFile           logging.LogFileConfig
 }
 
 // DefaultDBPath returns the default kiro-cli SQLite database location.
@@ -61,6 +67,9 @@ func ApplyEnvOverrides(cfg *Config) error {
 	if err := applyInt("KIROCC_OTEL_BODY_LIMIT", &cfg.OTelBodyLimit); err != nil {
 		return err
 	}
+	if err := applyDuration("KIROCC_KEEPALIVE_INTERVAL", &cfg.KeepAliveInterval); err != nil {
+		return err
+	}
 	applyString("KIROCC_LOG_FILE", &cfg.LogFile.Path)
 	if err := applyInt("KIROCC_LOG_MAX_SIZE", &cfg.LogFile.MaxSize); err != nil {
 		return err
@@ -93,6 +102,9 @@ func (c *Config) Validate() error {
 	if c.OTelBodyLimit < 0 {
 		return fmt.Errorf("otel-body-limit must be >= 0, got %d", c.OTelBodyLimit)
 	}
+	if c.KeepAliveInterval != 0 && c.KeepAliveInterval < time.Second {
+		return fmt.Errorf("keepalive-interval must be 0 or >= 1s, got %s", c.KeepAliveInterval)
+	}
 	return nil
 }
 
@@ -120,6 +132,17 @@ func applyBool(key string, dst *bool) error {
 			return fmt.Errorf("invalid %s=%q: %w", key, v, err)
 		}
 		*dst = b
+	}
+	return nil
+}
+
+func applyDuration(key string, dst *time.Duration) error {
+	if v := os.Getenv(key); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid %s=%q: %w", key, v, err)
+		}
+		*dst = d
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestApplyString(t *testing.T) {
 	tests := []struct {
@@ -86,6 +89,43 @@ func TestApplyBool(t *testing.T) {
 	}
 }
 
+func TestApplyEnvOverrides_KeepAliveInterval(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		want         time.Duration
+		wantApplyErr bool
+		wantValidErr bool
+	}{
+		{name: "duration", value: "15s", want: 15 * time.Second},
+		{name: "disabled", value: "0", want: 0},
+		{name: "negative", value: "-1s", want: -time.Second, wantValidErr: true},
+		{name: "invalid", value: "not-a-duration", wantApplyErr: true},
+		{name: "too small", value: "500ms", want: 500 * time.Millisecond, wantValidErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KIROCC_KEEPALIVE_INTERVAL", tt.value)
+			cfg := Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: DefaultKeepAliveInterval}
+
+			err := ApplyEnvOverrides(&cfg)
+			if (err != nil) != tt.wantApplyErr {
+				t.Fatalf("ApplyEnvOverrides() err = %v, wantApplyErr = %v", err, tt.wantApplyErr)
+			}
+			if tt.wantApplyErr {
+				return
+			}
+			if cfg.KeepAliveInterval != tt.want {
+				t.Fatalf("KeepAliveInterval = %v, want %v", cfg.KeepAliveInterval, tt.want)
+			}
+			if err := cfg.Validate(); (err != nil) != tt.wantValidErr {
+				t.Fatalf("Validate() err = %v, wantValidErr = %v", err, tt.wantValidErr)
+			}
+		})
+	}
+}
+
 func TestDefaultDBPathFor(t *testing.T) {
 	tests := []struct {
 		name string
@@ -160,6 +200,10 @@ func TestConfig_Validate(t *testing.T) {
 		{"port negative", Config{Host: "127.0.0.1", Port: -1}, true},
 		{"port too large", Config{Host: "127.0.0.1", Port: 70000}, true},
 		{"negative otel body limit", Config{Host: "127.0.0.1", Port: 3456, OTelBodyLimit: -1}, true},
+		{"keep-alive disabled", Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: 0}, false},
+		{"keep-alive minimum", Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: time.Second}, false},
+		{"keep-alive negative", Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: -time.Second}, true},
+		{"keep-alive too small", Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: 500 * time.Millisecond}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/respconv/streaming.go
+++ b/internal/respconv/streaming.go
@@ -22,21 +22,25 @@ type SSEWriter struct {
 	blockIndex int
 	activeType string // "thinking", "text", "tool_use", or ""
 	started    bool
-	writeErr   bool // true if a write/flush to the client failed
+	writeErr   error
 	acc        responseAccumulator
 
 	// OnVisibleOutput is called once, just before the first visible output
-	// (text delta or tool_use) is written. Used by GateWriter to promote
+	// (text delta or tool_use) is written. Used by the stream session to promote
 	// the buffered writer to direct mode.
-	OnVisibleOutput func()
+	OnVisibleOutput func() error
 	visibleFired    bool
 }
 
 // NewSSEWriter creates a new SSEWriter and sets response headers.
 func NewSSEWriter(ctx context.Context, w http.ResponseWriter, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int) *SSEWriter {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
+	if setter, ok := w.(interface{ SetSSEHeaders() }); ok {
+		setter.SetSSEHeaders()
+	} else {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+	}
 
 	f, _ := w.(http.Flusher)
 	sw := &SSEWriter{
@@ -61,8 +65,8 @@ func (s *SSEWriter) LocalStop() bool {
 	return s.acc.LocalStop
 }
 
-// WriteErr reports whether a write to the client failed (client likely disconnected).
-func (s *SSEWriter) WriteErr() bool {
+// WriteErr returns the first downstream write, promotion, or flush error.
+func (s *SSEWriter) WriteErr() error {
 	return s.writeErr
 }
 
@@ -85,7 +89,7 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 			s.writeDelta("text_delta", "text", d.TextDelta)
 		}
 		if d.StopSignal {
-			s.Finish()
+			_ = s.Finish()
 			return true
 		}
 
@@ -111,7 +115,7 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 		}
 		s.writeThinkingDelta(d)
 		if d.StopSignal {
-			s.Finish()
+			_ = s.Finish()
 			return true
 		}
 
@@ -119,7 +123,7 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 		if d.ThinkingDelta != "" {
 			s.writeThinkingDelta(d)
 			if d.StopSignal {
-				s.Finish()
+				_ = s.Finish()
 				return true
 			}
 			return false
@@ -151,35 +155,31 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 			},
 		})
 		if d.StopSignal {
-			s.Finish()
+			_ = s.Finish()
 			return true
 		}
 
 	case kiroproto.EventInvalidState, kiroproto.EventException:
-		if !s.started {
-			return true
-		}
-		errType := "invalid_state"
-		if e.Type == kiroproto.EventException {
-			errType = "api_error"
-		}
-		s.WriteError(errType, d.ErrorMessage)
+		// Error classification and JSON-vs-SSE output belong to the request-scoped
+		// stream session, which knows whether HTTP is committed and whether
+		// semantic output has been promoted.
 		return true
 	}
 	return false
 }
 
 // WriteError writes an error SSE event to the stream.
-func (s *SSEWriter) WriteError(errType, message string) {
+func (s *SSEWriter) WriteError(errType, message string) error {
 	s.closeActiveBlock()
 	s.writeSSE("error", map[string]any{
 		"type":  "error",
 		"error": map[string]any{"type": errType, "message": message},
 	})
+	return s.writeErr
 }
 
 // Finish writes the closing SSE events (message_delta + message_stop).
-func (s *SSEWriter) Finish() {
+func (s *SSEWriter) Finish() error {
 	s.ensureStarted()
 
 	textDelta, thinkingDelta, res := finalizeResult(&s.acc)
@@ -195,7 +195,7 @@ func (s *SSEWriter) Finish() {
 	s.closeActiveBlock()
 
 	// Do NOT inject an empty text block here. If this is a thinking-only
-	// response, the caller (GateWriter) will detect it via IsEmptyVisibleEndTurn
+	// response, the caller will detect it via IsEmptyVisibleEndTurn
 	// and retry the request instead.
 
 	s.writeSSE("message_delta", map[string]any{
@@ -209,6 +209,7 @@ func (s *SSEWriter) Finish() {
 	s.writeSSE("message_stop", map[string]any{
 		"type": "message_stop",
 	})
+	return s.writeErr
 }
 
 func (s *SSEWriter) ensureStarted() {
@@ -339,7 +340,9 @@ func (s *SSEWriter) fireVisibleOutput() {
 	}
 	s.visibleFired = true
 	if s.OnVisibleOutput != nil {
-		s.OnVisibleOutput()
+		if err := s.OnVisibleOutput(); err != nil && s.writeErr == nil {
+			s.writeErr = err
+		}
 	}
 }
 
@@ -376,7 +379,7 @@ func (s *SSEWriter) ResetAccumulator(contextWindowSize int, stopSequences []stri
 }
 
 func (s *SSEWriter) writeSSE(eventType string, data map[string]any) {
-	if s.writeErr {
+	if s.writeErr != nil {
 		return
 	}
 	b, err := json.Marshal(data)
@@ -386,26 +389,37 @@ func (s *SSEWriter) writeSSE(eventType string, data map[string]any) {
 	}
 	_, err = fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", eventType, b)
 	if err != nil {
-		s.writeErr = true
+		s.writeErr = err
 		return
 	}
 	if s.flusher != nil {
 		s.flusher.Flush()
 	}
+	s.captureWriterError()
 }
 
 // writeRawSSE writes a pre-formatted SSE event using fmt.Fprintf, avoiding map allocation and json.Marshal.
 func (s *SSEWriter) writeRawSSE(eventType, format string, args ...any) {
-	if s.writeErr {
+	if s.writeErr != nil {
 		return
 	}
 	_, err := fmt.Fprintf(s.w, "event: "+eventType+"\ndata: "+format+"\n\n", args...)
 	if err != nil {
-		s.writeErr = true
+		s.writeErr = err
 		return
 	}
 	if s.flusher != nil {
 		s.flusher.Flush()
+	}
+	s.captureWriterError()
+}
+
+func (s *SSEWriter) captureWriterError() {
+	if s.writeErr != nil {
+		return
+	}
+	if reporter, ok := s.w.(interface{ Err() error }); ok {
+		s.writeErr = reporter.Err()
 	}
 }
 

--- a/internal/respconv/streaming_test.go
+++ b/internal/respconv/streaming_test.go
@@ -2,6 +2,8 @@ package respconv
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -15,7 +17,7 @@ func TestSSEWriter_TextOnly(t *testing.T) {
 
 	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hello"})
 	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hello world"})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, "event: message_start\n") {
@@ -48,7 +50,7 @@ func TestSSEWriter_ThinkingWithSignature(t *testing.T) {
 	sw.HandleEvent(kiroproto.Event{Type: "reasoningContentEvent", ThinkingText: "Let me", Signature: "sig_abc123"})
 	sw.HandleEvent(kiroproto.Event{Type: "reasoningContentEvent", ThinkingText: "Let me think"})
 	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Answer"})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"signature":"sig_abc123"`) {
@@ -74,7 +76,7 @@ func TestSSEWriter_ToolUse(t *testing.T) {
 		Type: "toolUseEvent", ToolStop: true,
 		ToolUseID: "toolu_01", ToolName: "get_weather", ToolInput: `{"city":"Tokyo"}`,
 	})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"stop_reason":"tool_use"`) {
@@ -104,7 +106,7 @@ func TestSSEWriter_InvalidState_PreStream(t *testing.T) {
 	}
 }
 
-func TestSSEWriter_InvalidState_MidStream(t *testing.T) {
+func TestSSEWriter_InvalidState_MidStreamLeavesErrorOutputToCaller(t *testing.T) {
 	w := httptest.NewRecorder()
 	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)
 
@@ -116,8 +118,42 @@ func TestSSEWriter_InvalidState_MidStream(t *testing.T) {
 		t.Fatal("expected error return")
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, `"invalid_state"`) {
-		t.Fatal("missing error event in stream")
+	if strings.Contains(body, "event: error") {
+		t.Fatal("SSEWriter must leave final error classification/output to the stream session")
+	}
+}
+
+type failingSSEWriter struct {
+	header http.Header
+	err    error
+}
+
+func (w *failingSSEWriter) Header() http.Header { return w.header }
+func (w *failingSSEWriter) WriteHeader(int)     {}
+func (w *failingSSEWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func TestSSEWriter_StoresConcreteWriteError(t *testing.T) {
+	wantErr := errors.New("downstream write failed")
+	w := &failingSSEWriter{header: make(http.Header), err: wantErr}
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)
+
+	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hello"})
+	if !errors.Is(sw.WriteErr(), wantErr) {
+		t.Fatalf("WriteErr() = %v, want %v", sw.WriteErr(), wantErr)
+	}
+}
+
+func TestSSEWriter_StoresPromotionError(t *testing.T) {
+	wantErr := errors.New("promote flush failed")
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)
+	sw.OnVisibleOutput = func() error { return wantErr }
+
+	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hello"})
+	if !errors.Is(sw.WriteErr(), wantErr) {
+		t.Fatalf("WriteErr() = %v, want %v", sw.WriteErr(), wantErr)
 	}
 }
 
@@ -130,7 +166,7 @@ func TestSSEWriter_MetadataEvent(t *testing.T) {
 		CacheReadInputTokens: 20, CacheWriteInputTokens: 10,
 	})
 	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hi"})
-	sw.Finish()
+	_ = sw.Finish()
 
 	input, output := sw.Usage()
 	if input != 100 || output != 50 {
@@ -152,7 +188,7 @@ func TestSSEWriter_Credits(t *testing.T) {
 
 	sw.HandleEvent(kiroproto.Event{Type: "meteringEvent", Credits: 0.5417})
 	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hi"})
-	sw.Finish()
+	_ = sw.Finish()
 
 	credits, ok := sw.Credits()
 	if !ok {
@@ -192,7 +228,7 @@ func TestSSEWriter_RedactedContent(t *testing.T) {
 
 	sw.HandleEvent(kiroproto.Event{Type: "reasoningContentEvent", RedactedContent: "base64data"})
 	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Answer"})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"redacted_thinking"`) {
@@ -210,7 +246,7 @@ func TestSSEWriter_NoOpEvents(t *testing.T) {
 	// These should not cause any output or errors.
 	sw.HandleEvent(kiroproto.Event{Type: "followupPromptEvent"})
 	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "Hi"})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"Hi"`) {
@@ -227,7 +263,7 @@ func TestSSEWriter_ThinkingViaTags(t *testing.T) {
 		Type:    "assistantResponseEvent",
 		Content: "<thinking>Step 1: analyze the problem</thinking>The answer is 42",
 	})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	// Should have thinking block.
@@ -262,7 +298,7 @@ func TestSSEWriter_ThinkingOnly_ViaTags(t *testing.T) {
 		Type:    "assistantResponseEvent",
 		Content: "<thinking>Let me reason through this</thinking>",
 	})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"thinking_delta"`) {
@@ -286,7 +322,7 @@ func TestSSEWriter_ThinkingOnly_ViaReasoningEvent(t *testing.T) {
 
 	// Only a reasoning content event — no text, no regular tool.
 	sw.HandleEvent(kiroproto.Event{Type: "reasoningContentEvent", ThinkingText: "Thinking...", Signature: "sig_x"})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"thinking_delta"`) {
@@ -317,7 +353,7 @@ func TestSSEWriter_ThinkingWithToolUse_NoTextInjection(t *testing.T) {
 		ToolUseID: "t2", ToolName: "bash",
 		ToolInput: `{"cmd":"ls"}`,
 	})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"stop_reason":"tool_use"`) {
@@ -344,7 +380,7 @@ func TestSSEWriter_ThinkingViaTags_WithRegularTool(t *testing.T) {
 		ToolUseID: "t2", ToolName: "bash",
 		ToolInput: `{"cmd":"ls"}`,
 	})
-	sw.Finish()
+	_ = sw.Finish()
 
 	body := w.Body.String()
 	if !strings.Contains(body, `"thinking_delta"`) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	messagesapp "github.com/d-kuro/kirocc/internal/app/messages"
 	"github.com/d-kuro/kirocc/internal/kiroclient"
@@ -24,14 +25,21 @@ func WithCapture(enabled bool) ServerOption {
 	return func(s *Server) { s.captureEnabled = enabled }
 }
 
+// WithKeepAliveInterval sets the idle interval for streaming SSE comments.
+// A zero duration disables keep-alive comments.
+func WithKeepAliveInterval(interval time.Duration) ServerOption {
+	return func(s *Server) { s.keepAliveInterval = interval }
+}
+
 // Server is the HTTP server for the kirocc proxy.
 type Server struct {
-	apiKey         string
-	otel           bool
-	otelBodyLimit  int
-	captureEnabled bool
-	mux            *http.ServeMux
-	messages       *messagesapp.Service
+	apiKey            string
+	otel              bool
+	otelBodyLimit     int
+	captureEnabled    bool
+	keepAliveInterval time.Duration
+	mux               *http.ServeMux
+	messages          *messagesapp.Service
 }
 
 // New creates a new Server.
@@ -43,7 +51,10 @@ func New(authMgr messagesapp.TokenGetter, apiKey string, client kiroclient.Clien
 	for _, opt := range opts {
 		opt(s)
 	}
-	s.messages = messagesapp.New(authMgr, client, messagesapp.WithCapture(s.captureEnabled))
+	s.messages = messagesapp.New(authMgr, client,
+		messagesapp.WithCapture(s.captureEnabled),
+		messagesapp.WithKeepAliveInterval(s.keepAliveInterval),
+	)
 	s.registerRoutes()
 	return s
 }

--- a/internal/server/sse_keepalive_test.go
+++ b/internal/server/sse_keepalive_test.go
@@ -1,0 +1,448 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/d-kuro/kirocc/internal/auth"
+	"github.com/d-kuro/kirocc/internal/kiroclient"
+	"github.com/d-kuro/kirocc/internal/kiroproto"
+	tu "github.com/d-kuro/kirocc/internal/testutil"
+)
+
+const toolSearchStreamingRequest = `{
+	"model":"claude-sonnet-4-6",
+	"max_tokens":64,
+	"stream":true,
+	"messages":[{"role":"user","content":"find a read tool"}],
+	"tools":[
+		{"type":"tool_search_tool_regex_20251119","name":"tool_search_tool_regex"},
+		{"name":"Read","description":"Read a file","input_schema":{"type":"object","properties":{"path":{"type":"string"}}},"defer_loading":true}
+	]
+}`
+
+type pendingStream struct {
+	call   int
+	writer *io.PipeWriter
+}
+
+// keepAliveScriptClient returns a pipe for nil script entries and a complete
+// in-memory event stream for non-nil entries.
+type keepAliveScriptClient struct {
+	mu      sync.Mutex
+	scripts [][]any
+	calls   int
+	pending chan pendingStream
+}
+
+type retryThenErrorClient struct {
+	mu      sync.Mutex
+	calls   int
+	pending chan pendingStream
+	err     error
+}
+
+func (c *retryThenErrorClient) GenerateAssistantResponse(context.Context, string, *kiroproto.Payload, string) (*kiroclient.Response, error) {
+	c.mu.Lock()
+	c.calls++
+	call := c.calls
+	c.mu.Unlock()
+	if call > 1 {
+		return nil, c.err
+	}
+	reader, writer := io.Pipe()
+	c.pending <- pendingStream{call: call, writer: writer}
+	return &kiroclient.Response{
+		StatusCode: http.StatusOK,
+		Body:       reader,
+		Header:     http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}},
+	}, nil
+}
+
+func newKeepAliveScriptClient(scripts ...[]any) *keepAliveScriptClient {
+	return &keepAliveScriptClient{
+		scripts: scripts,
+		pending: make(chan pendingStream, len(scripts)),
+	}
+}
+
+func (c *keepAliveScriptClient) GenerateAssistantResponse(context.Context, string, *kiroproto.Payload, string) (*kiroclient.Response, error) {
+	c.mu.Lock()
+	call := c.calls
+	c.calls++
+	script := c.scripts[min(call, len(c.scripts)-1)]
+	c.mu.Unlock()
+
+	header := http.Header{"Content-Type": []string{"application/vnd.amazon.eventstream"}}
+	if script != nil {
+		return &kiroclient.Response{StatusCode: http.StatusOK, Body: buildEventStream(script...), Header: header}, nil
+	}
+
+	reader, writer := io.Pipe()
+	c.pending <- pendingStream{call: call + 1, writer: writer}
+	return &kiroclient.Response{StatusCode: http.StatusOK, Body: reader, Header: header}, nil
+}
+
+func (c *keepAliveScriptClient) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+type streamingRecorder struct {
+	mu      sync.Mutex
+	header  http.Header
+	status  int
+	body    bytes.Buffer
+	flushed chan struct{}
+}
+
+func newStreamingRecorder() *streamingRecorder {
+	return &streamingRecorder{
+		header:  make(http.Header),
+		flushed: make(chan struct{}, 256),
+	}
+}
+
+func (w *streamingRecorder) Header() http.Header { return w.header }
+
+func (w *streamingRecorder) WriteHeader(status int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.status == 0 {
+		w.status = status
+	}
+}
+
+func (w *streamingRecorder) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.body.Write(p)
+}
+
+func (w *streamingRecorder) FlushError() error {
+	w.mu.Lock()
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	w.mu.Unlock()
+	select {
+	case w.flushed <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (w *streamingRecorder) snapshot() (status int, body string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.status, w.body.String()
+}
+
+func newKeepAliveServer(client kiroclient.Client, interval time.Duration) *Server {
+	mgr := &mockAuthManager{creds: &auth.Credentials{
+		AccessToken: "test-token",
+		ProfileARN:  "arn:test",
+		Region:      "us-east-1",
+	}}
+	return New(mgr, "", client, WithKeepAliveInterval(interval))
+}
+
+func startStreamingHandler(t *testing.T, srv *Server, body string) (*streamingRecorder, <-chan struct{}) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Claude-Code-Session-Id", "keepalive-test-session")
+	w := newStreamingRecorder()
+	done := make(chan struct{})
+	go func() {
+		srv.Handler().ServeHTTP(w, req)
+		close(done)
+	}()
+	return w, done
+}
+
+func awaitPendingStream(t *testing.T, pending <-chan pendingStream) pendingStream {
+	t.Helper()
+	select {
+	case stream := <-pending:
+		return stream
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream stream")
+		return pendingStream{}
+	}
+}
+
+func awaitHandlerDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handler completion")
+	}
+}
+
+func awaitBodyContains(t *testing.T, w *streamingRecorder, want string) string {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for {
+		_, body := w.snapshot()
+		if strings.Contains(body, want) {
+			return body
+		}
+		select {
+		case <-w.flushed:
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for downstream body %q; body = %s", want, body)
+		}
+	}
+}
+
+func writeUpstreamEvents(t *testing.T, w *io.PipeWriter, events ...any) {
+	t.Helper()
+	for i := 0; i < len(events); i += 2 {
+		if _, err := w.Write(tu.BuildFrame(events[i].(string), events[i+1].([]byte))); err != nil {
+			t.Fatalf("write upstream event: %v", err)
+		}
+	}
+}
+
+func TestSSEKeepAlive_StalledFirstFrameThenSuccess(t *testing.T) {
+	client := newKeepAliveScriptClient(nil)
+	srv := newKeepAliveServer(client, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+
+	body := awaitBodyContains(t, w, ": keep-alive\n\n")
+	if body != ": keep-alive\n\n" {
+		t.Fatalf("first downstream bytes = %q, want keep-alive comment", body)
+	}
+	writeUpstreamEvents(t, upstream.writer, "assistantResponseEvent", mustJSON(map[string]string{"content": "eventual answer"}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	status, body := w.snapshot()
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !strings.Contains(body, "eventual answer") || !strings.Contains(body, "event: message_stop") {
+		t.Fatalf("successful SSE did not follow keep-alive: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_FinalErrorAfterCommitIsSSE(t *testing.T) {
+	client := newKeepAliveScriptClient(nil)
+	srv := newKeepAliveServer(client, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+	_ = awaitBodyContains(t, w, ": keep-alive\n\n")
+
+	writeUpstreamEvents(t, upstream.writer, "invalidStateEvent", mustJSON(map[string]string{
+		"reason": "FATAL_STATE", "message": "request rejected",
+	}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	status, body := w.snapshot()
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want committed 200", status)
+	}
+	if !strings.Contains(body, "event: error") {
+		t.Fatalf("missing SSE error after keep-alive commit: %s", body)
+	}
+	if strings.Contains(body, "\n{\"type\":\"error\"") {
+		t.Fatalf("standalone JSON error injected into SSE body: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_FinalErrorAfterPromotionClosesActiveBlock(t *testing.T) {
+	events := []any{
+		"assistantResponseEvent", mustJSON(map[string]string{"content": "partial"}),
+		"invalidStateEvent", mustJSON(map[string]string{"reason": "FATAL_STATE", "message": "request rejected"}),
+	}
+	client := newKeepAliveScriptClient(events)
+	srv := newKeepAliveServer(client, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	awaitHandlerDone(t, done)
+	status, body := w.snapshot()
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want promoted 200", status)
+	}
+	stop := strings.Index(body, "event: content_block_stop")
+	errEvent := strings.Index(body, "event: error")
+	if stop < 0 || errEvent < 0 || stop > errEvent {
+		t.Fatalf("active block was not closed before SSE error: %s", body)
+	}
+	if !strings.Contains(body, `"type":"invalid_state"`) {
+		t.Fatalf("mid-stream invalid state type changed: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_FinalErrorBeforeCommitIsNon200JSON(t *testing.T) {
+	srv := newKeepAliveServer(&errorClient{err: errors.New("upstream unavailable")}, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	awaitHandlerDone(t, done)
+	status, body := w.snapshot()
+	if status != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body = %s", status, body)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	if !strings.HasPrefix(body, "{") || !strings.Contains(body, `"type":"error"`) || !strings.Contains(body, `"type":"api_error"`) {
+		t.Fatalf("body is not a JSON error: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_DisabledDoesNotWriteWhileStalled(t *testing.T) {
+	client := newKeepAliveScriptClient(nil)
+	srv := newKeepAliveServer(client, 0)
+	w, done := startStreamingHandler(t, srv, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+
+	select {
+	case <-w.flushed:
+		_, body := w.snapshot()
+		t.Fatalf("disabled keep-alive flushed early: %s", body)
+	case <-time.After(40 * time.Millisecond):
+	}
+	if _, body := w.snapshot(); body != "" {
+		t.Fatalf("disabled keep-alive wrote while stalled: %s", body)
+	}
+
+	writeUpstreamEvents(t, upstream.writer, "assistantResponseEvent", mustJSON(map[string]string{"content": "normal response"}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	_, body := w.snapshot()
+	if strings.Contains(body, ": keep-alive") {
+		t.Fatalf("disabled keep-alive wrote a comment: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_TransparentRetryAfterCommit(t *testing.T) {
+	normal := []any{"assistantResponseEvent", mustJSON(map[string]string{"content": "retry answer"})}
+	client := newKeepAliveScriptClient(nil, normal)
+	srv := newKeepAliveServer(client, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+	_ = awaitBodyContains(t, w, ": keep-alive\n\n")
+
+	writeUpstreamEvents(t, upstream.writer, "assistantResponseEvent", mustJSON(map[string]string{"content": "<thinking>discard me</thinking>"}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	_, body := w.snapshot()
+	if client.callCount() != 2 {
+		t.Fatalf("upstream calls = %d, want 2", client.callCount())
+	}
+	if !strings.Contains(body, "retry answer") {
+		t.Fatalf("retry response missing: %s", body)
+	}
+	if strings.Contains(body, "thinking_delta") || strings.Contains(body, "discard me") {
+		t.Fatalf("first attempt semantic events leaked: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_RetryHTTPFailureAfterCommitIsSSE(t *testing.T) {
+	client := &retryThenErrorClient{
+		pending: make(chan pendingStream, 1),
+		err:     errors.New("second upstream call failed"),
+	}
+	srv := newKeepAliveServer(client, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+	_ = awaitBodyContains(t, w, ": keep-alive\n\n")
+
+	writeUpstreamEvents(t, upstream.writer, "assistantResponseEvent", mustJSON(map[string]string{"content": "<thinking>retry me</thinking>"}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	status, body := w.snapshot()
+	if status != http.StatusOK || !strings.Contains(body, "event: error") {
+		t.Fatalf("retry HTTP failure was not SSE on committed response: status=%d body=%s", status, body)
+	}
+	if strings.Contains(body, "\n{\"type\":\"error\"") {
+		t.Fatalf("retry HTTP failure injected JSON: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_ToolSearchAcrossRounds(t *testing.T) {
+	toolRound := []any{"toolUseEvent", mustJSON(map[string]any{
+		"name": "ToolSearch", "toolUseId": "tool-search-1", "input": `{"query":"Read"}`, "stop": true,
+	})}
+	client := newKeepAliveScriptClient(toolRound, nil)
+	srv := newKeepAliveServer(client, 20*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, toolSearchStreamingRequest)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+	if upstream.call != 2 {
+		t.Fatalf("stalled stream is call %d, want round 2", upstream.call)
+	}
+
+	body := awaitBodyContains(t, w, ": keep-alive\n\n")
+	if !strings.Contains(body, "tool_search_tool_result") {
+		t.Fatalf("heartbeat did not remain after round-1 semantic output: %s", body)
+	}
+	writeUpstreamEvents(t, upstream.writer, "assistantResponseEvent", mustJSON(map[string]string{"content": "round two answer"}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	_, body = w.snapshot()
+	if !strings.Contains(body, "round two answer") {
+		t.Fatalf("round 2 response missing: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_ToolSearchOuterRetryAfterCommit(t *testing.T) {
+	normal := []any{"assistantResponseEvent", mustJSON(map[string]string{"content": "tool-search retry answer"})}
+	client := newKeepAliveScriptClient(nil, normal)
+	srv := newKeepAliveServer(client, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, toolSearchStreamingRequest)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+	_ = awaitBodyContains(t, w, ": keep-alive\n\n")
+
+	writeUpstreamEvents(t, upstream.writer, "assistantResponseEvent", mustJSON(map[string]string{"content": "<thinking>discard tool-search attempt</thinking>"}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	_, body := w.snapshot()
+	if client.callCount() != 2 || !strings.Contains(body, "tool-search retry answer") {
+		t.Fatalf("tool-search outer retry failed: calls=%d body=%s", client.callCount(), body)
+	}
+	if strings.Contains(body, "discard tool-search attempt") || strings.Contains(body, "thinking_delta") {
+		t.Fatalf("tool-search first attempt leaked semantic output: %s", body)
+	}
+}
+
+func TestSSEKeepAlive_ToolSearchTailErrorIsEmitted(t *testing.T) {
+	client := newKeepAliveScriptClient(nil)
+	srv := newKeepAliveServer(client, 10*time.Millisecond)
+	w, done := startStreamingHandler(t, srv, toolSearchStreamingRequest)
+	upstream := awaitPendingStream(t, client.pending)
+	t.Cleanup(func() { _ = upstream.writer.Close() })
+	writeUpstreamEvents(t, upstream.writer, "toolUseEvent", mustJSON(map[string]any{
+		"name": "ToolSearch", "toolUseId": "tool-search-tail", "input": `{"query":"Read"}`, "stop": true,
+	}))
+	_ = awaitBodyContains(t, w, ": keep-alive\n\n")
+	writeUpstreamEvents(t, upstream.writer, "invalidStateEvent", mustJSON(map[string]string{
+		"reason": "TAIL_FAILURE", "message": "tail failed",
+	}))
+	_ = upstream.writer.Close()
+	awaitHandlerDone(t, done)
+	_, body := w.snapshot()
+	if !strings.Contains(body, "event: error") {
+		t.Fatalf("tail exception produced neither error nor message_stop: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary

Changes independent of the Fable 5 model addition, extracted from the `feat/claude-fable-5` working branch.

> **Note:** The token-usage fallback fix originally in this PR was dropped in favor of #84, which fixes the same bug (`metadataEvent` without `tokenUsage` zeroing usage). This PR now contains only the SSE keep-alive work and no longer conflicts with #84.

### feat: SSE keep-alive heartbeat with request-scoped stream session

Emit SSE keep-alive comments while Kiro is silent so idle client timeouts do not close valid streaming requests. A new request-scoped `streamSession` owns every downstream write for one streaming `/v1/messages` request:

- Idle heartbeat with configurable interval (`-keepalive-interval` flag / `KIROCC_KEEPALIVE_INTERVAL` env, default 15s, `0` disables, `<1s` rejected)
- Buffered-to-direct promotion keyed on first visible output, so transparent retry (empty visible end_turn, retryable invalid state) still works after a keep-alive has committed HTTP 200
- Pre-commit errors return JSON; post-commit errors are delivered as Anthropic-compatible SSE error events
- One session (and its heartbeat) spans retry attempts and tool-search rounds
- `SSEWriter.WriteErr` now returns the concrete downstream error instead of a boolean

Plan: `_docs/plans/sse-keep-alive.md`

### fix: bound socket writes and close Start/Stop race (review follow-up)

- Per-write deadline (30s) on downstream socket writes so a client that stops reading cannot wedge `Stop`/`Promote`/`WriteFinalError` behind the session mutex
- `Start`'s stopped-check and `wg.Add(1)` now share one critical section, closing a race where a concurrent `Stop` could return before the heartbeat goroutine launched

### docs(skill): expand kiro-capture for 2.10.0 event types and auth flow

Document `reasoningContentEvent` / `meteringEvent` and the 2.10.0 auth flow observed in a fresh capture.

## Testing

- `make test` (full suite with `-race`) and `make lint` pass on this branch
- Also verified green with #84 merged on top (no conflicts, no test failures)
- New tests: `stream_session_test.go` (incl. concurrent Start/Stop and write-deadline coverage), `sse_keepalive_test.go`, config/flag validation cases