### PR TITLE
feat(auth): support Kiro API keys via KIRO_API_KEY

### DIFF
--- a/cmd/kirocc/main.go
+++ b/cmd/kirocc/main.go
@@ -61,7 +61,13 @@ func run(ctx context.Context, args []string) error {
 		slog.Info("OpenTelemetry tracing enabled", "body_limit", cfg.OTelBodyLimit)
 	}
 
-	authMgr := auth.NewAuthManager(cfg.DBPath)
+	authMgr := auth.NewAuthManager(cfg.DBPath, auth.WithAPIKey(cfg.KiroAPIKey, cfg.KiroAPIRegion))
+	if authMgr.UsesAPIKey() {
+		// Say so up front: with a key there is no database read and no refresh,
+		// so the usual "credentials loaded" line never appears and its absence
+		// would otherwise look like a failure.
+		slog.Info("using Kiro API key", "auth_type", auth.AuthTypeAPIKey, "db_read", false)
+	}
 	kiroClient := buildKiroClient(authMgr, cfg)
 	srv := buildServer(authMgr, kiroClient, cfg)
 
@@ -102,6 +108,8 @@ func parseFlags(args []string) (config.Config, error) {
 	fs.StringVar(&cfg.Host, "host", "127.0.0.1", "bind host")
 	fs.StringVar(&cfg.DBPath, "db", config.DefaultDBPath(), "kiro-cli SQLite DB path")
 	fs.StringVar(&cfg.APIKey, "api-key", "", "optional API key for authentication")
+	fs.StringVar(&cfg.KiroAPIKey, "kiro-api-key", "", "Kiro API key (ksk_...) to use instead of the kiro-cli database credential; also KIRO_API_KEY")
+	fs.StringVar(&cfg.KiroAPIRegion, "kiro-api-region", "", "region for Kiro API key auth (default us-east-1); also KIRO_API_REGION")
 	fs.BoolVar(&cfg.Debug, "debug", false, "enable debug logging with OTel JSON Lines output")
 	fs.BoolVar(&cfg.OTel, "otel", false, "enable OpenTelemetry tracing (OTLP HTTP exporter)")
 	fs.IntVar(&cfg.OTelBodyLimit, "otel-body-limit", config.DefaultOTelBodyLimit, "max bytes of request body to capture in OTel spans (0 = unlimited)")
@@ -131,6 +139,9 @@ func buildKiroClient(authMgr *auth.AuthManager, cfg config.Config) kiroclient.Cl
 			}
 			return creds.AccessToken, nil
 		}),
