### PR TITLE
Release v0.8.0

### DIFF
--- a/docs/release-notes/v0.8.0.md
+++ b/docs/release-notes/v0.8.0.md
@@ -1,0 +1,55 @@
+# Release v0.8.0
+
+## New Features
+
+### GPT 5.6 Model Support (#97)
+
+Adds support for the GPT 5.6 family served by the Kiro backend: `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
+
+#### Using GPT 5.6 with Claude Code
+
+Select a model via the environment variable or CLI flag:
+
+```bash
+ANTHROPIC_MODEL=gpt-5.6-sol claude
+# or
+claude --model gpt-5.6-sol
+```
+
+To list GPT 5.6 models in the `/model` picker, enable gateway model discovery:
+
+```bash
+CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 claude
+```
+
+The picker shows them under "From gateway" (`GPT 5.6 Sol`, `GPT 5.6 Terra`, `GPT 5.6 Luna`) via `claude-gpt-5.6-*` discovery aliases, since Claude Code's model discovery only lists IDs starting with `claude`/`anthropic`. The canonical `gpt-5.6-*` IDs still work everywhere else.
+
+#### Details
+
+- **Effort schema**: GPT models use `reasoning.effort` (6-value enum including `none`) instead of `output_config.effort`. Thinking config maps automatically: `disabled` → `none`, `enabled`/`adaptive` → backend default (`high`).
+- **Redacted reasoning blobs**: opaque `redacted_thinking` blobs that arrive after text/tool_use are captured via drain-on-stop and replayed as `reasoningContent.redactedContent` on tool-use continuations.
+
+#### Constraints
+
+- No `[1m]` suffix or `context-1m` header support (`gpt-5.6-sol[1m]` does not resolve)
+- Context window: 272k input / 128k output, enforced by the backend
+
+## Dependencies
+
+- Update modernc.org/sqlite to v1.56.0 (#94)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.8.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.7.0...v0.8.0


### PR DESCRIPTION
## Summary

Release v0.8.0

See `docs/release-notes/v0.8.0.md` for details.