### PR TITLE
feat(models): add GPT 5.6 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,13 @@ Listens on `http://127.0.0.1:3456` by default.
 ```bash
 export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 export ANTHROPIC_AUTH_TOKEN=dummy
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1   # optional: adds kirocc's models to the /model picker
 claude
 ```
 
 `ANTHROPIC_AUTH_TOKEN` is required by Claude Code but not used for authentication by kirocc (credentials are read from Kiro CLI's DB). Any non-empty value works unless `-api-key` is set.
+
+`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` makes Claude Code fetch `GET /v1/models` from kirocc and list the results in the `/model` picker under "From gateway" — including the GPT 5.6 models via their `claude-gpt-5.6-*` aliases (see [Model picker integration](#model-picker-integration-discovery-aliases)).
 
 ### Use with a Kiro API key
 
@@ -73,6 +76,7 @@ kirocc                               # no Kiro CLI login or database needed
 ```
 
 When `KIRO_API_KEY` is set:
+
 - The SQLite credential database is **never opened** — kirocc does not need Kiro CLI installed
 - No token refresh occurs — the key is presented directly to the Kiro API
 - A revoked key surfaces as a 401 from the API at request time
@@ -88,7 +92,7 @@ export ANTHROPIC_AUTH_TOKEN=dummy
 claude
 ```
 
-API keys are available for Kiro Pro, Pro+, Pro Max, and Power subscribers. On group subscriptions, an administrator must enable key generation in *Settings → Kiro settings → Enable users to generate API keys*. Create keys at [app.kiro.dev](https://app.kiro.dev) → API Keys.
+API keys are available for Kiro Pro, Pro+, Pro Max, and Power subscribers. On group subscriptions, an administrator must enable key generation in _Settings → Kiro settings → Enable users to generate API keys_. Create keys at [app.kiro.dev](https://app.kiro.dev) → API Keys.
 
 ### Command-line options
 
@@ -283,6 +287,51 @@ Per-model allowed effort levels:
 
 `thinking.budget_tokens` is accepted in the request but no longer affects behavior; reasoning depth is conveyed entirely through `effort`.
 
+#### GPT 5.6 models (reasoning schema)
+
+The GPT 5.6 family (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) uses a different `additionalModelRequestFields` schema — `reasoning.effort` instead of `output_config.effort`:
+
+```json
+{
+  "conversationState": { "...": "..." },
+  "additionalModelRequestFields": {
+    "reasoning": { "effort": "high" }
+  }
+}
+```
+
+GPT-specific effort rules:
+
+- No `thinking` field and no explicit effort → the field is omitted entirely (the backend defaults to `high`, matching kiro-cli behavior)
+- `thinking.type: "enabled"` / `"adaptive"` → still omitted (= backend default `high`); no downgrade to `medium`
+- `thinking.type: "disabled"` → `reasoning.effort: "none"` (takes precedence over an explicit effort)
+- Explicit `output_config.effort` → validated against the GPT enum (`none`, `low`, `medium`, `high`, `xhigh`, `max`) and forwarded as `reasoning.effort`
+
+GPT reasoning streams as opaque `redacted_thinking` blocks (base64 blobs, no visible thinking text). The blob arrives **after** text/tool_use in the upstream stream and is surfaced to the client in that order. During tool-use continuations the client must send the `redacted_thinking` block back; kirocc replays it as `reasoningContent.redactedContent` in the request history only while that tool round is in flight.
+
+The `[1m]` suffix and `context-1m` header are not supported for GPT models (`gpt-5.6-sol[1m]` does not resolve). Context window is 272k input / 128k output; limits are enforced by the backend, not the proxy.
+
+#### Model picker integration (discovery aliases)
+
+Claude Code's [gateway model discovery](https://code.claude.com/docs/en/llm-gateway-protocol) fetches `GET /v1/models` and adds the results to the `/model` picker — but it silently drops any ID that doesn't start with `claude` or `anthropic`, so the bare `gpt-5.6-*` IDs never appear. kirocc therefore also advertises `claude-` prefixed discovery aliases:
+
+| Alias                  | Kiro model      | Picker label    |
+| ---------------------- | --------------- | --------------- |
+| `claude-gpt-5.6-sol`   | `gpt-5.6-sol`   | `GPT 5.6 Sol`   |
+| `claude-gpt-5.6-terra` | `gpt-5.6-terra` | `GPT 5.6 Terra` |
+| `claude-gpt-5.6-luna`  | `gpt-5.6-luna`  | `GPT 5.6 Luna`  |
+
+The aliases resolve identically to the canonical IDs (same 272k window, same reasoning schema). To surface them in the picker, launch Claude Code with:
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
+export ANTHROPIC_AUTH_TOKEN=dummy
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+claude
+```
+
+The picker shows them under "From gateway" using the `display_name` values above. The canonical `gpt-5.6-*` IDs still work everywhere else (`--model gpt-5.6-sol`, `ANTHROPIC_MODEL`, direct API calls).
+
 ### Tool Search
 
 The Kiro backend does not support Anthropic's [Tool Search Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool). kirocc implements it proxy-side with an inner loop:
@@ -322,10 +371,16 @@ Supported query forms:
 | `claude-opus-4-6[1m]`   | `claude-opus-4.6`      | 1M             |
 | `claude-opus-4.5`       | `claude-opus-4.5`      | 200k           |
 | `claude-haiku-4.5`      | `claude-haiku-4.5`     | 200k           |
+| `gpt-5.6-sol`           | `gpt-5.6-sol`          | 272k           |
+| `gpt-5.6-terra`         | `gpt-5.6-terra`        | 272k           |
+| `gpt-5.6-luna`          | `gpt-5.6-luna`         | 272k           |
+| `claude-gpt-5.6-sol`    | `gpt-5.6-sol`          | 272k           |
+| `claude-gpt-5.6-terra`  | `gpt-5.6-terra`        | 272k           |
+| `claude-gpt-5.6-luna`   | `gpt-5.6-luna`         | 272k           |
 
 Opus 5, Opus 4.6, 4.7, 4.8, and Sonnet 5 always use 1M context (no 200k SKU exists upstream). Unlike Sonnet 4.6, `claude-opus-5` and `claude-sonnet-5` have no separate `-1m` SKU: each single SKU is always 1M. The explicit `[1m]`-suffixed aliases (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field — this matches Claude Code's 1M-context model state and keeps its context-window check happy without spuriously enabling extended thinking. On these always-1M models, thinking remains opt-in via the `context-1m` header or the `thinking` field; the `[1m]` suffix remains a thinking opt-in for models without a first-class always-1M alias.
 
-Unmatched `claude-*` models are passed through as-is. Non-claude models fall back to `claude-sonnet-4.6`.
+Unmatched `claude-*` models are passed through as-is. Non-claude models fall back to `claude-sonnet-4.6` (the `gpt-5.6-*` IDs and their `claude-gpt-5.6-*` discovery aliases above are explicit entries and do not fall back).
 
 #### Response model ID
 

--- a/internal/anthropic/types.go
+++ b/internal/anthropic/types.go
@@ -34,6 +34,7 @@ type ThinkingConfig struct {
 const (
 	ThinkingTypeEnabled  = "enabled"
 	ThinkingTypeAdaptive = "adaptive"
+	ThinkingTypeDisabled = "disabled"
 )
 
 // IsThinkingEnabled reports whether extended thinking is enabled in the request.
@@ -43,6 +44,14 @@ func (r *Request) IsThinkingEnabled() bool {
 		return false
 	}
 	return r.Thinking.Type == ThinkingTypeEnabled || r.Thinking.Type == ThinkingTypeAdaptive
+}
+
+// IsThinkingDisabled reports whether the request explicitly opts out of
+// reasoning via thinking.type "disabled". Distinguishing disabled from absent
+// matters for models where the opt-out must be forwarded (GPT 5.6 sends
+// reasoning.effort "none" for disabled, omits the field entirely for absent).
+func (r *Request) IsThinkingDisabled() bool {
+	return r.Thinking != nil && r.Thinking.Type == ThinkingTypeDisabled
 }
 
 // Effort returns the effort level from output_config.effort.
@@ -124,6 +133,9 @@ type ContentBlock struct {
 	// thinking block
 	Thinking  string `json:"thinking,omitempty"`
 	Signature string `json:"signature,omitempty"`
+
+	// redacted_thinking block: opaque encrypted reasoning blob (base64)
+	Data string `json:"data,omitempty"`
 
 	// tool_use / server_tool_use block (assistant)
 	ID    string         `json:"id,omitempty"`

--- a/internal/anthropic/types_test.go
+++ b/internal/anthropic/types_test.go
@@ -270,6 +270,33 @@ func TestRequest_Effort(t *testing.T) {
 	}
 }
 
+func TestRequest_ThinkingFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		thinking     *ThinkingConfig
+		wantEnabled  bool
+		wantDisabled bool
+	}{
+		{name: "absent"},
+		{name: "enabled", thinking: &ThinkingConfig{Type: ThinkingTypeEnabled}, wantEnabled: true},
+		{name: "adaptive", thinking: &ThinkingConfig{Type: ThinkingTypeAdaptive}, wantEnabled: true},
+		{name: "disabled", thinking: &ThinkingConfig{Type: ThinkingTypeDisabled}, wantDisabled: true},
+		{name: "unknown", thinking: &ThinkingConfig{Type: "unknown"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := Request{Thinking: tt.thinking}
+			if got := req.IsThinkingEnabled(); got != tt.wantEnabled {
+				t.Fatalf("IsThinkingEnabled() = %v, want %v", got, tt.wantEnabled)
+			}
+			if got := req.IsThinkingDisabled(); got != tt.wantDisabled {
+				t.Fatalf("IsThinkingDisabled() = %v, want %v", got, tt.wantDisabled)
+			}
+		})
+	}
+}
+
 func TestRequest_UnmarshalJSON_OutputConfig(t *testing.T) {
 	raw := `{
 		"model": "claude-opus-4-6",

--- a/internal/app/messages/effort.go
+++ b/internal/app/messages/effort.go
@@ -27,7 +27,9 @@ func formatContextWindow(size int) string {
 const defaultThinkingEffort = models.EffortMedium
 
 // resolveEffort maps the request's reasoning intent to a native effort level the
-// resolved Kiro model accepts. Precedence:
+// resolved Kiro model accepts.
+//
+// Claude (output_config style) precedence:
 //
 //  1. An explicit, recognized output_config.effort wins (validated/clamped to
 //     the model's enum; xhigh on a 4-value model clamps to max).
@@ -36,12 +38,24 @@ const defaultThinkingEffort = models.EffortMedium
 //  3. Otherwise (and for unrecognized or unsupported effort), return "" so
 //     additionalModelRequestFields is omitted.
 //
+// GPT 5.6 (reasoning style) differs deliberately:
+//
+//   - thinking.type disabled → "none" (explicit opt-out, wins over explicit effort)
+//   - explicit output_config.effort → validated as usual
+//   - thinking enabled/absent → "" (field omitted; the backend default is high,
+//     matching kiro-cli, which never sends the field)
+//
 // An explicit but unrecognized effort is dropped without invoking the thinking
 // fallback — the client asked for something specific that we couldn't honor, so
 // we don't silently substitute a guess.
 func resolveEffort(ctx context.Context, kiroModel string, req *anthropic.Request, thinking bool) string {
 	_, short := logging.TraceIDs(ctx)
 	requested := req.Effort()
+	reasoningStyle := models.IsReasoningModel(kiroModel)
+
+	if reasoningStyle && req.IsThinkingDisabled() {
+		return models.ResolveEffort(kiroModel, models.EffortNone)
+	}
 
 	if requested != "" {
 		resolved := models.ResolveEffort(kiroModel, requested)
@@ -56,6 +70,12 @@ func resolveEffort(ctx context.Context, kiroModel string, req *anthropic.Request
 			}
 		}
 		return resolved
+	}
+
+	// Reasoning-style models omit the field for enabled/absent: the backend
+	// default (high) already exceeds defaultThinkingEffort.
+	if reasoningStyle {
+		return ""
 	}
 
 	if thinking {

--- a/internal/app/messages/effort_test.go
+++ b/internal/app/messages/effort_test.go
@@ -10,46 +10,63 @@ import (
 
 func TestResolveEffort(t *testing.T) {
 	tests := []struct {
-		name      string
-		kiroModel string
-		effort    string // request output_config.effort
-		thinking  bool   // resolved thinking flag (type/[1m]/context-1m)
-		want      string
+		name         string
+		kiroModel    string
+		effort       string // request output_config.effort
+		thinking     bool   // resolved thinking flag (type/[1m]/context-1m)
+		want         string
+		thinkingType string // request thinking.type ("" = absent)
 	}{
 		// Explicit effort passes through (validated against the model enum).
-		{"explicit max on opus-5", "claude-opus-5", "max", false, "max"},
-		{"explicit xhigh on opus-5", "claude-opus-5", "xhigh", true, "xhigh"},
-		{"explicit max on opus-4.8", "claude-opus-4.8", "max", false, "max"},
-		{"explicit xhigh on opus-4.8", "claude-opus-4.8", "xhigh", true, "xhigh"},
-		{"explicit xhigh clamps on sonnet-4.6", "claude-sonnet-4.6", "xhigh", false, "max"},
+		{"explicit max on opus-5", "claude-opus-5", "max", false, "max", ""},
+		{"explicit xhigh on opus-5", "claude-opus-5", "xhigh", true, "xhigh", ""},
+		{"explicit max on opus-4.8", "claude-opus-4.8", "max", false, "max", ""},
+		{"explicit xhigh on opus-4.8", "claude-opus-4.8", "xhigh", true, "xhigh", ""},
+		{"explicit xhigh clamps on sonnet-4.6", "claude-sonnet-4.6", "xhigh", false, "max", ""},
 		// sonnet-5 is the first Sonnet with a 5-value enum: xhigh is honored, not clamped.
-		{"explicit xhigh honored on sonnet-5", "claude-sonnet-5", "xhigh", false, "xhigh"},
-		{"explicit high on sonnet-5", "claude-sonnet-5", "high", false, "high"},
+		{"explicit xhigh honored on sonnet-5", "claude-sonnet-5", "xhigh", false, "xhigh", ""},
+		{"explicit high on sonnet-5", "claude-sonnet-5", "high", false, "high", ""},
 
 		// No effort + no thinking: nothing sent.
-		{"no effort no thinking", "claude-opus-4.8", "", false, ""},
+		{"no effort no thinking", "claude-opus-4.8", "", false, "", ""},
 
 		// No effort but thinking enabled: fall back to the default effort so the
 		// reasoning request still reaches the backend natively.
-		{"thinking only, effort-capable opus-5", "claude-opus-5", "", true, models.EffortMedium},
-		{"thinking only, effort-capable opus-4.8", "claude-opus-4.8", "", true, models.EffortMedium},
-		{"thinking only, effort-capable sonnet-4.6", "claude-sonnet-4.6", "", true, models.EffortMedium},
+		{"thinking only, effort-capable opus-5", "claude-opus-5", "", true, models.EffortMedium, ""},
+		{"thinking only, effort-capable opus-4.8", "claude-opus-4.8", "", true, models.EffortMedium, ""},
+		{"thinking only, effort-capable sonnet-4.6", "claude-sonnet-4.6", "", true, models.EffortMedium, ""},
 
 		// Thinking enabled but model has no effort schema: cannot express it, omit.
-		{"thinking only, unsupported model", "claude-opus-4.5", "", true, ""},
+		{"thinking only, unsupported model", "claude-opus-4.5", "", true, "", ""},
 
 		// Explicit effort wins even when thinking is also enabled.
-		{"explicit low beats thinking default", "claude-opus-4.8", "low", true, "low"},
+		{"explicit low beats thinking default", "claude-opus-4.8", "low", true, "low", ""},
 
 		// Invalid effort value is dropped; thinking default does NOT rescue an
 		// explicitly-bad value (the explicit value was unrecognized, so we omit).
-		{"invalid effort dropped despite thinking", "claude-opus-4.8", "bogus", true, ""},
+		{"invalid effort dropped despite thinking", "claude-opus-4.8", "bogus", true, "", ""},
+
+		// GPT 5.6 (reasoning style): enabled/absent omit the field so the
+		// backend default (high) applies — never downgraded to medium.
+		{"gpt absent thinking omits effort", "gpt-5.6-sol", "", false, "", ""},
+		{"gpt enabled thinking omits effort (backend default high)", "gpt-5.6-sol", "", true, "", ""},
+		// Explicit effort still honored.
+		{"gpt explicit xhigh", "gpt-5.6-sol", "xhigh", false, "xhigh", ""},
+		{"gpt explicit low with thinking", "gpt-5.6-terra", "low", true, "low", ""},
+		// disabled → none, and it wins over explicit effort.
+		{name: "gpt disabled maps to none", kiroModel: "gpt-5.6-sol", thinkingType: anthropic.ThinkingTypeDisabled, want: "none"},
+		{name: "gpt disabled beats explicit effort", kiroModel: "gpt-5.6-luna", effort: "high", thinkingType: anthropic.ThinkingTypeDisabled, want: "none"},
+		// Claude models never receive none: disabled just means no thinking fallback.
+		{name: "claude disabled does not map to none", kiroModel: "claude-opus-4.8", thinkingType: anthropic.ThinkingTypeDisabled, want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := &anthropic.Request{}
 			if tt.effort != "" {
 				req.OutputConfig = &anthropic.OutputConfig{Effort: tt.effort}
+			}
+			if tt.thinkingType != "" {
+				req.Thinking = &anthropic.ThinkingConfig{Type: tt.thinkingType}
 			}
 			got := resolveEffort(context.Background(), tt.kiroModel, req, tt.thinking)
 			if got != tt.want {

--- a/internal/app/messages/execute.go
+++ b/internal/app/messages/execute.go
@@ -51,7 +51,7 @@ func (s *Service) callAndHandle(ctx context.Context, w http.ResponseWriter, sess
 
 	var reason string
 	if inv.req.Stream {
-		reason = s.handleStreamingResponse(ctx, session, apiResp, inv.responseModel, inv.contextWindowSize, inv.req.StopSequences, inv.req.MaxTokens, apiResp.PromptTokens, capture, inv.toolNameMap)
+		reason = s.handleStreamingResponse(ctx, session, apiResp, inv.model, inv.responseModel, inv.contextWindowSize, inv.req.StopSequences, inv.req.MaxTokens, apiResp.PromptTokens, capture, inv.toolNameMap)
 	} else {
 		reason = s.handleNonStreamingResponse(ctx, w, apiResp, inv.responseModel, inv.contextWindowSize, inv.req.StopSequences, inv.req.MaxTokens, apiResp.PromptTokens, capture, inv.toolNameMap)
 	}

--- a/internal/app/messages/response.go
+++ b/internal/app/messages/response.go
@@ -15,6 +15,7 @@ import (
 	"github.com/d-kuro/kirocc/internal/kiroclient"
 	"github.com/d-kuro/kirocc/internal/kiroproto"
 	"github.com/d-kuro/kirocc/internal/logging"
+	"github.com/d-kuro/kirocc/internal/models"
 	"github.com/d-kuro/kirocc/internal/respconv"
 )
 
@@ -28,12 +29,15 @@ func roundCredits(c float64) float64 {
 
 const retryReasonEmptyVisibleEndTurn = "empty_visible_end_turn"
 
-func (s *Service) handleStreamingResponse(ctx context.Context, session *streamSession, apiResp *kiroclient.Response, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture, toolNameMap map[string]string) string {
+func (s *Service) handleStreamingResponse(ctx context.Context, session *streamSession, apiResp *kiroclient.Response, kiroModel, model string, contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int, capture *upstreamAttemptCapture, toolNameMap map[string]string) string {
 	traceID, short := logging.TraceIDs(ctx)
 
 	sw := respconv.NewSSEWriter(ctx, session, model, contextWindowSize, stopSequences, maxTokens, preCountedInputTokens)
 	sw.OnVisibleOutput = session.Promote
 	sw.SetToolNameMap(toolNameMap)
+	// GPT 5.6 delivers a trailing redacted reasoning blob after tool_use, so
+	// the stream must keep draining past an adapter-side stop to capture it.
+	sw.SetDrainOnStop(models.IsReasoningModel(kiroModel))
 	// The kiro client has already confirmed HTTP 200 + event-stream at this
 	// point, and NewSSEWriter has installed downstream SSE headers.
 	session.Start()
@@ -78,6 +82,14 @@ func (s *Service) handleStreamingResponse(ctx context.Context, session *streamSe
 		}
 		if !shouldStop {
 			return false
+		}
+		// Upstream error frames terminate as errors even when a local stop is
+		// already latched (e.g. an exception arriving mid-drain after a GPT
+		// tool-use max_tokens stop) — otherwise the truncated stream would be
+		// reported as a normal local stop without Finish or an error SSE.
+		if e.Type == kiroproto.EventInvalidState || e.Type == kiroproto.EventException {
+			streamErr = true
+			return true
 		}
 		// Distinguish adapter-side stop (Finish already called) from error.
 		// Closing the upstream body immediately on localStop avoids paying

--- a/internal/app/messages/toolsearch.go
+++ b/internal/app/messages/toolsearch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/d-kuro/kirocc/internal/httpx"
 	"github.com/d-kuro/kirocc/internal/kiroproto"
 	"github.com/d-kuro/kirocc/internal/logging"
+	"github.com/d-kuro/kirocc/internal/models"
 	"github.com/d-kuro/kirocc/internal/reqconv"
 	"github.com/d-kuro/kirocc/internal/respconv"
 	"github.com/d-kuro/kirocc/internal/toolsearch"
@@ -82,6 +83,7 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, session *s
 
 	sw := respconv.NewSSEWriter(ctx, session, o.responseModel, o.contextWindowSize, o.req.StopSequences, o.req.MaxTokens, 0)
 	sw.OnVisibleOutput = session.Promote
+	sw.SetDrainOnStop(models.IsReasoningModel(o.buildOpts.ModelID))
 
 	msgs := slices.Clone(o.req.Messages)
 
@@ -165,6 +167,13 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, session *s
 			}
 			if !shouldStop {
 				return false
+			}
+			// Upstream error frames terminate as errors even when a local
+			// stop is already latched (e.g. an exception arriving mid-drain
+			// after a GPT tool-use max_tokens stop).
+			if e.Type == kiroproto.EventException || e.Type == kiroproto.EventInvalidState {
+				streamErr = true
+				return true
 			}
 			if sw.LocalStop() {
 				localStop = true
@@ -251,7 +260,7 @@ func (o *toolSearchOrchestrator) handleStreaming(ctx context.Context, session *s
 			return ""
 		}
 
-		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr, nameMap)
+		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr, nameMap, sw.RedactedContents())
 	}
 
 	// Max rounds reached without normal completion.
@@ -387,7 +396,7 @@ func (o *toolSearchOrchestrator) handleNonStreaming(ctx context.Context, w http.
 			})
 		}
 
-		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr, nameMap)
+		msgs = o.appendSearchMessages(msgs, srvToolUseID, searchInput, results, searchErr, nameMap, acc.RedactedContents())
 	}
 
 	// Max rounds reached without normal completion.
@@ -437,7 +446,10 @@ func (o *toolSearchOrchestrator) executeSearch(ctx context.Context, short string
 // appendSearchMessages appends the server_tool_use + tool_result messages to the conversation.
 // On error, the tool_result contains the error message instead of tool references.
 // Tool names in the result text are shortened via nameMap so Kiro sees consistent names.
-func (o *toolSearchOrchestrator) appendSearchMessages(msgs []anthropic.Message, srvToolUseID string, searchInput map[string]any, results []string, searchErr error, nameMap *reqconv.ToolNameMap) []anthropic.Message {
+// redacted carries the round's redacted reasoning blobs (GPT 5.6); they are
+// replayed as redacted_thinking blocks so buildHistory can attach the blob to
+// the in-flight tool round in the next request.
+func (o *toolSearchOrchestrator) appendSearchMessages(msgs []anthropic.Message, srvToolUseID string, searchInput map[string]any, results []string, searchErr error, nameMap *reqconv.ToolNameMap, redacted []string) []anthropic.Message {
 	var resultContent anthropic.MessageContent
 	var isError bool
 	if searchErr != nil {
@@ -451,12 +463,15 @@ func (o *toolSearchOrchestrator) appendSearchMessages(msgs []anthropic.Message, 
 		}
 		resultContent = anthropic.MessageContent{Text: "Found tools: " + strings.Join(shortened, ", ")}
 	}
+	assistantBlocks := make([]anthropic.ContentBlock, 0, len(redacted)+1)
+	for _, data := range redacted {
+		assistantBlocks = append(assistantBlocks, anthropic.ContentBlock{Type: anthropic.BlockTypeRedactedThinking, Data: data})
+	}
+	assistantBlocks = append(assistantBlocks, anthropic.ContentBlock{Type: anthropic.BlockTypeServerToolUse, ID: srvToolUseID, Name: toolsearch.KiroToolSearchName, Input: searchInput})
 	return append(msgs,
 		anthropic.Message{
-			Role: "assistant",
-			Content: anthropic.MessageContent{Blocks: []anthropic.ContentBlock{
-				{Type: anthropic.BlockTypeServerToolUse, ID: srvToolUseID, Name: toolsearch.KiroToolSearchName, Input: searchInput},
-			}},
+			Role:    "assistant",
+			Content: anthropic.MessageContent{Blocks: assistantBlocks},
 		},
 		anthropic.Message{
 			Role: "user",

--- a/internal/app/messages/toolsearch_test.go
+++ b/internal/app/messages/toolsearch_test.go
@@ -1,8 +1,12 @@
 package messages
 
 import (
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/d-kuro/kirocc/internal/anthropic"
+	"github.com/d-kuro/kirocc/internal/reqconv"
 )
 
 func TestParseToolSearchInput(t *testing.T) {
@@ -60,6 +64,62 @@ func TestParseToolSearchInput(t *testing.T) {
 			}
 			if maxResults != tt.wantMax {
 				t.Errorf("maxResults: got %d, want %d", maxResults, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestAppendSearchMessages_RedactedThinkingReplay(t *testing.T) {
+	o := &toolSearchOrchestrator{}
+	nameMap := reqconv.NewToolNameMap()
+
+	tests := []struct {
+		name      string
+		redacted  []string
+		wantBlobs []string
+	}{
+		{
+			name:      "no blobs",
+			redacted:  nil,
+			wantBlobs: nil,
+		},
+		{
+			name:      "single blob replayed",
+			redacted:  []string{"blob-1"},
+			wantBlobs: []string{"blob-1"},
+		},
+		{
+			name:      "multiple blobs kept as separate blocks",
+			redacted:  []string{"blob-1", "blob-2"},
+			wantBlobs: []string{"blob-1", "blob-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs := o.appendSearchMessages(nil, "srvtoolu_x", map[string]any{"query": "q"}, []string{"tool_a"}, nil, nameMap, tt.redacted)
+			if len(msgs) != 2 {
+				t.Fatalf("len(msgs) = %d, want 2", len(msgs))
+			}
+			assistant := msgs[0]
+			if assistant.Role != "assistant" {
+				t.Fatalf("first message role = %q, want assistant", assistant.Role)
+			}
+			var gotBlobs []string
+			var hasServerToolUse bool
+			for _, b := range assistant.Content.Blocks {
+				switch b.Type {
+				case anthropic.BlockTypeRedactedThinking:
+					gotBlobs = append(gotBlobs, b.Data)
+				case anthropic.BlockTypeServerToolUse:
+					hasServerToolUse = true
+				}
+			}
+			if !hasServerToolUse {
+				t.Fatal("missing server_tool_use block")
+			}
+			if !slices.Equal(gotBlobs, tt.wantBlobs) {
+				t.Fatalf("redacted blobs = %v, want %v", gotBlobs, tt.wantBlobs)
 			}
 		})
 	}

--- a/internal/e2e/gpt_test.go
+++ b/internal/e2e/gpt_test.go
@@ -1,0 +1,157 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json/v2"
+	"strings"
+	"testing"
+)
+
+// gptModel is the cheapest GPT 5.6 family model (rate 0.1) for E2E round trips.
+const gptModel = "gpt-5.6-luna"
+
+const gptToolsJSON = `[
+	{"name": "read", "description": "Read a file from disk", "input_schema": {"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}
+]`
+
+func TestE2E_GPT_TextOnly_Streaming(t *testing.T) {
+	url := newRealServer(t)
+	body := `{
+		"model": "` + gptModel + `",
+		"max_tokens": 1024,
+		"stream": true,
+		"messages": [{"role": "user", "content": "Say hello in one word"}]
+	}`
+	resp := postMessages(t, url, body)
+	defer resp.Body.Close()
+	requireStatus(t, resp, 200)
+
+	events := readSSEEvents(t, resp.Body)
+	requireSSEContains(t, events, "text")
+	requireSSEEventField(t, events, "message_delta", "stop_reason", "end_turn")
+}
+
+// TestE2E_GPT_ToolUseContinuation exercises the full GPT 5.6 tool round trip:
+// round 1 returns tool_use (call_* ID) plus a trailing redacted_thinking blob;
+// round 2 replays both with a tool_result and must complete the turn.
+func TestE2E_GPT_ToolUseContinuation(t *testing.T) {
+	url := newRealServer(t)
+
+	round1 := `{
+		"model": "` + gptModel + `",
+		"max_tokens": 2048,
+		"messages": [{"role": "user", "content": "Read the file at /tmp/test.txt using the read tool."}],
+		"tools": ` + gptToolsJSON + `
+	}`
+	resp := postMessages(t, url, round1)
+	defer resp.Body.Close()
+	requireStatus(t, resp, 200)
+
+	var result map[string]any
+	if err := json.UnmarshalRead(resp.Body, &result); err != nil {
+		t.Fatalf("decode round-1 response: %v", err)
+	}
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		t.Fatal("round-1 content is empty")
+	}
+
+	var toolUseID, redactedData string
+	for _, block := range content {
+		bm, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch bm["type"] {
+		case "tool_use":
+			toolUseID, _ = bm["id"].(string)
+		case "redacted_thinking":
+			redactedData, _ = bm["data"].(string)
+		}
+	}
+	if toolUseID == "" {
+		t.Fatalf("round-1 has no tool_use block: %v", content)
+	}
+	if !strings.HasPrefix(toolUseID, "call_") {
+		t.Errorf("tool_use ID = %q, want call_ prefix (pass-through)", toolUseID)
+	}
+	// The backend does not always emit a reasoning blob for trivial prompts;
+	// when present, the continuation below verifies the replay path.
+	if redactedData == "" {
+		t.Log("round-1 returned no redacted_thinking blob; continuing without replay")
+	}
+	if sr, _ := result["stop_reason"].(string); sr != "tool_use" {
+		t.Errorf("round-1 stop_reason = %q, want tool_use", sr)
+	}
+
+	// Round 2: replay assistant turn (redacted_thinking + tool_use) with a tool_result.
+	assistantBlocks := []map[string]any{}
+	if redactedData != "" {
+		assistantBlocks = append(assistantBlocks, map[string]any{"type": "redacted_thinking", "data": redactedData})
+	}
+	assistantBlocks = append(assistantBlocks, map[string]any{"type": "tool_use", "id": toolUseID, "name": "read", "input": map[string]any{"path": "/tmp/test.txt"}})
+	assistantContent := mustJSONString(t, assistantBlocks)
+	userContent := mustJSONString(t, []map[string]any{
+		{"type": "tool_result", "tool_use_id": toolUseID, "content": "hello from test file"},
+	})
+	round2 := `{
+		"model": "` + gptModel + `",
+		"max_tokens": 2048,
+		"messages": [
+			{"role": "user", "content": "Read the file at /tmp/test.txt using the read tool."},
+			{"role": "assistant", "content": ` + assistantContent + `},
+			{"role": "user", "content": ` + userContent + `}
+		],
+		"tools": ` + gptToolsJSON + `
+	}`
+	resp2 := postMessages(t, url, round2)
+	defer resp2.Body.Close()
+	requireStatus(t, resp2, 200)
+
+	var result2 map[string]any
+	if err := json.UnmarshalRead(resp2.Body, &result2); err != nil {
+		t.Fatalf("decode round-2 response: %v", err)
+	}
+	content2, _ := result2["content"].([]any)
+	var hasText bool
+	for _, block := range content2 {
+		bm, ok := block.(map[string]any)
+		if ok && bm["type"] == "text" {
+			hasText = true
+		}
+	}
+	if !hasText {
+		t.Errorf("round-2 has no text block: %v", content2)
+	}
+}
+
+func TestE2E_GPT_EffortNone_ThinkingDisabled(t *testing.T) {
+	url := newRealServer(t)
+	body := `{
+		"model": "` + gptModel + `",
+		"max_tokens": 512,
+		"thinking": {"type": "disabled"},
+		"messages": [{"role": "user", "content": "Say hello in one word"}]
+	}`
+	resp := postMessages(t, url, body)
+	defer resp.Body.Close()
+	requireStatus(t, resp, 200)
+
+	var result map[string]any
+	if err := json.UnmarshalRead(resp.Body, &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if content, _ := result["content"].([]any); len(content) == 0 {
+		t.Fatal("empty content")
+	}
+}
+
+func mustJSONString(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/kiroproto/types.go
+++ b/internal/kiroproto/types.go
@@ -22,15 +22,23 @@ type Payload struct {
 	AdditionalModelRequestFields *AdditionalModelRequestFields `json:"additionalModelRequestFields,omitempty"`
 }
 
-// AdditionalModelRequestFields carries model-specific request options. kiro-cli
-// 2.10.0 sends this at the request root (sibling of conversationState/profileArn)
-// and currently only populates output_config.effort.
+// AdditionalModelRequestFields carries model-specific request options at the
+// request root (sibling of conversationState/profileArn). Exactly one of
+// OutputConfig (Claude family) or Reasoning (GPT 5.6 family) may be set —
+// the backend schemas are mutually exclusive per model.
 type AdditionalModelRequestFields struct {
-	OutputConfig *OutputConfig `json:"output_config,omitempty"`
+	OutputConfig *OutputConfig    `json:"output_config,omitempty"`
+	Reasoning    *ReasoningConfig `json:"reasoning,omitempty"`
 }
 
 // OutputConfig carries the reasoning effort level (low/medium/high/xhigh/max).
 type OutputConfig struct {
+	Effort string `json:"effort,omitempty"`
+}
+
+// ReasoningConfig carries the GPT 5.6 reasoning effort level
+// (none/low/medium/high/xhigh/max).
+type ReasoningConfig struct {
 	Effort string `json:"effort,omitempty"`
 }
 
@@ -161,11 +169,21 @@ type HistoryUserInputMessage struct {
 }
 
 // AssistantResponseMessage is an assistant message within history.
+// Field declaration order is the wire order (HistoryEntry.MarshalJSONTo
+// re-marshals the struct): reasoningContent must sit between toolUses and
+// cachePoint to match kiro-cli captures.
 type AssistantResponseMessage struct {
-	MessageID  string           `json:"messageId,omitempty"`
-	Content    string           `json:"content"`
-	ToolUses   []HistoryToolUse `json:"toolUses,omitempty"`
-	CachePoint *CachePoint      `json:"cachePoint,omitempty"`
+	MessageID        string            `json:"messageId,omitempty"`
+	Content          string            `json:"content"`
+	ToolUses         []HistoryToolUse  `json:"toolUses,omitempty"`
+	ReasoningContent *ReasoningContent `json:"reasoningContent,omitempty"`
+	CachePoint       *CachePoint       `json:"cachePoint,omitempty"`
+}
+
+// ReasoningContent carries the opaque redacted reasoning blob that GPT 5.6
+// models emit and require replayed on tool-use continuation.
+type ReasoningContent struct {
+	RedactedContent string `json:"redactedContent"` // base64-encoded
 }
 
 // HistoryToolUse represents a tool call in an assistant history message.

--- a/internal/kiroproto/types_test.go
+++ b/internal/kiroproto/types_test.go
@@ -2,6 +2,7 @@ package kiroproto
 
 import (
 	"encoding/json/v2"
+	"strings"
 	"testing"
 )
 
@@ -174,6 +175,126 @@ func TestAssistantResponseMessage_WithToolUses(t *testing.T) {
 	tu := toolUses[0].(map[string]any)
 	if tu["toolUseId"] != "toolu_01" {
 		t.Fatalf("toolUseId = %v", tu["toolUseId"])
+	}
+}
+
+func TestAssistantResponseMessage_ReasoningContent(t *testing.T) {
+	tests := []struct {
+		name         string
+		arm          AssistantResponseMessage
+		wantKey      bool
+		wantKeyOrder []string // exact wire order of present keys
+	}{
+		{
+			name: "redacted content is emitted between toolUses and cachePoint",
+			arm: AssistantResponseMessage{
+				MessageID: "mid",
+				Content:   "",
+				ToolUses:  []HistoryToolUse{{ToolUseID: "call_x", Name: "read", Input: map[string]any{}}},
+				ReasoningContent: &ReasoningContent{
+					RedactedContent: "base64blob",
+				},
+				CachePoint: &CachePoint{Type: "default"},
+			},
+			wantKey:      true,
+			wantKeyOrder: []string{"messageId", "content", "toolUses", "reasoningContent", "cachePoint"},
+		},
+		{
+			name:    "nil reasoning content omits the key",
+			arm:     AssistantResponseMessage{MessageID: "mid", Content: "hi"},
+			wantKey: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.arm)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var m map[string]any
+			if err := json.Unmarshal(data, &m); err != nil {
+				t.Fatal(err)
+			}
+			_, ok := m["reasoningContent"]
+			if ok != tt.wantKey {
+				t.Fatalf("reasoningContent present = %v, want %v (json: %s)", ok, tt.wantKey, data)
+			}
+			if tt.wantKey {
+				rc := m["reasoningContent"].(map[string]any)
+				if rc["redactedContent"] != "base64blob" {
+					t.Fatalf("redactedContent = %v", rc["redactedContent"])
+				}
+			}
+			if tt.wantKeyOrder != nil {
+				assertKeyOrder(t, data, tt.wantKeyOrder)
+			}
+		})
+	}
+}
+
+// assertKeyOrder verifies top-level JSON keys appear in the given order.
+func assertKeyOrder(t *testing.T, data []byte, want []string) {
+	t.Helper()
+	s := string(data)
+	pos := -1
+	for _, key := range want {
+		idx := strings.Index(s, `"`+key+`"`)
+		if idx < 0 {
+			t.Fatalf("key %q not found in %s", key, s)
+		}
+		if idx < pos {
+			t.Fatalf("key %q out of order in %s", key, s)
+		}
+		pos = idx
+	}
+}
+
+func TestAdditionalModelRequestFields_MarshalEffortSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   AdditionalModelRequestFields
+		wantKeys []string
+		banKeys  []string
+	}{
+		{
+			name:     "reasoning only",
+			fields:   AdditionalModelRequestFields{Reasoning: &ReasoningConfig{Effort: "none"}},
+			wantKeys: []string{"reasoning"},
+			banKeys:  []string{"output_config"},
+		},
+		{
+			name:     "output_config only",
+			fields:   AdditionalModelRequestFields{OutputConfig: &OutputConfig{Effort: "high"}},
+			wantKeys: []string{"output_config"},
+			banKeys:  []string{"reasoning"},
+		},
+		{
+			name:    "empty object",
+			fields:  AdditionalModelRequestFields{},
+			banKeys: []string{"output_config", "reasoning"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.fields)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var m map[string]any
+			if err := json.Unmarshal(data, &m); err != nil {
+				t.Fatal(err)
+			}
+			for _, k := range tt.wantKeys {
+				if _, ok := m[k]; !ok {
+					t.Fatalf("missing key %q in %s", k, data)
+				}
+			}
+			for _, k := range tt.banKeys {
+				if _, ok := m[k]; ok {
+					t.Fatalf("unexpected key %q in %s", k, data)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/models/effort.go
+++ b/internal/models/effort.go
@@ -11,9 +11,14 @@ const (
 	EffortMax    = "max"
 )
 
-// effortRank is the global low→high ordering of valid effort levels. It is the
-// single source of truth for which strings are valid effort values; anything not
-// present here is treated as an unrecognized value and dropped.
+// EffortNone disables reasoning on models whose enum lists it (GPT 5.6 family).
+// Deliberately NOT in effortRank: it is not a rankable level, and adding it
+// there would make ResolveEffort clamp "none" to "max" on Claude models.
+const EffortNone = "none"
+
+// effortRank is the global low→high ordering of rankable effort levels.
+// Model-specific unranked values such as "none" are accepted only through the
+// capability's explicit enum.
 var effortRank = map[string]int{
 	EffortLow:    0,
 	EffortMedium: 1,
@@ -22,22 +27,48 @@ var effortRank = map[string]int{
 	EffortMax:    4,
 }
 
-// effortEnums maps each effort-capable Kiro model to its allowed effort levels,
-// matching the per-model additionalModelRequestFieldsSchema advertised by
-// ListAvailableModels (kiro-cli 2.10.0). Models absent from this table do not
-// support effort and must omit additionalModelRequestFields entirely.
-var effortEnums = map[string][]string{
+type effortCapability struct {
+	// reasoning marks the GPT 5.6 reasoning-style family; see IsReasoningModel.
+	reasoning bool
+	levels    []string
+}
+
+var (
+	fullEffortLevels      = []string{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax}
+	standardEffortLevels  = []string{EffortLow, EffortMedium, EffortHigh, EffortMax}
+	reasoningEffortLevels = []string{EffortNone, EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax}
+)
+
+// effortCapabilities is the single source of truth for both the wire schema
+// and accepted effort values of each upstream model. Models absent from this
+// table do not support effort.
+var effortCapabilities = map[string]effortCapability{
 	// 5-value enum (includes xhigh); 128000 max-output models.
-	"claude-opus-5":   {EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
-	"claude-opus-4.8": {EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
-	"claude-opus-4.7": {EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+	"claude-opus-5":   {levels: fullEffortLevels},
+	"claude-opus-4.8": {levels: fullEffortLevels},
+	"claude-opus-4.7": {levels: fullEffortLevels},
 	// 5-value enum (includes xhigh); 64000 max-output model.
-	"claude-sonnet-5": {EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+	"claude-sonnet-5": {levels: fullEffortLevels},
 	// 4-value enum (no xhigh); 64000 max-output models.
-	"claude-opus-4.6":      {EffortLow, EffortMedium, EffortHigh, EffortMax},
-	"claude-sonnet-4.6":    {EffortLow, EffortMedium, EffortHigh, EffortMax},
-	"claude-opus-4.6-1m":   {EffortLow, EffortMedium, EffortHigh, EffortMax},
-	"claude-sonnet-4.6-1m": {EffortLow, EffortMedium, EffortHigh, EffortMax},
+	"claude-opus-4.6":      {levels: standardEffortLevels},
+	"claude-sonnet-4.6":    {levels: standardEffortLevels},
+	"claude-opus-4.6-1m":   {levels: standardEffortLevels},
+	"claude-sonnet-4.6-1m": {levels: standardEffortLevels},
+	// GPT 5.6 family: 6-value enum including none (reasoning.effort schema);
+	// 128000 max-output models.
+	"gpt-5.6-sol":   {reasoning: true, levels: reasoningEffortLevels},
+	"gpt-5.6-terra": {reasoning: true, levels: reasoningEffortLevels},
+	"gpt-5.6-luna":  {reasoning: true, levels: reasoningEffortLevels},
+}
+
+// IsReasoningModel reports whether the resolved Kiro model belongs to a
+// reasoning-style family (GPT 5.6). These models share a bundle of behaviors:
+// the reasoning.effort wire schema (instead of output_config.effort), opaque
+// redacted_thinking blobs that trail tool_use and must be drained and
+// replayed, and no [1m]/thinking suffix support. Unknown models are
+// Claude-compatible (false).
+func IsReasoningModel(kiroModel string) bool {
+	return effortCapabilities[kiroModel].reasoning
 }
 
 // ResolveEffort returns the effort level to send for the given Kiro model.
@@ -52,15 +83,17 @@ func ResolveEffort(kiroModel, requested string) string {
 	if requested == "" {
 		return ""
 	}
-	if _, valid := effortRank[requested]; !valid {
-		return "" // unrecognized value: drop rather than guess.
-	}
-	enum, ok := effortEnums[kiroModel]
+	capability, ok := effortCapabilities[kiroModel]
 	if !ok {
 		return ""
 	}
-	if slices.Contains(enum, requested) {
+	// Enum membership wins: accepts model-specific values like "none" that
+	// are not rankable levels.
+	if slices.Contains(capability.levels, requested) {
 		return requested
 	}
-	return enum[len(enum)-1]
+	if _, valid := effortRank[requested]; !valid {
+		return "" // unrecognized value: drop rather than guess.
+	}
+	return capability.levels[len(capability.levels)-1]
 }

--- a/internal/models/effort_test.go
+++ b/internal/models/effort_test.go
@@ -44,6 +44,19 @@ func TestResolveEffort(t *testing.T) {
 		// Empty requested effort: nothing sent regardless of model.
 		{"opus-4.8 empty", "claude-opus-4.8", "", ""},
 		{"unsupported empty", "claude-opus-4.5", "", ""},
+
+		// GPT 5.6 family: 6-value enum including none.
+		{"gpt-5.6-sol none", "gpt-5.6-sol", "none", "none"},
+		{"gpt-5.6-sol low", "gpt-5.6-sol", "low", "low"},
+		{"gpt-5.6-sol xhigh", "gpt-5.6-sol", "xhigh", "xhigh"},
+		{"gpt-5.6-sol max", "gpt-5.6-sol", "max", "max"},
+		{"gpt-5.6-terra none", "gpt-5.6-terra", "none", "none"},
+		{"gpt-5.6-luna high", "gpt-5.6-luna", "high", "high"},
+		{"gpt-5.6-luna invalid dropped", "gpt-5.6-luna", "bogus", ""},
+
+		// none must never leak into Claude models (would clamp to max).
+		{"opus-4.8 none dropped not clamped", "claude-opus-4.8", "none", ""},
+		{"sonnet-4.6 none dropped not clamped", "claude-sonnet-4.6", "none", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -13,6 +13,12 @@ type Mapping struct {
 	Kiro              string `json:"kiro"`
 	Kiro1M            string `json:"kiro_1m,omitempty"`
 	ContextWindowSize int    `json:"context_window_size,omitzero"` // 0 means use default
+	// DisplayName, when set, additionally advertises the Anthropic ID in
+	// /v1/models with this display_name. Used for discovery aliases: Claude
+	// Code's gateway model discovery drops IDs not starting with
+	// claude/anthropic, so non-claude upstream models need a claude- prefixed
+	// alias to appear in the model picker.
+	DisplayName string `json:"display_name,omitempty"`
 }
 
 const ThinkingSuffix = "[1m]"
@@ -56,6 +62,17 @@ var modelMapOrdered = []Mapping{
 	{Anthropic: "claude-opus-4-6", Kiro: "claude-opus-4.6", Kiro1M: "claude-opus-4.6"},
 	{Anthropic: "claude-opus-4.5", Kiro: "claude-opus-4.5"},
 	{Anthropic: "claude-haiku-4.5", Kiro: "claude-haiku-4.5"},
+	// GPT 5.6 family (Kiro backend, reasoning.effort schema, 272k input window).
+	// No [1m] aliases: these models have a fixed 272k window and no 1M variant.
+	{Anthropic: "gpt-5.6-sol", Kiro: "gpt-5.6-sol", ContextWindowSize: 272_000},
+	{Anthropic: "gpt-5.6-terra", Kiro: "gpt-5.6-terra", ContextWindowSize: 272_000},
+	{Anthropic: "gpt-5.6-luna", Kiro: "gpt-5.6-luna", ContextWindowSize: 272_000},
+	// Discovery aliases: claude- prefixed IDs that pass Claude Code's gateway
+	// model discovery filter (which drops IDs not starting with
+	// claude/anthropic), so the GPT models appear in the /model picker.
+	{Anthropic: "claude-gpt-5.6-sol", Kiro: "gpt-5.6-sol", ContextWindowSize: 272_000, DisplayName: "GPT 5.6 Sol"},
+	{Anthropic: "claude-gpt-5.6-terra", Kiro: "gpt-5.6-terra", ContextWindowSize: 272_000, DisplayName: "GPT 5.6 Terra"},
+	{Anthropic: "claude-gpt-5.6-luna", Kiro: "gpt-5.6-luna", ContextWindowSize: 272_000, DisplayName: "GPT 5.6 Luna"},
 }
 
 const DefaultModel = "claude-sonnet-4.6"
@@ -155,12 +172,22 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 	}
 
 	// Tier 2: strip `[1m]` (treated as thinking opt-in) and retry.
+	// Reasoning-style models (GPT 5.6) are excluded — they have no 1M variant
+	// and no thinking opt-in, so e.g. `gpt-5.6-sol[1m]` falls through to the
+	// default fallback below. Judging by the resolved Kiro model's intrinsic
+	// capability (not a per-row flag) means env aliases inherit the exclusion
+	// automatically.
+	var reasoningExcluded bool
 	if !matched {
 		if before, ok := strings.CutSuffix(model, ThinkingSuffix); ok {
 			model = before
 			thinking = true
 			for _, m := range mappings {
 				if model == m.Anthropic || model == m.Kiro {
+					if IsReasoningModel(m.Kiro) {
+						reasoningExcluded = true
+						continue
+					}
 					kiroModel = m.Kiro
 					matchedKiro1M = m.Kiro1M
 					matchedWindowSize = m.ContextWindowSize
@@ -177,7 +204,10 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 	}
 
 	if !matched {
-		if strings.HasPrefix(model, "claude-") {
+		// reasoningExcluded blocks the claude- passthrough: a claude- prefixed
+		// discovery alias to a GPT model (`claude-gpt-5.6-sol[1m]`) must not
+		// be forwarded verbatim as an unknown upstream SKU.
+		if strings.HasPrefix(model, "claude-") && !reasoningExcluded {
 			kiroModel = model
 			anthropicModel = model
 		} else {
@@ -217,16 +247,33 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 	return kiroModel, thinking, contextWindowSize, anthropicModel
 }
 
-// ListModels returns a deduplicated list of all Kiro model values from
-// modelMapOrdered plus any env overrides.
-func ListModels() []string {
+// ModelInfo is one entry served by /v1/models.
+type ModelInfo struct {
+	ID          string
+	DisplayName string // optional; picked up by Claude Code's model picker
+}
+
+// ListModels returns a deduplicated list of all model IDs to advertise in
+// /v1/models: each mapping's Kiro value, plus the Anthropic ID of any mapping
+// with a DisplayName (discovery aliases). Env overrides are included.
+func ListModels() []ModelInfo {
 	seen := make(map[string]struct{})
-	var result []string
-	for _, m := range effectiveMappings() {
-		if _, ok := seen[m.Kiro]; !ok {
-			seen[m.Kiro] = struct{}{}
-			result = append(result, m.Kiro)
+	var result []ModelInfo
+	add := func(id, displayName string) {
+		if id == "" {
+			return
 		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		result = append(result, ModelInfo{ID: id, DisplayName: displayName})
+	}
+	for _, m := range effectiveMappings() {
+		if m.DisplayName != "" {
+			add(m.Anthropic, m.DisplayName)
+		}
+		add(m.Kiro, "")
 	}
 	return result
 }

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -271,6 +271,64 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-sonnet-4-6",
 		},
 		{
+			name:               "gpt-5.6-sol resolves with 272k window",
+			model:              "gpt-5.6-sol",
+			wantKiroModel:      "gpt-5.6-sol",
+			wantContextWindow:  272_000,
+			wantAnthropicModel: "gpt-5.6-sol",
+		},
+		{
+			name:               "gpt-5.6-terra resolves with 272k window",
+			model:              "gpt-5.6-terra",
+			wantKiroModel:      "gpt-5.6-terra",
+			wantContextWindow:  272_000,
+			wantAnthropicModel: "gpt-5.6-terra",
+		},
+		{
+			name:               "gpt-5.6-luna resolves with 272k window",
+			model:              "gpt-5.6-luna",
+			wantKiroModel:      "gpt-5.6-luna",
+			wantContextWindow:  272_000,
+			wantAnthropicModel: "gpt-5.6-luna",
+		},
+		{
+			name:               "gpt-5.6-sol[1m] does not match and falls back to default",
+			model:              "gpt-5.6-sol[1m]",
+			wantThinking:       true,
+			wantKiroModel:      DefaultModel,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
+		},
+		{
+			name:               "claude-gpt-5.6-sol discovery alias resolves to gpt-5.6-sol",
+			model:              "claude-gpt-5.6-sol",
+			wantKiroModel:      "gpt-5.6-sol",
+			wantContextWindow:  272_000,
+			wantAnthropicModel: "claude-gpt-5.6-sol",
+		},
+		{
+			name:               "claude-gpt-5.6-terra discovery alias resolves to gpt-5.6-terra",
+			model:              "claude-gpt-5.6-terra",
+			wantKiroModel:      "gpt-5.6-terra",
+			wantContextWindow:  272_000,
+			wantAnthropicModel: "claude-gpt-5.6-terra",
+		},
+		{
+			name:               "claude-gpt-5.6-luna discovery alias resolves to gpt-5.6-luna",
+			model:              "claude-gpt-5.6-luna",
+			wantKiroModel:      "gpt-5.6-luna",
+			wantContextWindow:  272_000,
+			wantAnthropicModel: "claude-gpt-5.6-luna",
+		},
+		{
+			name:               "claude-gpt-5.6-sol[1m] falls back to default instead of claude passthrough",
+			model:              "claude-gpt-5.6-sol[1m]",
+			wantThinking:       true,
+			wantKiroModel:      DefaultModel,
+			wantContextWindow:  DefaultContextWindowSize,
+			wantAnthropicModel: "claude-sonnet-4-6",
+		},
+		{
 			name:               "env override custom model",
 			envMappings:        `[{"anthropic":"my-custom-model","kiro":"claude-custom-1"}]`,
 			model:              "my-custom-model",
@@ -330,7 +388,7 @@ func TestListModels(t *testing.T) {
 	tests := []struct {
 		name        string
 		envMappings string
-		checkModel  string // if set, verify this model is in the list
+		checkModel  string // if set, verify this model ID is in the list
 	}{
 		{
 			name:       "default models are deduplicated and contain DefaultModel",
@@ -343,6 +401,14 @@ func TestListModels(t *testing.T) {
 		{
 			name:       "claude-opus-5 is listed exactly once (both alias rows dedupe to one Kiro value)",
 			checkModel: "claude-opus-5",
+		},
+		{
+			name:       "canonical GPT ID is listed",
+			checkModel: "gpt-5.6-sol",
+		},
+		{
+			name:       "GPT discovery alias is listed alongside the canonical ID",
+			checkModel: "claude-gpt-5.6-sol",
 		},
 		{
 			name:        "env override model included",
@@ -366,17 +432,46 @@ func TestListModels(t *testing.T) {
 
 			// Check deduplication
 			seen := make(map[string]bool)
+			var ids []string
 			for _, m := range result {
-				if seen[m] {
-					t.Errorf("ListModels returned duplicate: %q", m)
+				if seen[m.ID] {
+					t.Errorf("ListModels returned duplicate: %q", m.ID)
 				}
-				seen[m] = true
+				seen[m.ID] = true
+				ids = append(ids, m.ID)
 			}
 
-			if tt.checkModel != "" && !slices.Contains(result, tt.checkModel) {
+			if tt.checkModel != "" && !slices.Contains(ids, tt.checkModel) {
 				t.Errorf("ListModels missing expected model %q", tt.checkModel)
 			}
 		})
+	}
+}
+
+func TestListModels_DiscoveryAliasDisplayNames(t *testing.T) {
+	t.Setenv("KIROCC_MODEL_MAPPINGS", "")
+
+	wantNames := map[string]string{
+		"claude-gpt-5.6-sol":   "GPT 5.6 Sol",
+		"claude-gpt-5.6-terra": "GPT 5.6 Terra",
+		"claude-gpt-5.6-luna":  "GPT 5.6 Luna",
+		// Canonical IDs carry no display name.
+		"gpt-5.6-sol":   "",
+		"claude-opus-5": "",
+	}
+	got := make(map[string]string)
+	for _, m := range ListModels() {
+		got[m.ID] = m.DisplayName
+	}
+	for id, want := range wantNames {
+		name, ok := got[id]
+		if !ok {
+			t.Errorf("ListModels missing %q", id)
+			continue
+		}
+		if name != want {
+			t.Errorf("ListModels %q display name = %q, want %q", id, name, want)
+		}
 	}
 }
 
@@ -390,5 +485,34 @@ func TestMapping_FieldNames(t *testing.T) {
 	}
 	if m.Kiro1M != "claude-test-kiro-1m" {
 		t.Errorf("Kiro1M = %q, want %q", m.Kiro1M, "claude-test-kiro-1m")
+	}
+}
+
+func TestIsReasoningModel_EnvAliasToGPT(t *testing.T) {
+	// An env alias must inherit the intrinsic capability of its resolved Kiro
+	// model instead of carrying a second, potentially inconsistent style value.
+	t.Setenv("KIROCC_MODEL_MAPPINGS", `[{"anthropic":"my-gpt","kiro":"gpt-5.6-sol","context_window_size":272000}]`)
+
+	kiroModel, _, _, _ := Resolve("my-gpt", false)
+	if kiroModel != "gpt-5.6-sol" {
+		t.Fatalf("Resolve(my-gpt) kiroModel = %q, want gpt-5.6-sol", kiroModel)
+	}
+	if !IsReasoningModel(kiroModel) {
+		t.Fatalf("IsReasoningModel(%q) = false, want true", kiroModel)
+	}
+}
+
+func TestResolve_EnvAliasToGPT_SuffixStillRejected(t *testing.T) {
+	// The tier-2 [1m]-strip exclusion is judged by the resolved Kiro model's
+	// intrinsic capability, so an env alias to a GPT model inherits it. Both
+	// the canonical ID and the alias must reject the suffix and fall through
+	// to the default fallback.
+	t.Setenv("KIROCC_MODEL_MAPPINGS", `[{"anthropic":"my-gpt","kiro":"gpt-5.6-sol","context_window_size":272000}]`)
+
+	for _, model := range []string{"gpt-5.6-sol[1m]", "my-gpt[1m]"} {
+		kiroModel, _, _, _ := Resolve(model, false)
+		if kiroModel != DefaultModel {
+			t.Errorf("Resolve(%q) kiroModel = %q, want default fallback %q", model, kiroModel, DefaultModel)
+		}
 	}
 }

--- a/internal/reqconv/build_payload.go
+++ b/internal/reqconv/build_payload.go
@@ -3,6 +3,7 @@ package reqconv
 import (
 	"github.com/d-kuro/kirocc/internal/anthropic"
 	"github.com/d-kuro/kirocc/internal/kiroproto"
+	"github.com/d-kuro/kirocc/internal/models"
 	"github.com/d-kuro/kirocc/internal/toolsearch"
 	"github.com/google/uuid"
 )
@@ -12,9 +13,9 @@ type BuildOptions struct {
 	ProfileARN     string
 	ModelID        string
 	ConversationID string
-	// Effort is the resolved reasoning effort level (low/medium/high/xhigh/max).
-	// Empty means the model does not support effort or none was requested, in
-	// which case additionalModelRequestFields is omitted entirely.
+	// Effort is the resolved reasoning effort level. Empty means the model does
+	// not support effort or none was requested, in which case
+	// additionalModelRequestFields is omitted entirely.
 	Effort        string
 	ToolSearchCtx *toolsearch.Context
 }
@@ -38,8 +39,17 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 	msgs := Normalize(req.Messages, hasTools)
 	historyMsgs, lastMsg := splitMessages(msgs)
 
+	// Single-pass scan of the current message for tool_results and images.
+	// The tool_result IDs also identify which trailing assistant tool round is
+	// still in flight (for redacted reasoning replay in history).
+	toolResults, images := scanCurrentMessage(lastMsg.Content)
+	currentToolResultIDs := make([]string, 0, len(toolResults))
+	for _, tr := range toolResults {
+		currentToolResultIDs = append(currentToolResultIDs, tr.ToolUseID)
+	}
+
 	// 3. Build history and place system prompt.
-	history := buildHistory(historyMsgs, nameMap)
+	history := buildHistory(historyMsgs, nameMap, currentToolResultIDs)
 	history, lastContent := placeSystemPrompt(systemPrompt, history, ExtractTextContent(lastMsg.Content))
 
 	// 4. Build currentMessage.
@@ -48,7 +58,7 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 	if len(historyMsgs) > 0 {
 		precedingToolUseIDs = extractToolUseIDs(historyMsgs[len(historyMsgs)-1])
 	}
-	userInputMessage := buildCurrentMessage(lastMsg, lastContent, options.ModelID, toolEntries, envState, precedingToolUseIDs)
+	userInputMessage := buildCurrentMessage(lastContent, options.ModelID, toolEntries, envState, toolResults, images, precedingToolUseIDs)
 
 	convState := kiroproto.ConversationState{
 		ConversationID:  options.ConversationID,
@@ -64,9 +74,13 @@ func BuildPayload(req *anthropic.Request, options BuildOptions) (*kiroproto.Payl
 		payload.ProfileARN = options.ProfileARN
 	}
 	if options.Effort != "" {
-		payload.AdditionalModelRequestFields = &kiroproto.AdditionalModelRequestFields{
-			OutputConfig: &kiroproto.OutputConfig{Effort: options.Effort},
+		amrf := &kiroproto.AdditionalModelRequestFields{}
+		if models.IsReasoningModel(options.ModelID) {
+			amrf.Reasoning = &kiroproto.ReasoningConfig{Effort: options.Effort}
+		} else {
+			amrf.OutputConfig = &kiroproto.OutputConfig{Effort: options.Effort}
 		}
+		payload.AdditionalModelRequestFields = amrf
 	}
 	return payload, nameMap, nil
 }
@@ -138,15 +152,13 @@ func placeSystemPrompt(systemPrompt string, history []kiroproto.HistoryEntry, la
 }
 
 // buildCurrentMessage constructs the Kiro UserInputMessage from the last Anthropic message.
-func buildCurrentMessage(lastMsg anthropic.Message, lastContent, modelID string, toolEntries []kiroproto.ToolEntry, envState *kiroproto.EnvState, precedingToolUseIDs []string) kiroproto.UserInputMessage {
+func buildCurrentMessage(lastContent, modelID string, toolEntries []kiroproto.ToolEntry, envState *kiroproto.EnvState, toolResults []kiroproto.ToolResult, images []kiroproto.Image, precedingToolUseIDs []string) kiroproto.UserInputMessage {
 	msg := kiroproto.UserInputMessage{
 		Content: lastContent,
 		ModelID: modelID,
 		Origin:  kiroproto.OriginKiroCLI,
 	}
 
-	// Single-pass scan of lastMsg.Content to extract both tool_results and images.
-	toolResults, images := scanCurrentMessage(lastMsg.Content)
 	toolResults = ReorderToolResults(toolResults, precedingToolUseIDs)
 	if envState != nil || len(toolEntries) > 0 || len(toolResults) > 0 {
 		// Field order matches the wire format: envState before tools.

--- a/internal/reqconv/build_payload_test.go
+++ b/internal/reqconv/build_payload_test.go
@@ -229,6 +229,168 @@ func TestBuildPayload_NoThinkingXMLInjected(t *testing.T) {
 	}
 }
 
+func TestBuildPayload_EffortReasoningStyle(t *testing.T) {
+	req := &anthropic.Request{
+		Model: "gpt-5.6-sol",
+		Messages: []anthropic.Message{
+			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
+		},
+	}
+	payload, _, err := BuildPayload(req, BuildOptions{ModelID: "gpt-5.6-sol", ConversationID: "conv-test", Effort: "none"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	amrf := payload.AdditionalModelRequestFields
+	if amrf == nil || amrf.Reasoning == nil {
+		t.Fatal("expected additionalModelRequestFields.reasoning")
+	}
+	if amrf.Reasoning.Effort != "none" {
+		t.Fatalf("effort = %q, want none", amrf.Reasoning.Effort)
+	}
+	if amrf.OutputConfig != nil {
+		t.Fatalf("output_config must not be set for reasoning style, got %+v", amrf.OutputConfig)
+	}
+}
+
+func TestBuildPayload_EffortSchemaFollowsModel(t *testing.T) {
+	tests := []struct {
+		name          string
+		modelID       string
+		effort        string
+		wantReasoning bool
+	}{
+		{
+			name:          "GPT model uses reasoning schema",
+			modelID:       "gpt-5.6-sol",
+			effort:        "none",
+			wantReasoning: true,
+		},
+		{
+			name:    "Claude model uses output_config schema",
+			modelID: "claude-opus-4.8",
+			effort:  "high",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &anthropic.Request{
+				Messages: []anthropic.Message{{
+					Role:    "user",
+					Content: anthropic.MessageContent{Text: "Hello"},
+				}},
+			}
+			payload, _, err := BuildPayload(req, BuildOptions{
+				ModelID: tt.modelID,
+				Effort:  tt.effort,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			fields := payload.AdditionalModelRequestFields
+			if fields == nil {
+				t.Fatal("additionalModelRequestFields is nil")
+			}
+			if got := fields.Reasoning != nil; got != tt.wantReasoning {
+				t.Fatalf("reasoning present = %v, want %v", got, tt.wantReasoning)
+			}
+			if got := fields.OutputConfig != nil; got == tt.wantReasoning {
+				t.Fatalf("output_config present = %v, want %v", got, !tt.wantReasoning)
+			}
+		})
+	}
+}
+
+func TestBuildPayload_RedactedThinkingReplay(t *testing.T) {
+	// Tool-use continuation: assistant tool_use + redacted_thinking, then user tool_result.
+	req := &anthropic.Request{
+		Model: "gpt-5.6-sol",
+		Tools: []anthropic.Tool{{Name: "read", InputSchema: map[string]any{"type": "object"}}},
+		Messages: []anthropic.Message{
+			{Role: "user", Content: anthropic.MessageContent{Text: "count files"}},
+			{
+				Role: "assistant",
+				Content: anthropic.MessageContent{
+					Blocks: []anthropic.ContentBlock{
+						{Type: anthropic.BlockTypeRedactedThinking, Data: "blob-abc"},
+						{Type: anthropic.BlockTypeToolUse, ID: "call_1", Name: "read", Input: map[string]any{"path": "/tmp"}},
+					},
+				},
+			},
+			{
+				Role: "user",
+				Content: anthropic.MessageContent{
+					Blocks: []anthropic.ContentBlock{
+						{Type: anthropic.BlockTypeToolResult, ToolUseID: "call_1", Content: anthropic.MessageContent{Text: "11 files"}},
+					},
+				},
+			},
+		},
+	}
+	payload, _, err := BuildPayload(req, BuildOptions{ModelID: "gpt-5.6-sol", ConversationID: "conv-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := payload.ConversationState.History
+	var arm *kiroproto.AssistantResponseMessage
+	for _, h := range history {
+		if h.AssistantResponseMessage != nil && len(h.AssistantResponseMessage.ToolUses) > 0 {
+			arm = h.AssistantResponseMessage
+		}
+	}
+	if arm == nil {
+		t.Fatal("assistant history entry with toolUses not found")
+	}
+	if arm.ReasoningContent == nil || arm.ReasoningContent.RedactedContent != "blob-abc" {
+		t.Fatalf("reasoningContent = %+v, want redactedContent blob-abc", arm.ReasoningContent)
+	}
+	// The blob must not leak into the text content.
+	if strings.Contains(arm.Content, "redacted") || strings.Contains(arm.Content, "blob-abc") {
+		t.Fatalf("content polluted by redacted block: %q", arm.Content)
+	}
+}
+
+func TestBuildPayload_RedactedThinkingOmittedOnCompletedTurn(t *testing.T) {
+	// Completed turn: assistant answered with text after the tool round.
+	// The old blob must NOT be replayed anymore.
+	req := &anthropic.Request{
+		Model: "gpt-5.6-sol",
+		Tools: []anthropic.Tool{{Name: "read", InputSchema: map[string]any{"type": "object"}}},
+		Messages: []anthropic.Message{
+			{Role: "user", Content: anthropic.MessageContent{Text: "count files"}},
+			{
+				Role: "assistant",
+				Content: anthropic.MessageContent{
+					Blocks: []anthropic.ContentBlock{
+						{Type: anthropic.BlockTypeRedactedThinking, Data: "blob-old"},
+						{Type: anthropic.BlockTypeToolUse, ID: "call_1", Name: "read", Input: map[string]any{}},
+					},
+				},
+			},
+			{
+				Role: "user",
+				Content: anthropic.MessageContent{
+					Blocks: []anthropic.ContentBlock{
+						{Type: anthropic.BlockTypeToolResult, ToolUseID: "call_1", Content: anthropic.MessageContent{Text: "11"}},
+					},
+				},
+			},
+			{Role: "assistant", Content: anthropic.MessageContent{Text: "11 files."}},
+			{Role: "user", Content: anthropic.MessageContent{Text: "thanks, next question"}},
+		},
+	}
+	payload, _, err := BuildPayload(req, BuildOptions{ModelID: "gpt-5.6-sol", ConversationID: "conv-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, h := range payload.ConversationState.History {
+		if h.AssistantResponseMessage != nil && h.AssistantResponseMessage.ReasoningContent != nil {
+			t.Fatalf("history[%d] must not carry reasoningContent on a completed turn: %+v", i, h.AssistantResponseMessage.ReasoningContent)
+		}
+	}
+}
+
 func TestBuildPayload_EffortNative(t *testing.T) {
 	req := &anthropic.Request{
 		Model: "claude-opus-4-8",
@@ -788,4 +950,78 @@ func containsStr(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestBuildPayload_RedactedThinkingReplay_PicksLastBlob(t *testing.T) {
+	// Tool-search rounds can leave intermediate-round blobs before the final
+	// round's blob in one assistant message. The blob answering the in-flight
+	// tool round arrives last, so replay must pick the LAST blob attributed
+	// to the answered round.
+	req := &anthropic.Request{
+		Model: "gpt-5.6-sol",
+		Tools: []anthropic.Tool{{Name: "read", InputSchema: map[string]any{"type": "object"}}},
+		Messages: []anthropic.Message{
+			{Role: "user", Content: anthropic.MessageContent{Text: "read the file"}},
+			{Role: "assistant", Content: anthropic.MessageContent{Blocks: []anthropic.ContentBlock{
+				{Type: anthropic.BlockTypeRedactedThinking, Data: "stale-round-blob"},
+				{Type: anthropic.BlockTypeToolUse, ID: "call_2", Name: "read", Input: map[string]any{"path": "/tmp"}},
+				{Type: anthropic.BlockTypeRedactedThinking, Data: "current-round-blob"},
+			}}},
+			{Role: "user", Content: anthropic.MessageContent{Blocks: []anthropic.ContentBlock{
+				{Type: anthropic.BlockTypeToolResult, ToolUseID: "call_2", Content: anthropic.MessageContent{Text: "ok"}},
+			}}},
+		},
+	}
+	payload, _, err := BuildPayload(req, BuildOptions{ModelID: "gpt-5.6-sol"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, h := range payload.ConversationState.History {
+		arm := h.AssistantResponseMessage
+		if arm == nil || len(arm.ToolUses) == 0 {
+			continue
+		}
+		found = true
+		if arm.ReasoningContent == nil {
+			t.Fatal("reasoningContent not replayed")
+		}
+		if got := arm.ReasoningContent.RedactedContent; got != "current-round-blob" {
+			t.Fatalf("replayed blob = %q, want current-round-blob (the last one)", got)
+		}
+	}
+	if !found {
+		t.Fatal("assistant history entry with toolUses not found")
+	}
+}
+
+func TestBuildPayload_RedactedThinkingReplay_SkipsToolSearchRoundBlob(t *testing.T) {
+	// A tool-search round's blob belongs to its server_tool_use, whose
+	// reasoning the backend already consumed. When the final tool round has
+	// no blob of its own, nothing must be replayed — sending the stale
+	// tool-search blob against the final round would be rejected upstream.
+	req := &anthropic.Request{
+		Model: "gpt-5.6-sol",
+		Tools: []anthropic.Tool{{Name: "read", InputSchema: map[string]any{"type": "object"}}},
+		Messages: []anthropic.Message{
+			{Role: "user", Content: anthropic.MessageContent{Text: "read the file"}},
+			{Role: "assistant", Content: anthropic.MessageContent{Blocks: []anthropic.ContentBlock{
+				{Type: anthropic.BlockTypeRedactedThinking, Data: "tool-search-round-blob"},
+				{Type: anthropic.BlockTypeServerToolUse, ID: "srvtoolu_1", Name: "tool_search", Input: map[string]any{"query": "read"}},
+				{Type: anthropic.BlockTypeToolUse, ID: "call_9", Name: "read", Input: map[string]any{"path": "/tmp"}},
+			}}},
+			{Role: "user", Content: anthropic.MessageContent{Blocks: []anthropic.ContentBlock{
+				{Type: anthropic.BlockTypeToolResult, ToolUseID: "call_9", Content: anthropic.MessageContent{Text: "ok"}},
+			}}},
+		},
+	}
+	payload, _, err := BuildPayload(req, BuildOptions{ModelID: "gpt-5.6-sol"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, h := range payload.ConversationState.History {
+		if arm := h.AssistantResponseMessage; arm != nil && arm.ReasoningContent != nil {
+			t.Fatalf("history[%d] replayed a stale tool-search blob: %+v", i, arm.ReasoningContent)
+		}
+	}
 }

--- a/internal/reqconv/content_text.go
+++ b/internal/reqconv/content_text.go
@@ -19,7 +19,7 @@ func ExtractTextContent(content anthropic.MessageContent) string {
 		switch b.Type {
 		case anthropic.BlockTypeText:
 			parts = append(parts, b.Text)
-		case anthropic.BlockTypeThinking, anthropic.BlockTypeToolUse, anthropic.BlockTypeToolResult, anthropic.BlockTypeImage, anthropic.BlockTypeToolReference,
+		case anthropic.BlockTypeThinking, anthropic.BlockTypeRedactedThinking, anthropic.BlockTypeToolUse, anthropic.BlockTypeToolResult, anthropic.BlockTypeImage, anthropic.BlockTypeToolReference,
 			anthropic.BlockTypeServerToolUse, anthropic.BlockTypeToolSearchToolResult:
 			// Skip — handled separately.
 		default:

--- a/internal/reqconv/history.go
+++ b/internal/reqconv/history.go
@@ -2,6 +2,7 @@ package reqconv
 
 import (
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/d-kuro/kirocc/internal/anthropic"
@@ -23,8 +24,78 @@ func extractToolUseIDs(msg anthropic.Message) []string {
 	return ids
 }
 
+// extractReplayableRedactedThinking returns the redacted reasoning blob to
+// replay for the in-flight tool round, or "" when no blob is attributable to
+// it.
+//
+// A blob is attributed to the nearest tool-call block (tool_use or
+// server_tool_use) after it, falling back to the nearest one before it — this
+// covers both kirocc's emission order (blob after its tool_use) and the
+// Anthropic replay convention (thinking blocks first). Blobs attributed to a
+// server_tool_use belong to an internal tool-search round whose reasoning the
+// backend has already consumed; replaying them against the final tool round
+// would be rejected, so they are skipped. When several blobs attribute to the
+// answered round, the last one wins (blobs are never concatenated — joining
+// base64 blobs would corrupt them).
+func extractReplayableRedactedThinking(msg anthropic.Message, answeredIDs []string) string {
+	if msg.Content.IsString() {
+		return ""
+	}
+	blocks := msg.Content.Blocks
+	answersCurrentRound := func(b anthropic.ContentBlock) bool {
+		return b.IsToolUse() && slices.Contains(answeredIDs, b.ID)
+	}
+	isToolCall := func(b anthropic.ContentBlock) bool {
+		return b.IsToolUse() || b.Type == anthropic.BlockTypeServerToolUse
+	}
+	var data string
+	for i, b := range blocks {
+		if b.Type != anthropic.BlockTypeRedactedThinking || b.Data == "" {
+			continue
+		}
+		attributed := false
+		foundNext := false
+		for j := i + 1; j < len(blocks); j++ {
+			if isToolCall(blocks[j]) {
+				attributed = answersCurrentRound(blocks[j])
+				foundNext = true
+				break
+			}
+		}
+		if !foundNext {
+			for j := i - 1; j >= 0; j-- {
+				if isToolCall(blocks[j]) {
+					attributed = answersCurrentRound(blocks[j])
+					break
+				}
+			}
+		}
+		if attributed {
+			data = b.Data
+		}
+	}
+	return data
+}
+
+// answersToolUses reports whether any of resultIDs answers one of the given
+// tool uses — i.e. the assistant's tool round is the one currently being
+// continued.
+func answersToolUses(toolUses []kiroproto.HistoryToolUse, resultIDs []string) bool {
+	for _, tu := range toolUses {
+		if slices.Contains(resultIDs, tu.ToolUseID) {
+			return true
+		}
+	}
+	return false
+}
+
 // buildHistory converts normalized Anthropic messages to Kiro history entries.
-func buildHistory(msgs []anthropic.Message, nameMap *ToolNameMap) []kiroproto.HistoryEntry {
+//
+// currentToolResultIDs are the tool_use IDs referenced by the current (last)
+// user message's tool_result blocks. A redacted reasoning blob is replayed
+// only on the trailing assistant message whose tool_use IDs those results
+// answer — captures show completed turns omit reasoningContent entirely.
+func buildHistory(msgs []anthropic.Message, nameMap *ToolNameMap, currentToolResultIDs []string) []kiroproto.HistoryEntry {
 	var history []kiroproto.HistoryEntry
 
 	for i, msg := range msgs {
@@ -76,6 +147,15 @@ func buildHistory(msgs []anthropic.Message, nameMap *ToolNameMap) []kiroproto.Hi
 			// Only real tool_use blocks are included.
 			if len(allToolUses) > 0 {
 				arm.ToolUses = allToolUses
+
+				// Replay the redacted reasoning blob only when this assistant's
+				// tool round is still in flight (the current user message
+				// answers its tool_use IDs) and it is the last assistant entry.
+				if i == len(msgs)-1 && answersToolUses(allToolUses, currentToolResultIDs) {
+					if data := extractReplayableRedactedThinking(msg, currentToolResultIDs); data != "" {
+						arm.ReasoningContent = &kiroproto.ReasoningContent{RedactedContent: data}
+					}
+				}
 			}
 
 			history = append(history, kiroproto.HistoryEntry{AssistantResponseMessage: arm})

--- a/internal/respconv/accumulator.go
+++ b/internal/respconv/accumulator.go
@@ -56,6 +56,9 @@ type responseAccumulator struct {
 	Credits    float64
 	// Signature from reasoningContentEvent.
 	Signature string
+	// Redacted reasoning blobs from reasoningContentEvent (GPT 5.6). Kept as
+	// separate blocks; base64 blobs must never be concatenated.
+	RedactedContents []string
 	// Conversation metadata.
 	ConversationID string
 	// Text presence.
@@ -96,14 +99,15 @@ func newAccumulator(contextWindowSize int, stopSequences []string, maxTokens int
 	return acc
 }
 
-// IsEmptyVisibleEndTurn reports whether the response completed with thinking
-// content but no visible text and no tool use. This indicates the upstream model
-// produced only a thinking block and the client would see an empty response.
+// IsEmptyVisibleEndTurn reports whether the response completed with reasoning
+// content (thinking text or redacted blobs) but no visible text and no tool
+// use — the client would see an empty response, so the caller retries.
 func (a *responseAccumulator) IsEmptyVisibleEndTurn() bool {
 	if a.LocalStop {
 		return false // stop_sequence/max_tokens are not empty-response cases
 	}
-	return a.ThinkingBuf.Len() > 0 && a.TextBuf.Len() == 0 && !a.HasToolUse
+	hasReasoning := a.ThinkingBuf.Len() > 0 || len(a.RedactedContents) > 0
+	return hasReasoning && a.TextBuf.Len() == 0 && !a.HasToolUse
 }
 
 // accumulateThinking applies max_tokens budget to thinking content and writes to ThinkingBuf.

--- a/internal/respconv/event_accumulator_test.go
+++ b/internal/respconv/event_accumulator_test.go
@@ -2,6 +2,7 @@ package respconv
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/d-kuro/kirocc/internal/kiroproto"
@@ -674,5 +675,87 @@ func TestAccumulator_IsEmptyVisibleEndTurn(t *testing.T) {
 				t.Errorf("IsEmptyVisibleEndTurn() = %v, want %v", got, tt.expect)
 			}
 		})
+	}
+}
+
+func TestAccumulator_RedactedContentCountsTowardUsage(t *testing.T) {
+	a := newAccumulator(272000, nil, 0, 100)
+	a.ProcessEvent(kiroproto.Event{Type: kiroproto.EventReasoningContent, RedactedContent: strings.Repeat("A", 400)})
+
+	in, out := a.resolvedUsage()
+	if in != 100 {
+		t.Fatalf("input = %d, want pre-counted 100", in)
+	}
+	if out < 1 {
+		t.Fatalf("output = %d, want >= 1 (redacted blob must count toward estimated output)", out)
+	}
+}
+
+func TestAccumulator_RedactedContentCountsTowardMaxTokensBudget(t *testing.T) {
+	// 2-token budget = 8 runes; a 400-rune blob exceeds it. The blob is never
+	// truncated (opaque base64) but must trip the budget like tool input does.
+	a := newAccumulator(272000, nil, 2, 0)
+	a.ProcessEvent(kiroproto.Event{Type: kiroproto.EventReasoningContent, RedactedContent: strings.Repeat("A", 400)})
+
+	if !a.LocalStop {
+		t.Fatal("expected LocalStop after blob exceeds max_tokens budget")
+	}
+	if a.StopReason != StopReasonMaxTokens {
+		t.Fatalf("StopReason = %q, want max_tokens", a.StopReason)
+	}
+	if len(a.RedactedContents) != 1 || len(a.RedactedContents[0]) != 400 {
+		t.Fatal("blob must be stored untruncated")
+	}
+}
+
+func TestAccumulator_RedactedContentReportsMaxTokensStop(t *testing.T) {
+	tests := []struct {
+		name           string
+		data           string
+		wantStopSignal bool
+	}{
+		{
+			name: "below budget",
+			data: strings.Repeat("A", 7),
+		},
+		{
+			name:           "at budget",
+			data:           strings.Repeat("A", 8),
+			wantStopSignal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := newAccumulator(272000, nil, 2, 0)
+			delta := a.ProcessEvent(kiroproto.Event{
+				Type:            kiroproto.EventReasoningContent,
+				RedactedContent: tt.data,
+			})
+
+			if delta.StopSignal != tt.wantStopSignal {
+				t.Fatalf("StopSignal = %v, want %v", delta.StopSignal, tt.wantStopSignal)
+			}
+			if tt.wantStopSignal && delta.StopReason != StopReasonMaxTokens {
+				t.Fatalf("StopReason = %q, want %q", delta.StopReason, StopReasonMaxTokens)
+			}
+		})
+	}
+}
+
+func TestAccumulator_TrailingBlobDoesNotOverrideStopSequence(t *testing.T) {
+	// A stop_sequence hit latches the stop reason; a trailing redacted blob
+	// that overruns the max_tokens budget afterwards must not overwrite it
+	// (first-wins), or the client would lose the stop_sequence value.
+	a := newAccumulator(272000, []string{"STOP"}, 2, 0)
+	a.ProcessEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "hi STOP"})
+	if !a.LocalStop || a.StopReason != StopReasonStopSequence {
+		t.Fatalf("precondition: LocalStop=%v StopReason=%q, want stop_sequence latch", a.LocalStop, a.StopReason)
+	}
+
+	a.ProcessEvent(kiroproto.Event{Type: kiroproto.EventReasoningContent, RedactedContent: strings.Repeat("A", 400)})
+
+	if a.StopReason != StopReasonStopSequence {
+		t.Fatalf("StopReason = %q, want stop_sequence to survive the trailing blob", a.StopReason)
 	}
 }

--- a/internal/respconv/event_processor.go
+++ b/internal/respconv/event_processor.go
@@ -3,7 +3,6 @@ package respconv
 import (
 	"encoding/json/jsontext"
 	"math"
-	"unicode/utf8"
 
 	"github.com/d-kuro/kirocc/internal/kiroproto"
 )
@@ -48,7 +47,7 @@ func (a *responseAccumulator) ProcessEvent(e kiroproto.Event) EventDelta {
 			a.Signature = e.Signature
 		}
 		if e.RedactedContent != "" {
-			d.RedactedContent = e.RedactedContent
+			a.accumulateRedacted(e.RedactedContent, &d)
 			return d
 		}
 		// Guard against double-counting: if thinking tags were already parsed
@@ -142,12 +141,7 @@ func (a *responseAccumulator) processToolUseEvent(e kiroproto.Event, d *EventDel
 	// Unlike text/thinking, tool input JSON cannot be truncated mid-stream
 	// (would produce invalid JSON), so we check the budget inline instead
 	// of using applyMaxTokensBudget which truncates at a rune boundary.
-	toolRunes := utf8.RuneCountInString(e.ToolInput)
-	a.outputRuneCount += toolRunes
-	if a.maxTokensBudget > 0 && a.outputRuneCount/4 >= a.maxTokensBudget {
-		a.LocalStop = true
-		a.StopReason = StopReasonMaxTokens
-	}
+	a.accumulateOpaqueOutput(e.ToolInput)
 	a.ToolCalls = append(a.ToolCalls, tc)
 	d.ToolStop = true
 	d.ToolUseID = e.ToolUseID

--- a/internal/respconv/nonstreaming.go
+++ b/internal/respconv/nonstreaming.go
@@ -63,6 +63,11 @@ func (n *NonStreamingAccumulator) ThinkingLen() int {
 	return n.acc.ThinkingBuf.Len()
 }
 
+// RedactedContents returns the redacted reasoning blobs accumulated so far.
+func (n *NonStreamingAccumulator) RedactedContents() []string {
+	return n.acc.RedactedContents
+}
+
 // Credits returns the per-response credit consumption from meteringEvent.
 // The bool is false if no meteringEvent was received.
 func (n *NonStreamingAccumulator) Credits() (float64, bool) {
@@ -116,6 +121,15 @@ func buildResponseFromAcc(acc *responseAccumulator, model string) (map[string]an
 			"id":    tc.ID,
 			"name":  tc.Name,
 			"input": input,
+		})
+	}
+	// Redacted reasoning blobs (GPT 5.6) arrive after text/tool_use in the
+	// upstream stream, so they close the content array — matching the
+	// streaming emission order. One block per blob, never concatenated.
+	for _, rc := range acc.RedactedContents {
+		content = append(content, map[string]any{
+			"type": anthropic.BlockTypeRedactedThinking,
+			"data": rc,
 		})
 	}
 

--- a/internal/respconv/nonstreaming_test.go
+++ b/internal/respconv/nonstreaming_test.go
@@ -6,6 +6,61 @@ import (
 	"github.com/d-kuro/kirocc/internal/kiroproto"
 )
 
+func TestBuildNonStreamingResponse_RedactedThinking(t *testing.T) {
+	// GPT 5.6 order: tool_use / text stream first, redacted blob arrives last.
+	events := []kiroproto.Event{
+		{Type: "toolUseEvent", ToolStop: true, ToolUseID: "call_1", ToolName: "read", ToolInput: `{"path":"/tmp"}`},
+		{Type: kiroproto.EventReasoningContent, RedactedContent: "blob-abc"},
+		{Type: "metadataEvent", InputTokens: 10, OutputTokens: 5},
+	}
+	resp, _ := BuildNonStreamingResponse(events, "gpt-5.6-sol", 272000, nil, 0, 0)
+	content := resp["content"].([]any)
+	if len(content) != 2 {
+		t.Fatalf("content len = %d, want 2 (tool_use + redacted_thinking): %v", len(content), content)
+	}
+	tu := content[0].(map[string]any)
+	if tu["type"] != "tool_use" || tu["id"] != "call_1" {
+		t.Fatalf("first block = %v, want tool_use call_1", tu)
+	}
+	rt := content[1].(map[string]any)
+	if rt["type"] != "redacted_thinking" || rt["data"] != "blob-abc" {
+		t.Fatalf("second block = %v, want redacted_thinking blob-abc", rt)
+	}
+	if resp["stop_reason"] != "tool_use" {
+		t.Fatalf("stop_reason = %v, want tool_use", resp["stop_reason"])
+	}
+}
+
+func TestBuildNonStreamingResponse_MultipleRedactedBlobs(t *testing.T) {
+	// Multiple blobs must stay separate blocks, never concatenated.
+	events := []kiroproto.Event{
+		{Type: kiroproto.EventReasoningContent, RedactedContent: "blob-1"},
+		{Type: "assistantResponseEvent", Content: "hi"},
+		{Type: kiroproto.EventReasoningContent, RedactedContent: "blob-2"},
+	}
+	resp, _ := BuildNonStreamingResponse(events, "gpt-5.6-sol", 272000, nil, 0, 0)
+	content := resp["content"].([]any)
+	var datas []string
+	for _, c := range content {
+		b := c.(map[string]any)
+		if b["type"] == "redacted_thinking" {
+			datas = append(datas, b["data"].(string))
+		}
+	}
+	if len(datas) != 2 || datas[0] != "blob-1" || datas[1] != "blob-2" {
+		t.Fatalf("redacted blobs = %v, want [blob-1 blob-2]", datas)
+	}
+}
+
+func TestNonStreamingAccumulator_RedactedOnlyIsEmptyVisible(t *testing.T) {
+	// A redacted-only response has no visible output → retry contract holds.
+	acc := NewNonStreamingAccumulator(272000, nil, 0, 0)
+	acc.ProcessEvent(kiroproto.Event{Type: kiroproto.EventReasoningContent, RedactedContent: "blob-only"})
+	if !acc.IsEmptyVisibleEndTurn() {
+		t.Fatal("redacted-only response must be treated as empty visible end_turn")
+	}
+}
+
 func TestBuildNonStreamingResponse_TextOnly(t *testing.T) {
 	events := []kiroproto.Event{
 		{Type: "assistantResponseEvent", Content: "Hello"},

--- a/internal/respconv/reasoning.go
+++ b/internal/respconv/reasoning.go
@@ -1,0 +1,32 @@
+package respconv
+
+import (
+	"unicode/utf8"
+)
+
+// accumulateRedacted records one opaque reasoning block and applies the same
+// output accounting used for non-truncatable tool input.
+func (a *responseAccumulator) accumulateRedacted(data string, delta *EventDelta) {
+	if data == "" {
+		return
+	}
+	a.RedactedContents = append(a.RedactedContents, data)
+	a.accumulateOpaqueOutput(data)
+	delta.RedactedContent = data
+	if a.LocalStop {
+		delta.StopSignal = true
+		delta.StopReason = a.StopReason
+	}
+}
+
+// accumulateOpaqueOutput counts output that cannot be truncated without
+// corrupting its wire representation, such as JSON tool input or base64
+// reasoning content. The stop reason is first-wins: once a local stop is
+// latched (e.g. stop_sequence), later budget overruns must not overwrite it.
+func (a *responseAccumulator) accumulateOpaqueOutput(content string) {
+	a.outputRuneCount += utf8.RuneCountInString(content)
+	if !a.LocalStop && a.maxTokensBudget > 0 && a.outputRuneCount/4 >= a.maxTokensBudget {
+		a.LocalStop = true
+		a.StopReason = StopReasonMaxTokens
+	}
+}

--- a/internal/respconv/streaming.go
+++ b/internal/respconv/streaming.go
@@ -25,6 +25,13 @@ type SSEWriter struct {
 	writeErr   error
 	acc        responseAccumulator
 
+	// drainOnStop keeps the stream draining after an adapter-side stop when a
+	// completed tool call exists, so a trailing reasoningContentEvent blob
+	// (GPT 5.6) can still be captured. Set by the caller for models that emit
+	// trailing reasoning; Claude models finish immediately to avoid paying for
+	// tokens the client will never receive.
+	drainOnStop bool
+
 	// OnVisibleOutput is called once, just before the first visible output
 	// (text delta or tool_use) is written. Used by the stream session to promote
 	// the buffered writer to direct mode.
@@ -89,8 +96,7 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 			s.writeDelta("text_delta", "text", d.TextDelta)
 		}
 		if d.StopSignal {
-			_ = s.Finish()
-			return true
+			return s.stopOrDrain()
 		}
 
 	case kiroproto.EventReasoningContent:
@@ -108,6 +114,9 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 				},
 			})
 			s.closeActiveBlock()
+			if d.StopSignal {
+				return s.stopOrDrain()
+			}
 			return false
 		}
 		if d.ThinkingDelta == "" {
@@ -115,16 +124,14 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 		}
 		s.writeThinkingDelta(d)
 		if d.StopSignal {
-			_ = s.Finish()
-			return true
+			return s.stopOrDrain()
 		}
 
 	case kiroproto.EventToolUse:
 		if d.ThinkingDelta != "" {
 			s.writeThinkingDelta(d)
 			if d.StopSignal {
-				_ = s.Finish()
-				return true
+				return s.stopOrDrain()
 			}
 			return false
 		}
@@ -155,8 +162,7 @@ func (s *SSEWriter) HandleEvent(e kiroproto.Event) bool {
 			},
 		})
 		if d.StopSignal {
-			_ = s.Finish()
-			return true
+			return s.stopOrDrain()
 		}
 
 	case kiroproto.EventInvalidState, kiroproto.EventException:
@@ -314,15 +320,47 @@ func (s *SSEWriter) HasContextUsage() bool { return s.acc.HasContextUsage }
 // The bool is false if no meteringEvent was received.
 func (s *SSEWriter) Credits() (float64, bool) { return s.acc.Credits, s.acc.HasCredits }
 
-// RecordTail forwards trailing metadata events (meteringEvent, contextUsageEvent)
-// to the inner accumulator without writing anything to the SSE stream. Used by
-// the tool-search orchestrator to keep collecting credit/context usage after the
-// upstream tool-use frame is detected, so cumulative stats remain accurate.
+// RecordTail forwards trailing metadata events (meteringEvent, contextUsageEvent,
+// reasoningContentEvent) to the inner accumulator without writing anything to
+// the SSE stream. Used by the tool-search orchestrator to keep collecting
+// credit/context usage and trailing redacted reasoning blobs after the upstream
+// tool-use frame is detected, so cumulative stats stay accurate and the blob
+// can be replayed into the next round's history.
 func (s *SSEWriter) RecordTail(e kiroproto.Event) {
 	switch e.Type {
 	case kiroproto.EventMetering, kiroproto.EventContextUsage:
 		s.acc.ProcessEvent(e)
+	case kiroproto.EventReasoningContent:
+		if e.RedactedContent != "" {
+			s.acc.ProcessEvent(e)
+		}
 	}
+}
+
+// RedactedContents returns the redacted reasoning blobs accumulated this round.
+func (s *SSEWriter) RedactedContents() []string {
+	return s.acc.RedactedContents
+}
+
+// SetDrainOnStop marks the stream as draining after an adapter-side stop when
+// a completed tool call exists. Set for models that emit a trailing
+// reasoningContentEvent blob after tool_use (GPT 5.6).
+func (s *SSEWriter) SetDrainOnStop(drain bool) {
+	s.drainOnStop = drain
+}
+
+// stopOrDrain handles an adapter-side stop signal (stop_sequence / max_tokens).
+// When drainOnStop is set and a completed tool call exists, the model may still
+// deliver a trailing reasoningContentEvent blob the client needs for
+// continuation, so the stream keeps draining; the caller's parse loop reaches
+// upstream EOF and calls Finish. Otherwise the stream finishes immediately to
+// avoid paying for tokens the client will never receive.
+func (s *SSEWriter) stopOrDrain() bool {
+	if s.drainOnStop && s.acc.HasToolUse {
+		return false
+	}
+	_ = s.Finish()
+	return true
 }
 
 // writeThinkingDelta writes a thinking_delta SSE event using direct formatting.

--- a/internal/respconv/streaming_test.go
+++ b/internal/respconv/streaming_test.go
@@ -393,3 +393,107 @@ func TestSSEWriter_ThinkingViaTags_WithRegularTool(t *testing.T) {
 		t.Fatal("expected tool_use stop_reason")
 	}
 }
+
+func TestSSEWriter_RecordTail_RedactedContent(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "gpt-5.6-sol", 272000, nil, 0, 100)
+	bodyBefore := w.Body.Len()
+	redacted := strings.Repeat("A", 400)
+
+	// Trailing redacted blob after the tool-search frame must be accumulated
+	// for next-round replay, without writing anything to the SSE stream.
+	sw.RecordTail(kiroproto.Event{Type: kiroproto.EventReasoningContent, RedactedContent: redacted})
+
+	if w.Body.Len() != bodyBefore {
+		t.Fatalf("RecordTail wrote SSE bytes (%d → %d)", bodyBefore, w.Body.Len())
+	}
+	got := sw.RedactedContents()
+	if len(got) != 1 || got[0] != redacted {
+		t.Fatalf("RedactedContents() = %v, want one 400-rune blob", got)
+	}
+	inputTokens, outputTokens := sw.Usage()
+	if inputTokens != 100 || outputTokens < 1 {
+		t.Fatalf("Usage() = (%d, %d), want (100, >=1)", inputTokens, outputTokens)
+	}
+}
+
+func TestSSEWriter_MaxTokensWithToolUse_DrainsTrailingBlob(t *testing.T) {
+	w := httptest.NewRecorder()
+	// budget 1 token = 4 runes; the tool input exceeds it → LocalStop.
+	sw := NewSSEWriter(context.Background(), w, "gpt-5.6-sol", 272000, nil, 1, 0)
+	sw.SetDrainOnStop(true)
+
+	stopped := sw.HandleEvent(kiroproto.Event{Type: "toolUseEvent", ToolStop: true, ToolUseID: "call_1", ToolName: "read", ToolInput: `{"path":"/tmp/somewhere"}`})
+	if stopped {
+		t.Fatal("HandleEvent must not terminate on max_tokens when a completed tool call exists (drain trailing blob)")
+	}
+	if !sw.LocalStop() {
+		t.Fatal("expected LocalStop after budget exceeded")
+	}
+	// Trailing blob arrives after the tool_use frame — must still be emitted.
+	sw.HandleEvent(kiroproto.Event{Type: kiroproto.EventReasoningContent, RedactedContent: "late-blob"})
+	_ = sw.Finish()
+
+	body := w.Body.String()
+	if !strings.Contains(body, `"redacted_thinking"`) || !strings.Contains(body, `"late-blob"`) {
+		t.Fatalf("missing trailing redacted_thinking block: %s", body)
+	}
+	if !strings.Contains(body, `"stop_reason":"max_tokens"`) {
+		t.Fatalf("stop_reason should stay max_tokens: %s", body)
+	}
+	if !strings.Contains(body, "message_stop") {
+		t.Fatalf("missing message_stop: %s", body)
+	}
+}
+
+func TestSSEWriter_MaxTokensTextOnly_StopsImmediately(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 1, 0)
+
+	stopped := sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "0123456789abcdef"})
+	if !stopped {
+		t.Fatal("text-only max_tokens must terminate the stream immediately")
+	}
+	if !strings.Contains(w.Body.String(), "message_stop") {
+		t.Fatal("Finish must have been called on immediate stop")
+	}
+}
+
+func TestSSEWriter_MaxTokensWithToolUse_NoDrainStopsImmediately(t *testing.T) {
+	// Claude models never emit a trailing reasoning blob: a completed tool
+	// call must not keep the stream draining when drainOnStop is unset.
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 1, 0)
+
+	stopped := sw.HandleEvent(kiroproto.Event{Type: "toolUseEvent", ToolStop: true, ToolUseID: "toolu_1", ToolName: "read", ToolInput: `{"path":"/tmp/somewhere"}`})
+	if !stopped {
+		t.Fatal("max_tokens with tool use must terminate immediately without drainOnStop")
+	}
+	if !strings.Contains(w.Body.String(), "message_stop") {
+		t.Fatal("Finish must have been called on immediate stop")
+	}
+}
+
+func TestSSEWriter_MaxTokensRedactedOnly_StopsImmediately(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "gpt-5.6-sol", 272000, nil, 2, 0)
+
+	stopped := sw.HandleEvent(kiroproto.Event{
+		Type:            kiroproto.EventReasoningContent,
+		RedactedContent: strings.Repeat("A", 8),
+	})
+
+	if !stopped {
+		t.Fatal("redacted-only max_tokens must terminate the stream immediately")
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"redacted_thinking"`) {
+		t.Fatalf("missing redacted_thinking block: %s", body)
+	}
+	if !strings.Contains(body, `"stop_reason":"max_tokens"`) {
+		t.Fatalf("missing max_tokens stop reason: %s", body)
+	}
+	if !strings.Contains(body, "message_stop") {
+		t.Fatalf("missing message_stop: %s", body)
+	}
+}

--- a/internal/server/e2e_response_test.go
+++ b/internal/server/e2e_response_test.go
@@ -651,3 +651,33 @@ func TestE2E_Success_DoesNotSaveFailureCapture(t *testing.T) {
 		t.Fatal("capture log should not appear on success")
 	}
 }
+
+func TestE2E_GPTDrainAfterLocalStop_UpstreamErrorEndsStream(t *testing.T) {
+	// GPT drain regression: after a tool-use max_tokens local stop, the stream
+	// keeps draining for a trailing reasoning blob. An upstream error frame
+	// arriving mid-drain must terminate the stream as an error, not be
+	// swallowed as a normal local stop that reports a clean max_tokens end.
+	toolUse := mustJSON(map[string]any{
+		"name": "read", "toolUseId": "call_1",
+		"input": `{"path":"/tmp/some/long/path/exceeding/budget"}`, "stop": true,
+	})
+	invalidState := mustJSON(map[string]string{"reason": "UNEXPECTED", "message": "boom"})
+	client := &capturingClient{events: []any{
+		"toolUseEvent", toolUse,
+		"invalidStateEvent", invalidState,
+	}}
+	srv := newE2EServer(t, client)
+	defer srv.Close()
+
+	// max_tokens: 1 → 4-rune budget; the tool input exceeds it → LocalStop.
+	body := `{"model":"gpt-5.6-sol","max_tokens":1,"messages":[{"role":"user","content":"hi"}],"tools":[{"name":"read","input_schema":{"type":"object"}}],"stream":true}`
+	resp := postMessages(t, srv.URL, body)
+	defer func() { _ = resp.Body.Close() }()
+	requireStatus(t, resp, 200)
+
+	data, _ := io.ReadAll(resp.Body)
+	sse := string(data)
+	if !strings.Contains(sse, "event: error") {
+		t.Fatalf("upstream error mid-drain was not reported as an error event: %s", sse)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -17,12 +17,16 @@ func (s *Server) handleModels(w http.ResponseWriter, _ *http.Request) {
 	data := make([]any, 0, len(modelList))
 	now := time.Now().Unix()
 	for _, m := range modelList {
-		data = append(data, map[string]any{
-			"id":       m,
+		entry := map[string]any{
+			"id":       m.ID,
 			"object":   "model",
 			"created":  now,
 			"owned_by": "kiro",
-		})
+		}
+		if m.DisplayName != "" {
+			entry["display_name"] = m.DisplayName
+		}
+		data = append(data, entry)
 	}
 	httpx.WriteJSON(w, http.StatusOK, map[string]any{
 		"object": "list",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -130,6 +130,41 @@ func TestGetModels_ContainsDefaultModel(t *testing.T) {
 	}
 }
 
+func TestGetModels_DiscoveryAliasHasDisplayName(t *testing.T) {
+	srv := newTestServer(t, "", nil)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]any
+	_ = json.UnmarshalRead(resp.Body, &result)
+	data := result["data"].([]any)
+	var alias map[string]any
+	for _, item := range data {
+		m := item.(map[string]any)
+		if m["id"] == "claude-gpt-5.6-sol" {
+			alias = m
+			break
+		}
+		// Canonical Kiro IDs must not carry a display_name.
+		if m["id"] == "gpt-5.6-sol" {
+			if _, ok := m["display_name"]; ok {
+				t.Errorf("canonical gpt-5.6-sol should not have display_name")
+			}
+		}
+	}
+	if alias == nil {
+		t.Fatal("discovery alias claude-gpt-5.6-sol not found in /v1/models")
+	}
+	if alias["display_name"] != "GPT 5.6 Sol" {
+		t.Errorf("display_name = %v, want %q", alias["display_name"], "GPT 5.6 Sol")
+	}
+}
+
 func TestCountTokens(t *testing.T) {
 	srv := newTestServer(t, "", nil)
 	defer srv.Close()
@@ -498,5 +533,56 @@ func TestIsLocalhostOrigin(t *testing.T) {
 				t.Errorf("isLocalhostOrigin(%q) = %v, want %v", tt.origin, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetModels_GPTModelsListedOnce(t *testing.T) {
+	srv := newTestServer(t, "", nil)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]any
+	_ = json.UnmarshalRead(resp.Body, &result)
+	data := result["data"].([]any)
+	counts := map[string]int{}
+	for _, item := range data {
+		m := item.(map[string]any)
+		counts[m["id"].(string)]++
+	}
+	for _, id := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		if counts[id] != 1 {
+			t.Errorf("model %q listed %d times, want exactly 1", id, counts[id])
+		}
+	}
+}
+
+func TestCountTokens_GPTModel(t *testing.T) {
+	srv := newTestServer(t, "", nil)
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/v1/messages/count_tokens",
+		"application/json",
+		strings.NewReader(`{"model":"gpt-5.6-luna","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+
+	var result map[string]any
+	_ = json.UnmarshalRead(resp.Body, &result)
+	tokens, ok := result["input_tokens"].(float64)
+	if !ok || tokens <= 0 {
+		t.Fatalf("input_tokens = %v, want > 0", result["input_tokens"])
 	}
 }


### PR DESCRIPTION
## Summary

Adds support for the GPT 5.6 family (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`)
served by the Kiro backend, including Claude Code model picker integration.

### Effort schema (`reasoning.effort`)

GPT models use `reasoning.effort` instead of `output_config.effort`, with a 6-value
enum including `none`. The schema switch, redacted-reasoning handling, and suffix
rejection are all keyed off a single `models.IsReasoningModel` predicate backed by
the effort capability table (single source of truth).

- `thinking.type: "disabled"` → `reasoning.effort: "none"`
- `thinking.type: "enabled"` / `"adaptive"` → omitted (backend defaults to `high`)
- Explicit effort is validated against the GPT enum and forwarded

### Redacted reasoning blobs

GPT reasoning streams as opaque `redacted_thinking` blobs that arrive **after**
text/tool_use:

- **Drain-on-stop**: when a tool call exists, the stream keeps draining past an
  adapter-side stop (`max_tokens` / `stop_sequence`) to capture the trailing blob.
  Claude streams still stop immediately (cost). Upstream error frames arriving
  mid-drain still terminate the stream as errors.
- **History replay**: on tool-use continuations the blob is replayed as
  `reasoningContent.redactedContent`, attributed to its tool round and only while
  that round is in flight. Blobs from tool-search rounds are skipped.

### Model picker integration (discovery aliases)

Claude Code's [gateway model discovery](https://code.claude.com/docs/en/llm-gateway-protocol)
drops `/v1/models` IDs that don't start with `claude`/`anthropic`, so bare
`gpt-5.6-*` IDs never reach the `/model` picker. This PR also advertises
`claude-gpt-5.6-*` discovery aliases with `display_name` ("GPT 5.6 Sol" etc.):

| Alias | Kiro model |
|---|---|
| `claude-gpt-5.6-sol` | `gpt-5.6-sol` |
| `claude-gpt-5.6-terra` | `gpt-5.6-terra` |
| `claude-gpt-5.6-luna` | `gpt-5.6-luna` |

The `claude-` passthrough is blocked for reasoning-excluded aliases, so
`claude-gpt-5.6-sol[1m]` falls back to the default model instead of being
forwarded as an unknown upstream SKU.

### Constraints

- No `[1m]` suffix or `context-1m` header support (`gpt-5.6-sol[1m]` does not resolve)
- Context window: 272k input / 128k output, enforced by the backend

## Testing

- `go test -race ./...` — all green, including new unit coverage for effort
  resolution, blob attribution/replay, drain-on-stop, discovery aliases, and
  `/v1/models` `display_name` output
- `make lint` — 0 issues
- E2E tests against the real Kiro API (`internal/e2e/gpt_test.go`): streaming,
  tool-use continuation with blob replay, effort levels
  (note: gpt-5.6 may omit `redactedContent` for trivial prompts, so E2E does not
  hard-assert blob presence)