+	}
+	if authMgr.UsesAPIKey() {
+		clientOpts = append(clientOpts, kiroclient.WithAPIKeyAuth())
 	}
 	if cfg.OTel {
 		clientOpts = append(clientOpts, kiroclient.WithOTel(cfg.OTelBodyLimit))

--- a/internal/auth/apikey_test.go
+++ b/internal/auth/apikey_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithAPIKey_ShortCircuitsDBAndRefresh(t *testing.T) {
+	// A path that cannot be opened proves the DB is never touched: if GetToken
+	// consulted it, this would fail rather than return the key.
+	m := NewAuthManager("/nonexistent/kirocc-test/data.sqlite3", WithAPIKey("ksk_test", ""))
+
+	if !m.UsesAPIKey() {
+		t.Fatal("UsesAPIKey() = false, want true")
+	}
+
+	creds, err := m.GetToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if creds.AccessToken != "ksk_test" {
+		t.Errorf("AccessToken = %q, want %q", creds.AccessToken, "ksk_test")
+	}
+	if creds.AuthType != AuthTypeAPIKey {
+		t.Errorf("AuthType = %q, want %q", creds.AuthType, AuthTypeAPIKey)
+	}
+	if creds.Region != defaultAPIKeyRegion {
+		t.Errorf("Region = %q, want %q", creds.Region, defaultAPIKeyRegion)
+	}
+	// An API key has no expiry to honour and no profile ARN to send; both must
+	// stay zero so the refresh and profileArn paths remain unreachable.
+	if creds.ExpiresAt != 0 {
+		t.Errorf("ExpiresAt = %d, want 0", creds.ExpiresAt)
+	}
+	if creds.RefreshToken != "" {
+		t.Errorf("RefreshToken = %q, want empty", creds.RefreshToken)
+	}
+	if creds.ProfileARN != "" {
+		t.Errorf("ProfileARN = %q, want empty", creds.ProfileARN)
+	}
+}
+
+// Repeated calls must keep working even though nothing is cached: an API key
+// never expires from kirocc's point of view, so the token-validity buffer that
+// governs database credentials must not apply to it.
+func TestWithAPIKey_StableAcrossCalls(t *testing.T) {
+	m := NewAuthManager("/nonexistent/kirocc-test/data.sqlite3", WithAPIKey("ksk_test", ""))
+	for i := range 3 {
+		creds, err := m.GetToken(context.Background())
+		if err != nil {
+			t.Fatalf("GetToken call %d: %v", i, err)
+		}
+		if creds.AccessToken != "ksk_test" {
+			t.Fatalf("call %d: AccessToken = %q", i, creds.AccessToken)
+		}
+	}
+}
+
+func TestWithAPIKey_RegionOverride(t *testing.T) {
+	m := NewAuthManager("", WithAPIKey("ksk_test", "eu-west-1"))
+	creds, err := m.GetToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if creds.Region != "eu-west-1" {
+		t.Errorf("Region = %q, want %q", creds.Region, "eu-west-1")
+	}
+}
+
+// An empty key must be inert, so that exporting KIRO_API_KEY= (or leaving the
+// flag unset) leaves the database path in effect rather than half-enabling a
+// credential-less API-key mode.
+func TestWithAPIKey_EmptyKeyIsIgnored(t *testing.T) {
+	m := NewAuthManager("/nonexistent/kirocc-test/data.sqlite3", WithAPIKey("", "us-east-1"))
+	if m.UsesAPIKey() {
+		t.Error("UsesAPIKey() = true for an empty key, want false")
+	}
+	if _, err := m.GetToken(context.Background()); err == nil {
+		t.Error("GetToken succeeded with no key and an unreadable DB, want error")
+	}
+}

--- a/internal/auth/db.go
+++ b/internal/auth/db.go
@@ -11,7 +11,16 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// Credentials holds authentication credentials read from Kiro CLI's SQLite database.
+// Auth types. Social and IDC are read from Kiro CLI's SQLite database and are
+// refreshable; APIKey is supplied directly via KIRO_API_KEY and is not.
+const (
+	AuthTypeSocial = "social"
+	AuthTypeIDC    = "idc"
+	AuthTypeAPIKey = "api_key"
+)
+
+// Credentials holds authentication credentials, either read from Kiro CLI's
+// SQLite database or, for AuthTypeAPIKey, supplied directly by the user.
 type Credentials struct {
 	AccessToken  string
 	RefreshToken string
@@ -21,7 +30,7 @@ type Credentials struct {
 	ClientID     string
 	ClientSecret string
 	ProfileARN   string // from state table, key "api.codewhisperer.profile"
-	AuthType     string // "social" or "idc" — determined by which token key was found
+	AuthType     string // "social", "idc", or "api_key"
 }
 
 // ErrNoCredentials is returned when no token key is found in the database.

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -25,10 +25,35 @@ func WithHTTPClient(c *http.Client) Option {
 	return func(m *AuthManager) { m.httpClient = c }
 }
 
+// WithAPIKey configures a Kiro API key ("ksk_…", normally from KIRO_API_KEY) as
+// the credential source. Such a key is long-lived and presented directly to the
+// API, so the SQLite database is never opened and no refresh ever happens —
+// which is what lets kirocc run with no Kiro CLI login, in CI or a container.
+// An empty key is ignored, leaving the database path in effect.
+func WithAPIKey(key, region string) Option {
+	return func(m *AuthManager) {
+		if key == "" {
+			return
+		}
+		if region == "" {
+			region = defaultAPIKeyRegion
+		}
+		m.apiKey = key
+		m.apiKeyRegion = region
+	}
+}
+
+// defaultAPIKeyRegion is the region to target for API-key auth when none is
+// configured. An API key carries no region of its own, unlike a credential read
+// from the database.
+const defaultAPIKeyRegion = "us-east-1"
+
 // AuthManager manages Kiro credentials with caching and automatic refresh.
 type AuthManager struct {
 	dbPath           string
 	db               *sql.DB // non-nil only in tests via newAuthManagerWithDB
+	apiKey           string  // when set, short-circuits both the DB and refresh
+	apiKeyRegion     string
 	httpClient       *http.Client
 	mu               sync.Mutex
 	cached           *Credentials
@@ -36,6 +61,10 @@ type AuthManager struct {
 	oidcEndpointFn   func(ssoRegion string) string
 	socialEndpointFn func(region string) string
 }
+
+// UsesAPIKey reports whether credentials come from a Kiro API key rather than
+// from the Kiro CLI database.
+func (m *AuthManager) UsesAPIKey() bool { return m.apiKey != "" }
 
 func newDefaultHTTPClient() *http.Client {
 	return &http.Client{Timeout: 30 * time.Second}
@@ -79,6 +108,18 @@ func defaultSocialEndpoint(region string) string {
 // GetToken returns valid credentials, refreshing if necessary.
 // It is safe for concurrent use. Concurrent refresh requests are deduplicated via singleflight.
 func (m *AuthManager) GetToken(ctx context.Context) (*Credentials, error) {
+	// An API key is static: nothing to read, nothing to expire, nothing to
+	// refresh. Checked before the cache so the DB and refresh paths below are
+	// unreachable in this mode — a revoked key therefore surfaces as a 401 from
+	// the API rather than as a refresh failure here.
+	if m.apiKey != "" {
+		return &Credentials{
+			AccessToken: m.apiKey,
+			Region:      m.apiKeyRegion,
+			AuthType:    AuthTypeAPIKey,
+		}, nil
+	}
+
 	m.mu.Lock()
 	// Return cached credentials if still valid (copy to prevent external mutation).
 	if m.cached != nil && isTokenValid(m.cached.ExpiresAt) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,10 +20,15 @@ const (
 
 // Config is the runtime configuration for kirocc.
 type Config struct {
-	Port              int
-	Host              string
-	DBPath            string
-	APIKey            string
+	Port   int
+	Host   string
+	DBPath string
+	APIKey string // guards kirocc's own endpoints; unrelated to KiroAPIKey
+	// KiroAPIKey is a Kiro API key ("ksk_…") used upstream instead of the
+	// kiro-cli database credential. Named after Kiro's own KIRO_API_KEY rather
+	// than the KIROCC_* convention, since it is Kiro's credential, not kirocc's.
+	KiroAPIKey        string
+	KiroAPIRegion     string
 	Debug             bool
 	OTel              bool
 	OTelBodyLimit     int
@@ -54,6 +59,10 @@ func DefaultDBPathFor(goos, home string) string {
 func ApplyEnvOverrides(cfg *Config) error {
 	applyString("KIROCC_DB_PATH", &cfg.DBPath)
 	applyString("KIROCC_API_KEY", &cfg.APIKey)
+	// Kiro's own variable names, so a machine already set up for headless
+	// kiro-cli needs no kirocc-specific configuration.
+	applyString("KIRO_API_KEY", &cfg.KiroAPIKey)
+	applyString("KIRO_API_REGION", &cfg.KiroAPIRegion)
 	applyString("KIROCC_HOST", &cfg.Host)
 	if err := applyInt("KIROCC_PORT", &cfg.Port); err != nil {
 		return err

--- a/internal/kiroclient/apikey_test.go
+++ b/internal/kiroclient/apikey_test.go
@@ -1,0 +1,91 @@
+package kiroclient
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/d-kuro/kirocc/internal/kiroproto"
+)
+
+func apiKeyTestPayload() *kiroproto.Payload {
+	return &kiroproto.Payload{
+		ConversationState: kiroproto.ConversationState{
+			ChatTriggerType: "MANUAL",
+			AgentTaskType:   "vibe",
+			CurrentMessage: kiroproto.CurrentMessage{
+				UserInputMessage: kiroproto.UserInputMessage{Content: "Hello"},
+			},
+		},
+	}
+}
+
+// The API distinguishes an API-key bearer from an OAuth bearer by this header
+// alone; without it the request is rejected for a missing profileArn, which an
+// API key cannot supply.
+func TestHTTPClient_APIKeyAuth_SendsTokenTypeHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     []HTTPClientOption
+		wantType string
+	}{
+		{name: "api key auth", opts: []HTTPClientOption{WithAPIKeyAuth()}, wantType: "API_KEY"},
+		{name: "database credential", opts: nil, wantType: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			var authorization string
+			srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("TokenType")
+				authorization = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("stream-body"))
+			}))
+			defer srv.Close()
+
+			opts := append([]HTTPClientOption{WithBaseURL(srv.URL)}, tt.opts...)
+			c := NewHTTPClient(opts...)
+
+			resp, err := c.GenerateAssistantResponse(context.Background(), "ksk_test", apiKeyTestPayload(), "us-east-1")
+			if err != nil {
+				t.Fatalf("GenerateAssistantResponse: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if got != tt.wantType {
+				t.Errorf("TokenType = %q, want %q", got, tt.wantType)
+			}
+			// The key is the bearer either way: there is no token exchange.
+			if authorization != "Bearer ksk_test" {
+				t.Errorf("Authorization = %q, want %q", authorization, "Bearer ksk_test")
+			}
+		})
+	}
+}
+
+// The user-agent is load-bearing: the API authorizes on it, and an API key does
+// not exempt a request from that check.
+func TestHTTPClient_APIKeyAuth_KeepsUserAgent(t *testing.T) {
+	var ua string
+	srv := newTCP4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("stream-body"))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(WithBaseURL(srv.URL), WithAPIKeyAuth())
+	resp, err := c.GenerateAssistantResponse(context.Background(), "ksk_test", apiKeyTestPayload(), "us-east-1")
+	if err != nil {
+		t.Fatalf("GenerateAssistantResponse: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if ua != userAgentValue {
+		t.Errorf("User-Agent = %q, want %q", ua, userAgentValue)
+	}
+}

--- a/internal/kiroclient/client.go
+++ b/internal/kiroclient/client.go
@@ -76,6 +76,7 @@ type HTTPClient struct {
 	tokenRefresher TokenRefresher
 	countTokens    func([]byte) (int, error) // nil = skip token counting
 	bodyReadIdle   time.Duration             // idle timeout for response body reads; 0 = use default
+	apiKeyAuth     bool                      // send TokenType: API_KEY with the bearer
 }
 
 // HTTPClientOption configures an HTTPClient.
@@ -89,6 +90,18 @@ func WithBaseURL(url string) HTTPClientOption {
 // WithTokenRefresher sets the token refresh callback for 403 retry.
 func WithTokenRefresher(fn TokenRefresher) HTTPClientOption {
 	return func(c *HTTPClient) { c.tokenRefresher = fn }
+}
+
+// WithAPIKeyAuth marks the bearer credential as a Kiro API key rather than an
+// OAuth access token, which the API distinguishes by a TokenType header. Set
+// once at construction because the credential source is fixed for the process
+// lifetime; this keeps it off the Client interface and out of every call site.
+//
+// Without the header the API treats the bearer as an OAuth token and rejects
+// the call with "profileArn is required for this request" — an API key has no
+// profile ARN to give.
+func WithAPIKeyAuth() HTTPClientOption {
+	return func(c *HTTPClient) { c.apiKeyAuth = true }
 }
 
 // WithTokenCounter sets a function to count prompt tokens from the serialized payload.
@@ -198,6 +211,11 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 		}
 
 		req.Header.Set("Authorization", "Bearer "+currentToken)
+		if c.apiKeyAuth {
+			// Canonical spelling in Kiro's own client is "TokenType"; the header
+			// name is case-insensitive on the wire.
+			req.Header.Set("TokenType", "API_KEY")
+		}
 		req.Header.Set("Content-Type", "application/x-amz-json-1.0")
 		req.Header.Set("Accept", "*/*")
 		req.Header.Set("X-Amz-Target", amzTarget)


### PR DESCRIPTION
Closes #87.

Adds a second credential source: a Kiro API key (`ksk_…`) presented directly to the API, so kirocc
no longer requires an interactive Kiro login on the same machine and can run in CI, a container, or
any headless environment.

### What changed

- **`internal/auth`** — `WithAPIKey(key, region)` sets a static credential and `GetToken` returns it
  before the cache check, so the SQLite database is never opened and neither refresh path is
  reachable. `AuthTypeSocial` / `AuthTypeIDC` / `AuthTypeAPIKey` constants replace the bare strings.
  `UsesAPIKey()` lets `main` wire the client and log the mode.
- **`internal/kiroclient`** — `WithAPIKeyAuth()` stamps `TokenType: API_KEY` alongside the existing
  bearer. Deliberately a construction-time option rather than a new `Client` parameter: the
  credential source cannot change mid-process, and this keeps the interface and all three call sites
  unchanged.
- **`cmd/kirocc` / `internal/config`** — `-kiro-api-key` and `-kiro-api-region`, plus `KIRO_API_KEY`
  and `KIRO_API_REGION` env overrides. Kiro's own variable names rather than `KIROCC_*`, since the
  credential is Kiro's, not kirocc's. A startup log line states the mode, because the usual
  `credentials loaded` message never appears in this mode and its absence otherwise reads as a
  failure.

### Behaviour

- `KIRO_API_KEY` set → API-key auth. Unset or empty → today's database path, unchanged.
- No expiry is tracked, so a revoked key surfaces as a 401 from the API rather than a refresh error.
- `profileArn` is intentionally left empty, matching Kiro's own API-key client.

### Tests

`internal/auth/apikey_test.go` and `internal/kiroclient/apikey_test.go`:

- `GetToken` returns the key with `AuthTypeAPIKey` and the default region, and `ExpiresAt`,
  `RefreshToken` and `ProfileARN` stay zero — asserted against a **nonexistent DB path**, which
  proves the database is never consulted.
- Stable across repeated calls, so the token-validity buffer cannot apply to a key.
- Region override honoured.
- Empty key is inert and the DB path still governs.
- The `TokenType` header is present with `WithAPIKeyAuth()` and absent without it, in both cases with
  the key as the bearer.
- The user-agent is unchanged under API-key auth.

Full suite passes; `gofmt` and `go vet` clean.

### Manual verification

Built with `GOEXPERIMENT=jsonv2` and run with `-db` pointing at a nonexistent path, so no Kiro CLI
credential was reachable:

```
using Kiro API key   auth_type=api_key db_read=false
--> POST /v1/messages  model=... context_window=200k
<-- POST /v1/messages  credits=0.052 status=200
```

Claude Code completed a streaming turn with tool use and Kiro billed the credits. Also confirmed:
without the key the same binary logs `credentials loaded auth_type=idc`, and with both present it
uses the key.
