### PR TITLE
fix(reqconv): wrap non-object tool schemas to prevent TOOL_SCHEMA_INVALID

### DIFF
--- a/internal/reqconv/schema_sanitize.go
+++ b/internal/reqconv/schema_sanitize.go
@@ -113,6 +113,41 @@ func SanitizeJSONSchema(schema map[string]any) map[string]any {
 	return result
 }
 
+// EnsureObjectRoot wraps a sanitized schema in an object envelope if its root
+// type is not "object". Call this on the final schema passed to Kiro, not during
+// recursive sanitization of nested properties.
+//
+// Kiro/Bedrock rejects any tool whose inputSchema.json.type is not "object":
+//
+//	ValidationException: The value at toolConfig.tools.0.toolSpec.inputSchema.json.type
+//	must be one of the following: object. reason: TOOL_SCHEMA_INVALID
+//
+// Anthropic's API has no such constraint, so clients (including Claude Code's
+// built-in tools like WebSearch) may send schemas with type:"string" or no type
+// at all. This wrapper satisfies the validation without altering semantics for
+// the model.
+func EnsureObjectRoot(schema map[string]any) map[string]any {
+	if len(schema) == 0 {
+		return map[string]any{"type": "object", "properties": map[string]any{}}
+	}
+	t, _ := schema["type"].(string)
+	if t == "object" {
+		return schema
+	}
+	if t == "" {
+		// No type declared — add it rather than wrapping.
+		schema["type"] = "object"
+		return schema
+	}
+	// Non-object type: wrap in an object envelope.
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"input": schema,
+		},
+	}
+}
+
 // dropNullBranches returns branches that are not {type: "null"}.
 func dropNullBranches(branches []any) []any {
 	var result []any

--- a/internal/reqconv/tool_convert.go
+++ b/internal/reqconv/tool_convert.go
@@ -22,7 +22,7 @@ func ConvertTools(tools []anthropic.Tool, nameMap *ToolNameMap) []kiroproto.Tool
 			ToolSpecification: &kiroproto.ToolSpecification{
 				Name:        name,
 				Description: desc,
-				InputSchema: kiroproto.InputSchema{JSON: SanitizeJSONSchema(t.InputSchema)},
+				InputSchema: kiroproto.InputSchema{JSON: EnsureObjectRoot(SanitizeJSONSchema(t.InputSchema))},
 			},
 		})
 	}

--- a/internal/reqconv/tool_schema_test.go
+++ b/internal/reqconv/tool_schema_test.go
@@ -418,3 +418,62 @@ func TestSanitizeJSONSchema_AnyOfOverridesType_Deterministic(t *testing.T) {
 		}
 	}
 }
+
+func TestEnsureObjectRoot_AlreadyObject(t *testing.T) {
+	schema := map[string]any{"type": "object", "properties": map[string]any{"x": map[string]any{"type": "string"}}}
+	got := EnsureObjectRoot(schema)
+	if got["type"] != "object" || got["properties"] == nil {
+		t.Fatalf("should be unchanged: %v", got)
+	}
+}
+
+func TestEnsureObjectRoot_StringType_Wraps(t *testing.T) {
+	schema := map[string]any{"type": "string", "description": "search query"}
+	got := EnsureObjectRoot(schema)
+	if got["type"] != "object" {
+		t.Fatalf("expected object root, got %v", got["type"])
+	}
+	props, ok := got["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected properties")
+	}
+	input, ok := props["input"].(map[string]any)
+	if !ok {
+		t.Fatal("expected input property")
+	}
+	if input["type"] != "string" {
+		t.Fatalf("wrapped schema lost type: %v", input)
+	}
+}
+
+func TestEnsureObjectRoot_NoType_AddsObject(t *testing.T) {
+	schema := map[string]any{"properties": map[string]any{"x": map[string]any{}}}
+	got := EnsureObjectRoot(schema)
+	if got["type"] != "object" {
+		t.Fatalf("expected type added, got %v", got["type"])
+	}
+	// Should not wrap — just add the type field.
+	if _, ok := got["properties"].(map[string]any)["x"]; !ok {
+		t.Fatal("original properties lost")
+	}
+}
+
+func TestEnsureObjectRoot_Empty(t *testing.T) {
+	got := EnsureObjectRoot(map[string]any{})
+	if got["type"] != "object" {
+		t.Fatalf("expected object for empty schema, got %v", got)
+	}
+}
+
+func TestEnsureObjectRoot_ArrayType_Wraps(t *testing.T) {
+	schema := map[string]any{"type": "array", "items": map[string]any{"type": "string"}}
+	got := EnsureObjectRoot(schema)
+	if got["type"] != "object" {
+		t.Fatalf("expected object root, got %v", got["type"])
+	}
+	props := got["properties"].(map[string]any)
+	input := props["input"].(map[string]any)
+	if input["type"] != "array" {
+		t.Fatalf("wrapped schema lost type: %v", input)
+	}
+}


### PR DESCRIPTION
Fixes #92.

Kiro/Bedrock requires `toolConfig.tools.*.toolSpec.inputSchema.json.type` to be `"object"`. Anthropic's API has no such constraint, so clients — including Claude Code's built-in tools like WebSearch — may send schemas with `type:"string"`, `type:"array"`, or no type at all. kirocc passed these through unchanged, causing:

```
ValidationException: Bedrock error message: The value at
toolConfig.tools.0.toolSpec.inputSchema.json.type must be one of the following: object.
reason: TOOL_SCHEMA_INVALID
```

This surfaced to users as a 502 when Claude Code attempted a web search.

### Fix

`EnsureObjectRoot()` is called after `SanitizeJSONSchema` in `ConvertTools`:

- **Root type is already `"object"`** → pass through unchanged
- **Root type is some other value** (e.g. `"string"`, `"array"`) → wrap in `{"type":"object","properties":{"input": <original>}}`
- **No type at all** (bare `{}` or combinators-only) → add `"type":"object"` in place
- **Empty schema** → `{"type":"object","properties":{}}`

Deliberately applied only at the root (in `ConvertTools`), not during recursive sanitization of nested properties — those are allowed to be non-object.

### Tests

5 new test cases covering each branch. The wrapping is lossy in principle, but for server-defined tools (WebSearch, etc.) the model already knows the real schema from training, so the envelope satisfies validation without altering semantics.

### Note

The `internal/models` test failure (`TestResolve/claude-haiku-4.5`) is pre-existing on `main` and unrelated to this change — it appears to be a stale test expectation after the haiku model name mapping was updated.