### PR TITLE
feat: Kiro API region override, model discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Just set `ANTHROPIC_BASE_URL` from any Anthropic API client (e.g., Claude Code) 
 - **Automatic auth management** — Reads credentials from Kiro CLI's SQLite DB with automatic token refresh (Social / OIDC)
 - **Kiro API key authentication** — Alternatively authenticate with a `KIRO_API_KEY` (`ksk_…`) for headless environments (CI, containers) where an interactive Kiro login is not available
 - **Model mapping** — Maps Anthropic model names (e.g., `claude-sonnet-4-6`) to Kiro model names. Customizable via environment variable
+- **Automatic model discovery** — Fetches Kiro's model catalog (`ListAvailableModels`) at startup, so models Kiro launches after a kirocc release resolve with the right context window and effort levels without a code change. Built-in mappings always win; discovery only fills gaps
+- **Custom API region** — Pin the region in `runtime.<region>.kiro.dev` with `-kiro-api-region`, for accounts whose stored credential region is not one Kiro serves
 - **Extended Thinking** — Enable via the `[1m]` suffix, the `thinking` field, or `output_config.effort`. Reasoning depth travels natively as `additionalModelRequestFields.output_config.effort` (validated against each model's enum; defaults to `medium` for effort-capable models when thinking is on without an explicit effort)
 - **Tool Search** — Proxy-side implementation of Anthropic's [Tool Search Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool). Supports `tool_search_tool_regex_20251119` and `tool_search_tool_bm25_20251119` with `defer_loading` for on-demand tool discovery
 - **Prompt Caching** — Converts Anthropic tool-level `cache_control` to Kiro `cachePoint`
@@ -96,23 +98,25 @@ API keys are available for Kiro Pro, Pro+, Pro Max, and Power subscribers. On gr
 
 ### Command-line options
 
-| Flag               | Default                   | Description                                                        |
-| ------------------ | ------------------------- | ------------------------------------------------------------------ |
-| `-port`            | `3456`                    | Listen port                                                        |
-| `-host`            | `127.0.0.1`               | Bind host                                                          |
-| `-db`              | (OS-dependent, see below) | Kiro CLI SQLite DB path                                            |
-| `-api-key`         | (none)                    | API key required to access the proxy                               |
-| `-kiro-api-key`    | (none)                    | Kiro API key (`ksk_…`) for upstream authentication                 |
-| `-kiro-api-region` | `us-east-1`               | Region for Kiro API key authentication                             |
-| `-debug`           | `false`                   | Enable debug logging                                               |
-| `-log-file`        | (none)                    | Write logs to file with rotation (file-only by default)            |
-| `-log-max-size`    | `10`                      | Max log file size in MB before rotation                            |
-| `-log-max-backups` | `5`                       | Max number of old log files to retain                              |
-| `-log-max-age`     | `7`                       | Max days to retain old log files                                   |
-| `-log-compress`    | `false`                   | Compress rotated log files with gzip                               |
-| `-log-console`     | `false`                   | Also write logs to console when `-log-file` is set                 |
-| `-otel`            | `false`                   | Enable OpenTelemetry tracing (OTLP HTTP exporter)                  |
-| `-otel-body-limit` | `32768`                   | Max bytes of request body to capture in OTel spans (0 = unlimited) |
+| Flag                  | Default                   | Description                                                         |
+| --------------------- | ------------------------- | ------------------------------------------------------------------- |
+| `-port`               | `3456`                    | Listen port                                                         |
+| `-host`               | `127.0.0.1`               | Bind host                                                           |
+| `-db`                 | (OS-dependent, see below) | Kiro CLI SQLite DB path                                             |
+| `-api-key`            | (none)                    | API key required to access the proxy                                |
+| `-kiro-api-key`       | (none)                    | Kiro API key (`ksk_…`) to use instead of the Kiro CLI DB credential |
+| `-kiro-api-region`    | (credential's region)     | Region for Kiro API endpoints (`runtime.<region>.kiro.dev`)         |
+| `-model-discovery`    | `true`                    | Fetch Kiro's model catalog at startup                               |
+| `-keepalive-interval` | `15s`                     | SSE idle keep-alive interval (0 = disabled)                         |
+| `-debug`              | `false`                   | Enable debug logging                                                |
+| `-log-file`           | (none)                    | Write logs to file with rotation (file-only by default)             |
+| `-log-max-size`       | `10`                      | Max log file size in MB before rotation                             |
+| `-log-max-backups`    | `5`                       | Max number of old log files to retain                               |
+| `-log-max-age`        | `7`                       | Max days to retain old log files                                    |
+| `-log-compress`       | `false`                   | Compress rotated log files with gzip                                |
+| `-log-console`        | `false`                   | Also write logs to console when `-log-file` is set                  |
+| `-otel`               | `false`                   | Enable OpenTelemetry tracing (OTLP HTTP exporter)                   |
+| `-otel-body-limit`    | `32768`                   | Max bytes of request body to capture in OTel spans (0 = unlimited)  |
 
 #### Default DB path
 
@@ -125,23 +129,58 @@ API keys are available for Kiro Pro, Pro+, Pro Max, and Power subscribers. On gr
 
 Command-line options can be overridden with environment variables.
 
-| Variable                 | Corresponding option |
-| ------------------------ | -------------------- |
-| `KIROCC_PORT`            | `-port`              |
-| `KIROCC_HOST`            | `-host`              |
-| `KIROCC_DB_PATH`         | `-db`                |
-| `KIROCC_API_KEY`         | `-api-key`           |
-| `KIRO_API_KEY`           | `-kiro-api-key`      |
-| `KIRO_API_REGION`        | `-kiro-api-region`   |
-| `KIROCC_DEBUG`           | `-debug`             |
-| `KIROCC_LOG_FILE`        | `-log-file`          |
-| `KIROCC_LOG_MAX_SIZE`    | `-log-max-size`      |
-| `KIROCC_LOG_MAX_BACKUPS` | `-log-max-backups`   |
-| `KIROCC_LOG_MAX_AGE`     | `-log-max-age`       |
-| `KIROCC_LOG_COMPRESS`    | `-log-compress`      |
-| `KIROCC_LOG_CONSOLE`     | `-log-console`       |
-| `KIROCC_OTEL`            | `-otel`              |
-| `KIROCC_OTEL_BODY_LIMIT` | `-otel-body-limit`   |
+| Variable                    | Corresponding option  |
+| --------------------------- | --------------------- |
+| `KIROCC_PORT`               | `-port`               |
+| `KIROCC_HOST`               | `-host`               |
+| `KIROCC_DB_PATH`            | `-db`                 |
+| `KIROCC_API_KEY`            | `-api-key`            |
+| `KIRO_API_KEY`              | `-kiro-api-key`       |
+| `KIRO_API_REGION`           | `-kiro-api-region`    |
+| `KIROCC_MODEL_DISCOVERY`    | `-model-discovery`    |
+| `KIROCC_KEEPALIVE_INTERVAL` | `-keepalive-interval` |
+| `KIROCC_DEBUG`              | `-debug`              |
+| `KIROCC_LOG_FILE`           | `-log-file`           |
+| `KIROCC_LOG_MAX_SIZE`       | `-log-max-size`       |
+| `KIROCC_LOG_MAX_BACKUPS`    | `-log-max-backups`    |
+| `KIROCC_LOG_MAX_AGE`        | `-log-max-age`        |
+| `KIROCC_LOG_COMPRESS`       | `-log-compress`       |
+| `KIROCC_LOG_CONSOLE`        | `-log-console`        |
+| `KIROCC_OTEL`               | `-otel`               |
+| `KIROCC_OTEL_BODY_LIMIT`    | `-otel-body-limit`    |
+
+`KIRO_API_KEY` and `KIRO_API_REGION` intentionally keep Kiro's own names rather than the `KIROCC_` prefix, so a machine already configured for headless kiro-cli needs no kirocc-specific setup.
+
+### Custom API region
+
+Kiro API endpoints are region-scoped: completions go to `runtime.<region>.kiro.dev` and the model catalog to `management.<region>.kiro.dev`. By default the region comes from the Kiro CLI credential (the profile ARN, or the region stored by kiro-cli).
+
+That default is not always a region Kiro serves. kiro-cli records the region you signed in from, and only a few regions have Kiro hosts — `us-east-1`, `eu-central-1`, `us-gov-east-1`, `us-gov-west-1` at the time of writing. If your credential resolves to anything else, the hostname does not exist and every request fails with an upstream error. `-kiro-api-region` pins the region instead:
+
+```bash
+kirocc -kiro-api-region us-east-1
+```
+
+```
+INFO Kiro API region pinned region=us-east-1
+INFO credentials loaded auth_type=idc region=ap-southeast-1
+```
+
+The override applies to the API endpoints only. Token refresh still targets the region that issued the credential, since a token is rejected outside it.
+
+### Automatic model discovery
+
+At startup kirocc calls Kiro's `ListAvailableModels` and installs the result as a fallback layer behind the built-in mapping table. A model Kiro launches after a kirocc release therefore resolves with its real context window and effort enum instead of falling back to pass-through defaults, and shows up in `GET /v1/models`.
+
+Resolution order is `KIROCC_MODEL_MAPPINGS` → built-in table → discovered catalog, first match wins. Built-ins deliberately win: they encode behaviour a mechanically derived entry cannot reproduce, such as which `[1m]` aliases must *not* enable extended thinking and which SKU a 1M request routes to.
+
+Discovery is best-effort and never blocks startup or fails a request. It is skipped when the credential has no profile ARN (which is the case for `-kiro-api-key` auth, since the API requires one), and any error leaves the built-in table in place:
+
+```
+WRN model discovery failed, using built-in model table region=ap-southeast-1 err="..."
+```
+
+Disable it with `-model-discovery=false`.
 
 ### OpenTelemetry tracing
 
@@ -189,6 +228,7 @@ flowchart TB
         MW["Middleware<br/>(OTel Tracing, Trace ID, CORS, API Key Auth)"]
         Handler["Messages Handler"]
         Auth["Auth<br/>(SQLite + Token Refresh)"]
+        Discovery["Model Discovery<br/>(startup)"]
 
         subgraph reqconv ["Request Conversion"]
             direction LR
@@ -213,12 +253,14 @@ flowchart TB
 
     subgraph Kiro ["Kiro API"]
         KiroAPI["runtime.{region}.kiro.dev"]
+        KiroMgmt["management.{region}.kiro.dev<br/>(ListAvailableModels)"]
     end
 
     CC -- "Anthropic Messages API<br/>(JSON / SSE)" --> MW
     MW --> Handler
     Handler --> Auth
     Handler --> reqconv
+    Discovery -- "model catalog<br/>(startup, best-effort)" --> KiroMgmt
     reqconv -- "Kiro Payload<br/>(JSON)" --> KiroAPI
     KiroAPI -- "AWS Event Stream<br/>(binary frames)" --> respconv
     respconv -- "Anthropic SSE / JSON" --> CC
@@ -283,6 +325,7 @@ Per-model allowed effort levels:
 
 - `claude-opus-5`, `claude-opus-4.8`, `claude-opus-4.7`, `claude-sonnet-5`: `low`, `medium`, `high`, `xhigh`, `max`
 - `claude-opus-4.6`, `claude-sonnet-4.6` (and their `-1m` variants): `low`, `medium`, `high`, `max` (no `xhigh`; clamps to `max`)
+- Models not listed here fall back to the enum advertised by [model discovery](#automatic-model-discovery), if any
 - All other models omit `additionalModelRequestFields` entirely
 
 `thinking.budget_tokens` is accepted in the request but no longer affects behavior; reasoning depth is conveyed entirely through `effort`.

--- a/cmd/kirocc/main.go
+++ b/cmd/kirocc/main.go
@@ -16,8 +16,10 @@ import (
 
 	"github.com/d-kuro/kirocc/internal/auth"
 	"github.com/d-kuro/kirocc/internal/config"
+	"github.com/d-kuro/kirocc/internal/kirocatalog"
 	"github.com/d-kuro/kirocc/internal/kiroclient"
 	"github.com/d-kuro/kirocc/internal/logging"
+	"github.com/d-kuro/kirocc/internal/models"
 	"github.com/d-kuro/kirocc/internal/server"
 	"github.com/d-kuro/kirocc/internal/tokencount"
 	"github.com/d-kuro/kirocc/internal/tracing"
@@ -68,8 +70,15 @@ func run(ctx context.Context, args []string) error {
 		// would otherwise look like a failure.
 		slog.Info("using Kiro API key", "auth_type", auth.AuthTypeAPIKey, "db_read", false)
 	}
+	if cfg.KiroAPIRegion != "" {
+		slog.Info("Kiro API region pinned", "region", cfg.KiroAPIRegion)
+	}
 	kiroClient := buildKiroClient(authMgr, cfg)
 	srv := buildServer(authMgr, kiroClient, cfg)
+
+	if cfg.ModelDiscovery {
+		go discoverModels(ctx, authMgr, cfg.KiroAPIRegion)
+	}
 
 	// Eagerly initialize tiktoken so the first API request doesn't block on BPE data fetch.
 	go tokencount.Preload()
@@ -109,7 +118,8 @@ func parseFlags(args []string) (config.Config, error) {
 	fs.StringVar(&cfg.DBPath, "db", config.DefaultDBPath(), "kiro-cli SQLite DB path")
 	fs.StringVar(&cfg.APIKey, "api-key", "", "optional API key for authentication")
 	fs.StringVar(&cfg.KiroAPIKey, "kiro-api-key", "", "Kiro API key (ksk_...) to use instead of the kiro-cli database credential; also KIRO_API_KEY")
-	fs.StringVar(&cfg.KiroAPIRegion, "kiro-api-region", "", "region for Kiro API key auth (default us-east-1); also KIRO_API_REGION")
+	fs.StringVar(&cfg.KiroAPIRegion, "kiro-api-region", "", "region for Kiro API endpoints (runtime.<region>.kiro.dev); overrides the credential's region; also KIRO_API_REGION")
+	fs.BoolVar(&cfg.ModelDiscovery, "model-discovery", true, "fetch Kiro's model catalog at startup so new models resolve without a kirocc update; also KIROCC_MODEL_DISCOVERY")
 	fs.BoolVar(&cfg.Debug, "debug", false, "enable debug logging with OTel JSON Lines output")
 	fs.BoolVar(&cfg.OTel, "otel", false, "enable OpenTelemetry tracing (OTLP HTTP exporter)")
 	fs.IntVar(&cfg.OTelBodyLimit, "otel-body-limit", config.DefaultOTelBodyLimit, "max bytes of request body to capture in OTel spans (0 = unlimited)")
@@ -143,10 +153,69 @@ func buildKiroClient(authMgr *auth.AuthManager, cfg config.Config) kiroclient.Cl
 	if authMgr.UsesAPIKey() {
 		clientOpts = append(clientOpts, kiroclient.WithAPIKeyAuth())
 	}
+	if cfg.KiroAPIRegion != "" {
+		clientOpts = append(clientOpts, kiroclient.WithRegion(cfg.KiroAPIRegion))
+	}
 	if cfg.OTel {
 		clientOpts = append(clientOpts, kiroclient.WithOTel(cfg.OTelBodyLimit))
 	}
 	return kiroclient.NewHTTPClient(clientOpts...)
+}
+
+// modelDiscoveryTimeout bounds the startup catalog fetch. Generous, because it
+// runs in the background and a slow answer costs nothing.
+const modelDiscoveryTimeout = 20 * time.Second
+
+// discoverModels installs Kiro's advertised model catalog as a fallback layer
+// behind the built-in mapping table, so a model Kiro launches after this build
+// resolves with the right context window and effort enum instead of falling
+// through to pass-through defaults. Best-effort: every failure path leaves the
+// built-in tables untouched.
+//
+// It runs in the background because it needs a credential, and blocking startup
+// on a network round trip would delay the listener for no benefit — the built-in
+// table already covers every model shipped with this build.
+func discoverModels(ctx context.Context, authMgr *auth.AuthManager, regionOverride string) {
+	ctx, cancel := context.WithTimeout(ctx, modelDiscoveryTimeout)
+	defer cancel()
+
+	creds, err := authMgr.GetToken(ctx)
+	if err != nil {
+		slog.Debug("model discovery skipped: no credentials", "err", err)
+		return
+	}
+	if creds.ProfileARN == "" {
+		// API keys carry no profile ARN, and the API rejects a request without
+		// one. Nothing to do but keep the built-in table.
+		slog.Debug("model discovery skipped: credential has no profile ARN", "auth_type", creds.AuthType)
+		return
+	}
+	region := creds.Region
+	if regionOverride != "" {
+		region = regionOverride
+	}
+
+	catalog, err := kirocatalog.New().List(ctx, kirocatalog.Request{
+		Token:      creds.AccessToken,
+		Region:     region,
+		ProfileARN: creds.ProfileARN,
+	})
+	if err != nil {
+		slog.Warn("model discovery failed, using built-in model table", "region", region, "err", err)
+		return
+	}
+
+	entries := make([]models.CatalogModel, 0, len(catalog))
+	for _, m := range catalog {
+		entries = append(entries, models.CatalogModel{
+			ID:             m.ID,
+			MaxInputTokens: m.MaxInputTokens,
+			EffortEnum:     m.EffortEnum,
+		})
+	}
+	added := models.SetCatalog(entries)
+	slog.Info("model catalog discovered",
+		"region", region, "advertised", len(catalog), "new_models", added)
 }
 
 func buildServer(authMgr *auth.AuthManager, client kiroclient.Client, cfg config.Config) *server.Server {

--- a/cmd/kirocc/main_test.go
+++ b/cmd/kirocc/main_test.go
@@ -14,6 +14,63 @@ func TestRun_HelpFlagReturnsNoError(t *testing.T) {
 	}
 }
 
+func TestParseFlags_KiroAPIRegion(t *testing.T) {
+	t.Run("default is empty so the credential region is used", func(t *testing.T) {
+		cfg, err := parseFlags(nil)
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.KiroAPIRegion != "" {
+			t.Fatalf("KiroAPIRegion = %q, want empty", cfg.KiroAPIRegion)
+		}
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		cfg, err := parseFlags([]string{"-kiro-api-region", "us-east-1"})
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.KiroAPIRegion != "us-east-1" {
+			t.Fatalf("KiroAPIRegion = %q, want us-east-1", cfg.KiroAPIRegion)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+	})
+
+	t.Run("invalid region is rejected by Validate", func(t *testing.T) {
+		cfg, err := parseFlags([]string{"-kiro-api-region", "evil.example.com"})
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("Validate: want error for a non-region value")
+		}
+	})
+}
+
+func TestParseFlags_ModelDiscovery(t *testing.T) {
+	t.Run("default enabled", func(t *testing.T) {
+		cfg, err := parseFlags(nil)
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if !cfg.ModelDiscovery {
+			t.Fatal("ModelDiscovery = false, want true")
+		}
+	})
+
+	t.Run("disabled by flag", func(t *testing.T) {
+		cfg, err := parseFlags([]string{"-model-discovery=false"})
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.ModelDiscovery {
+			t.Fatal("ModelDiscovery = true, want false")
+		}
+	})
+}
+
 func TestParseFlags_KeepAliveInterval(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		cfg, err := parseFlags(nil)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"time"
@@ -27,14 +28,33 @@ type Config struct {
 	// KiroAPIKey is a Kiro API key ("ksk_…") used upstream instead of the
 	// kiro-cli database credential. Named after Kiro's own KIRO_API_KEY rather
 	// than the KIROCC_* convention, since it is Kiro's credential, not kirocc's.
-	KiroAPIKey        string
-	KiroAPIRegion     string
+	KiroAPIKey string
+	// KiroAPIRegion pins the AWS region used to build Kiro API endpoints
+	// (https://runtime.<region>.kiro.dev/ and the ListAvailableModels control
+	// plane). It overrides the region derived from the credential, which is not
+	// always a region Kiro actually serves: kiro-cli stores the sign-in region
+	// in its token, and only a handful of regions have a runtime endpoint.
+	// Empty means "use the credential's region" (us-east-1 for API-key auth).
+	KiroAPIRegion string
+	// ModelDiscovery enables fetching Kiro's model catalog at startup so newly
+	// launched models resolve without a kirocc release. Built-in mappings always
+	// win; discovery only fills gaps.
+	ModelDiscovery    bool
 	Debug             bool
 	OTel              bool
 	OTelBodyLimit     int
 	KeepAliveInterval time.Duration
 	LogFile           logging.LogFileConfig
 }
+
+// regionPattern matches the region forms Kiro uses ("us-east-1",
+// "us-gov-west-1"). The value is interpolated into an API hostname, so it is
+// validated rather than trusted — a stray "/" or "@" would otherwise send
+// requests, and the bearer token with them, to an arbitrary host.
+var regionPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// maxRegionLen bounds the region string; real regions are far shorter.
+const maxRegionLen = 64
 
 // DefaultDBPath returns the default kiro-cli SQLite database location.
 func DefaultDBPath() string {
@@ -64,6 +84,9 @@ func ApplyEnvOverrides(cfg *Config) error {
 	applyString("KIRO_API_KEY", &cfg.KiroAPIKey)
 	applyString("KIRO_API_REGION", &cfg.KiroAPIRegion)
 	applyString("KIROCC_HOST", &cfg.Host)
+	if err := applyBool("KIROCC_MODEL_DISCOVERY", &cfg.ModelDiscovery); err != nil {
+		return err
+	}
 	if err := applyInt("KIROCC_PORT", &cfg.Port); err != nil {
 		return err
 	}
@@ -113,6 +136,11 @@ func (c *Config) Validate() error {
 	}
 	if c.KeepAliveInterval != 0 && c.KeepAliveInterval < time.Second {
 		return fmt.Errorf("keepalive-interval must be 0 or >= 1s, got %s", c.KeepAliveInterval)
+	}
+	if c.KiroAPIRegion != "" {
+		if len(c.KiroAPIRegion) > maxRegionLen || !regionPattern.MatchString(c.KiroAPIRegion) {
+			return fmt.Errorf("kiro-api-region must be a lowercase region like us-east-1, got %q", c.KiroAPIRegion)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -188,6 +189,48 @@ func TestApplyEnvOverrides_LogFields(t *testing.T) {
 	}
 }
 
+func TestApplyEnvOverrides_KiroAPIRegion(t *testing.T) {
+	t.Setenv("KIRO_API_REGION", "eu-central-1")
+	cfg := Config{Host: "127.0.0.1", Port: 3456}
+	if err := ApplyEnvOverrides(&cfg); err != nil {
+		t.Fatalf("ApplyEnvOverrides: %v", err)
+	}
+	if cfg.KiroAPIRegion != "eu-central-1" {
+		t.Errorf("KiroAPIRegion = %q, want %q", cfg.KiroAPIRegion, "eu-central-1")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestApplyEnvOverrides_ModelDiscovery(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		initial bool
+		want    bool
+		wantErr bool
+	}{
+		{name: "disable", value: "false", initial: true, want: false},
+		{name: "enable", value: "1", initial: false, want: true},
+		{name: "unset keeps flag default", value: "", initial: true, want: true},
+		{name: "invalid", value: "maybe", initial: true, want: true, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KIROCC_MODEL_DISCOVERY", tt.value)
+			cfg := Config{Host: "127.0.0.1", Port: 3456, ModelDiscovery: tt.initial}
+			err := ApplyEnvOverrides(&cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ApplyEnvOverrides() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if cfg.ModelDiscovery != tt.want {
+				t.Errorf("ModelDiscovery = %v, want %v", cfg.ModelDiscovery, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -204,6 +247,16 @@ func TestConfig_Validate(t *testing.T) {
 		{"keep-alive minimum", Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: time.Second}, false},
 		{"keep-alive negative", Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: -time.Second}, true},
 		{"keep-alive too small", Config{Host: "127.0.0.1", Port: 3456, KeepAliveInterval: 500 * time.Millisecond}, true},
+		{"region unset", Config{Host: "127.0.0.1", Port: 3456}, false},
+		{"region us-east-1", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "us-east-1"}, false},
+		{"region us-gov-west-1", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "us-gov-west-1"}, false},
+		{"region eu-central-1", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "eu-central-1"}, false},
+		{"region uppercase", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "US-EAST-1"}, true},
+		{"region with path traversal", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "us-east-1/../evil"}, true},
+		{"region with host injection", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "x.evil.com"}, true},
+		{"region with userinfo injection", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "a@evil.com"}, true},
+		{"region with leading hyphen", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "-us-east-1"}, true},
+		{"region too long", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: strings.Repeat("a", maxRegionLen+1)}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/kirocatalog/client.go
+++ b/internal/kirocatalog/client.go
@@ -1,0 +1,174 @@
+// Package kirocatalog fetches Kiro's model catalog via ListAvailableModels so
+// kirocc can resolve models that shipped after its own release.
+//
+// The catalog lives on a different host from the streaming API: models come from
+// the control plane at management.<region>.kiro.dev, while completions go to
+// runtime.<region>.kiro.dev.
+package kirocatalog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	amzTarget = "AmazonCodeWhispererService.ListAvailableModels"
+	// origin identifies the calling surface. The field is required and enum
+	// validated; KIRO_CLI is the value kiro-cli itself sends.
+	origin = "KIRO_CLI"
+	// errBodyLimit bounds how much of an error response is read into a message.
+	errBodyLimit = 2048
+	// respBodyLimit bounds the catalog response; the real one is ~10 KB.
+	respBodyLimit = 1 << 20
+)
+
+// Model is one model advertised by the catalog, reduced to the fields kirocc
+// uses for resolution.
+type Model struct {
+	ID              string
+	MaxInputTokens  int
+	MaxOutputTokens int
+	// EffortEnum lists accepted output_config.effort values, low → high. Empty
+	// when the model does not advertise an effort schema.
+	EffortEnum []string
+}
+
+// Request carries the credential and routing inputs for a catalog fetch.
+type Request struct {
+	Token string
+	// Region selects the control-plane host. Only a few regions serve one, and a
+	// token is rejected outside the region that issued it.
+	Region string
+	// ProfileARN is required by the API; a request without it fails validation.
+	// API-key credentials have no profile ARN and therefore cannot fetch.
+	ProfileARN string
+}
+
+// Client fetches model catalogs.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string // override for tests; empty = region-based URL
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithHTTPClient sets the HTTP client used for catalog requests.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) { c.httpClient = hc }
+}
+
+// WithBaseURL sets a custom endpoint (for testing).
+func WithBaseURL(url string) Option {
+	return func(c *Client) { c.baseURL = url }
+}
+
+// New creates a Client.
+func New(opts ...Option) *Client {
+	c := &Client{httpClient: &http.Client{Timeout: 15 * time.Second}}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *Client) endpointURL(region string) string {
+	if c.baseURL != "" {
+		return c.baseURL
+	}
+	return fmt.Sprintf("https://management.%s.kiro.dev/", region)
+}
+
+// listResponse mirrors the ListAvailableModels response. The effort enum is
+// nested inside a JSON Schema document describing additionalModelRequestFields:
+//
+//	additionalModelRequestFieldsSchema.properties.output_config.properties.effort.enum
+type listResponse struct {
+	Models []struct {
+		ModelID     string `json:"modelId"`
+		TokenLimits struct {
+			MaxInputTokens  int `json:"maxInputTokens"`
+			MaxOutputTokens int `json:"maxOutputTokens"`
+		} `json:"tokenLimits"`
+		Schema struct {
+			Properties struct {
+				OutputConfig struct {
+					Properties struct {
+						Effort struct {
+							Enum []string `json:"enum"`
+						} `json:"effort"`
+					} `json:"properties"`
+				} `json:"output_config"`
+			} `json:"properties"`
+		} `json:"additionalModelRequestFieldsSchema"`
+	} `json:"models"`
+}
+
+// List fetches the model catalog. It returns an error rather than a partial
+// result so callers can keep their built-in tables on any failure.
+func (c *Client) List(ctx context.Context, r Request) ([]Model, error) {
+	if r.Token == "" {
+		return nil, fmt.Errorf("kirocatalog: missing token")
+	}
+	if r.Region == "" {
+		return nil, fmt.Errorf("kirocatalog: missing region")
+	}
+	if r.ProfileARN == "" {
+		return nil, fmt.Errorf("kirocatalog: missing profile ARN")
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"origin":     origin,
+		"profileArn": r.ProfileARN,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kirocatalog: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(r.Region), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("kirocatalog: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+r.Token)
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("X-Amz-Target", amzTarget)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("kirocatalog: do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
+		return nil, fmt.Errorf("kirocatalog: status %d: %s", resp.StatusCode, errBody)
+	}
+
+	var parsed listResponse
+	if err := json.UnmarshalRead(io.LimitReader(resp.Body, respBodyLimit), &parsed); err != nil {
+		return nil, fmt.Errorf("kirocatalog: decode response: %w", err)
+	}
+	if len(parsed.Models) == 0 {
+		return nil, fmt.Errorf("kirocatalog: response contained no models")
+	}
+
+	out := make([]Model, 0, len(parsed.Models))
+	for _, m := range parsed.Models {
+		if m.ModelID == "" {
+			continue
+		}
+		out = append(out, Model{
+			ID:              m.ModelID,
+			MaxInputTokens:  m.TokenLimits.MaxInputTokens,
+			MaxOutputTokens: m.TokenLimits.MaxOutputTokens,
+			EffortEnum:      m.Schema.Properties.OutputConfig.Properties.Effort.Enum,
+		})
+	}
+	return out, nil
+}

--- a/internal/kirocatalog/client_test.go
+++ b/internal/kirocatalog/client_test.go
@@ -1,0 +1,206 @@
+package kirocatalog
+
+import (
+	"context"
+	"encoding/json/v2"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// catalogFixture mirrors the shape of a real ListAvailableModels response,
+// including the nested JSON Schema that carries the effort enum.
+const catalogFixture = `{
+  "defaultModel": {"modelId": "auto"},
+  "models": [
+    {
+      "modelId": "auto",
+      "tokenLimits": {"maxInputTokens": 1000000, "maxOutputTokens": 64000}
+    },
+    {
+      "modelId": "claude-opus-5",
+      "tokenLimits": {"maxInputTokens": 1000000, "maxOutputTokens": 128000},
+      "additionalModelRequestFieldsSchema": {
+        "type": "object",
+        "properties": {
+          "thinking": {"type": "object", "properties": {"type": {"type": "string", "enum": ["adaptive", "disabled"]}}},
+          "output_config": {
+            "type": "object",
+            "properties": {
+              "effort": {"type": "string", "enum": ["low", "medium", "high", "xhigh", "max"], "default": "high"}
+            }
+          },
+          "max_tokens": {"type": "integer", "minimum": 1024, "maximum": 128000}
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "modelId": "claude-haiku-4.5",
+      "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 64000}
+    }
+  ]
+}`
+
+func TestClient_List(t *testing.T) {
+	var (
+		gotPath   string
+		gotTarget string
+		gotAuth   string
+		gotBody   map[string]string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotTarget = r.Header.Get("X-Amz-Target")
+		gotAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		_, _ = w.Write([]byte(catalogFixture))
+	}))
+	defer srv.Close()
+
+	got, err := New(WithBaseURL(srv.URL)).List(context.Background(), Request{
+		Token:      "tok",
+		Region:     "us-east-1",
+		ProfileARN: "arn:aws:codewhisperer:us-east-1:123:profile/ABC",
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if gotPath != "/" {
+		t.Errorf("path = %q, want /", gotPath)
+	}
+	if gotTarget != amzTarget {
+		t.Errorf("X-Amz-Target = %q, want %q", gotTarget, amzTarget)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer tok")
+	}
+	if gotBody["origin"] != origin {
+		t.Errorf("body origin = %q, want %q", gotBody["origin"], origin)
+	}
+	if gotBody["profileArn"] != "arn:aws:codewhisperer:us-east-1:123:profile/ABC" {
+		t.Errorf("body profileArn = %q, want the request ARN", gotBody["profileArn"])
+	}
+
+	want := []Model{
+		{ID: "auto", MaxInputTokens: 1_000_000, MaxOutputTokens: 64_000},
+		{
+			ID:              "claude-opus-5",
+			MaxInputTokens:  1_000_000,
+			MaxOutputTokens: 128_000,
+			EffortEnum:      []string{"low", "medium", "high", "xhigh", "max"},
+		},
+		{ID: "claude-haiku-4.5", MaxInputTokens: 200_000, MaxOutputTokens: 64_000},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d models, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].ID != want[i].ID ||
+			got[i].MaxInputTokens != want[i].MaxInputTokens ||
+			got[i].MaxOutputTokens != want[i].MaxOutputTokens ||
+			!slices.Equal(got[i].EffortEnum, want[i].EffortEnum) {
+			t.Errorf("model %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestClient_List_MissingInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		req  Request
+	}{
+		{"no token", Request{Region: "us-east-1", ProfileARN: "arn:x"}},
+		{"no region", Request{Token: "t", ProfileARN: "arn:x"}},
+		{"no profile arn", Request{Token: "t", Region: "us-east-1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				t.Error("request must not be sent when inputs are incomplete")
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer srv.Close()
+			if _, err := New(WithBaseURL(srv.URL)).List(context.Background(), tt.req); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestClient_List_ErrorResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "validation error surfaces the message",
+			status:  http.StatusBadRequest,
+			body:    `{"__type":"com.amazon.kiro.controlplane#ValidationException","message":"Invalid profileArn."}`,
+			wantErr: "Invalid profileArn",
+		},
+		{
+			name:    "malformed json",
+			status:  http.StatusOK,
+			body:    `{"models":`,
+			wantErr: "decode response",
+		},
+		{
+			name:    "empty catalog",
+			status:  http.StatusOK,
+			body:    `{"models":[]}`,
+			wantErr: "no models",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			_, err := New(WithBaseURL(srv.URL)).List(context.Background(), Request{
+				Token: "t", Region: "us-east-1", ProfileARN: "arn:x",
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("err = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestClient_EndpointURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		region  string
+		want    string
+	}{
+		{"region-based", "", "us-east-1", "https://management.us-east-1.kiro.dev/"},
+		{"region-based eu", "", "eu-central-1", "https://management.eu-central-1.kiro.dev/"},
+		{"override", "http://localhost:8080", "us-east-1", "http://localhost:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []Option
+			if tt.baseURL != "" {
+				opts = append(opts, WithBaseURL(tt.baseURL))
+			}
+			if got := New(opts...).endpointURL(tt.region); got != tt.want {
+				t.Errorf("endpointURL(%q) = %q, want %q", tt.region, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/kiroclient/client.go
+++ b/internal/kiroclient/client.go
@@ -71,6 +71,7 @@ const defaultBodyReadIdleTimeout = 180 * time.Second
 type HTTPClient struct {
 	httpClient     *http.Client
 	baseURL        string // override for tests; empty = use region-based URL
+	region         string // pins the endpoint region; empty = use the per-call region
 	otel           bool
 	otelBodyLimit  int
 	tokenRefresher TokenRefresher
@@ -85,6 +86,17 @@ type HTTPClientOption func(*HTTPClient)
 // WithBaseURL sets a custom base URL (for testing).
 func WithBaseURL(url string) HTTPClientOption {
 	return func(c *HTTPClient) { c.baseURL = url }
+}
+
+// WithRegion pins the region used to build the Kiro API endpoint, overriding
+// the per-call region that comes from the credential. Needed because the
+// credential's region is a sign-in region, not necessarily a region with a
+// runtime endpoint: kiro-cli stores its own login region in the token, and
+// resolving it produces a hostname that does not exist for users who signed in
+// outside Kiro's serving regions. An empty value leaves the per-call region in
+// effect.
+func WithRegion(region string) HTTPClientOption {
+	return func(c *HTTPClient) { c.region = region }
 }
 
 // WithTokenRefresher sets the token refresh callback for 403 retry.
@@ -164,11 +176,20 @@ func (c *HTTPClient) recordError(ctx context.Context, err error) {
 	}
 }
 
+// effectiveRegion returns the region actually used for the endpoint: the pinned
+// override when set, otherwise the region supplied by the caller.
+func (c *HTTPClient) effectiveRegion(region string) string {
+	if c.region != "" {
+		return c.region
+	}
+	return region
+}
+
 func (c *HTTPClient) endpointURL(region string) string {
 	if c.baseURL != "" {
 		return c.baseURL
 	}
-	return fmt.Sprintf("https://runtime.%s.kiro.dev/", region)
+	return fmt.Sprintf("https://runtime.%s.kiro.dev/", c.effectiveRegion(region))
 }
 
 // GenerateAssistantResponse sends a request to the Kiro API with retry logic.
@@ -180,7 +201,7 @@ func (c *HTTPClient) GenerateAssistantResponse(ctx context.Context, token string
 		ctx, span = tracing.Tracer().Start(ctx, "kiro.GenerateAssistantResponse")
 		defer span.End()
 		span.SetAttributes(
-			attribute.String("kiro.region", region),
+			attribute.String("kiro.region", c.effectiveRegion(region)),
 			attribute.String("kiro.endpoint", endpoint),
 		)
 	}

--- a/internal/kiroclient/client_test.go
+++ b/internal/kiroclient/client_test.go
@@ -310,13 +310,17 @@ func TestAmzSdkRequestHeader_ConsistentAcrossRetries(t *testing.T) {
 
 func TestHTTPClient_EndpointURL(t *testing.T) {
 	tests := []struct {
-		name    string
-		baseURL string
-		region  string
-		want    string
+		name           string
+		baseURL        string
+		regionOverride string
+		region         string
+		want           string
 	}{
-		{"region-based", "", "us-west-2", "https://runtime.us-west-2.kiro.dev/"},
-		{"override", "http://localhost:8080", "us-west-2", "http://localhost:8080"},
+		{"region-based", "", "", "us-west-2", "https://runtime.us-west-2.kiro.dev/"},
+		{"override", "http://localhost:8080", "", "us-west-2", "http://localhost:8080"},
+		{"region override wins over credential region", "", "eu-central-1", "ap-southeast-1", "https://runtime.eu-central-1.kiro.dev/"},
+		{"region override applies when credential region is empty", "", "us-east-1", "", "https://runtime.us-east-1.kiro.dev/"},
+		{"base URL wins over region override", "http://localhost:8080", "eu-central-1", "us-west-2", "http://localhost:8080"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -324,9 +328,36 @@ func TestHTTPClient_EndpointURL(t *testing.T) {
 			if tt.baseURL != "" {
 				opts = append(opts, WithBaseURL(tt.baseURL))
 			}
+			if tt.regionOverride != "" {
+				opts = append(opts, WithRegion(tt.regionOverride))
+			}
 			c := NewHTTPClient(opts...)
 			if got := c.endpointURL(tt.region); got != tt.want {
 				t.Errorf("endpointURL(%q) = %q, want %q", tt.region, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPClient_EffectiveRegion(t *testing.T) {
+	tests := []struct {
+		name           string
+		regionOverride string
+		region         string
+		want           string
+	}{
+		{"no override passes through", "", "us-west-2", "us-west-2"},
+		{"override replaces", "eu-central-1", "us-west-2", "eu-central-1"},
+		{"empty override with empty region", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []HTTPClientOption
+			if tt.regionOverride != "" {
+				opts = append(opts, WithRegion(tt.regionOverride))
+			}
+			if got := NewHTTPClient(opts...).effectiveRegion(tt.region); got != tt.want {
+				t.Errorf("effectiveRegion(%q) = %q, want %q", tt.region, got, tt.want)
 			}
 		})
 	}

--- a/internal/models/catalog.go
+++ b/internal/models/catalog.go
@@ -1,0 +1,106 @@
+package models
+
+import (
+	"strings"
+	"sync"
+)
+
+// CatalogModel is one entry of Kiro's ListAvailableModels response, reduced to
+// the fields that drive model resolution. Declared here rather than imported so
+// the models package stays free of transport dependencies.
+type CatalogModel struct {
+	// ID is the Kiro SKU, e.g. "claude-opus-5" or "claude-sonnet-4.6".
+	ID string
+	// MaxInputTokens is the advertised context window.
+	MaxInputTokens int
+	// EffortEnum lists the accepted output_config.effort values, low → high.
+	// Empty means the model does not support effort.
+	EffortEnum []string
+}
+
+// catalog holds mappings derived from Kiro's model catalog. It is consulted
+// *after* the built-in tables, so built-ins always win and discovery only fills
+// gaps — models Kiro has launched that this build has no entry for. That
+// ordering matters: the built-in rows encode Claude Code-specific behaviour
+// (which `[1m]` aliases must not enable thinking, which SKU a 1M request routes
+// to) that a mechanically derived row cannot reproduce.
+var catalog struct {
+	mu       sync.RWMutex
+	mappings []Mapping
+	efforts  map[string][]string
+}
+
+// SetCatalog installs a discovered model catalog and returns the Kiro SKUs that
+// the built-in table did not already cover, for logging. Non-Claude models are
+// ignored: kirocc speaks the Anthropic Messages API, and its fallback for a
+// non-claude request is DefaultModel.
+func SetCatalog(discovered []CatalogModel) []string {
+	var (
+		mappings []Mapping
+		added    []string
+	)
+	efforts := make(map[string][]string, len(discovered))
+
+	builtin := make(map[string]struct{}, len(modelMapOrdered))
+	for _, m := range modelMapOrdered {
+		builtin[m.Kiro] = struct{}{}
+	}
+
+	for _, d := range discovered {
+		if !strings.HasPrefix(d.ID, "claude-") {
+			continue
+		}
+		if len(d.EffortEnum) > 0 {
+			efforts[d.ID] = d.EffortEnum
+		}
+		if _, ok := builtin[d.ID]; !ok {
+			added = append(added, d.ID)
+		}
+
+		alias := anthropicAlias(d.ID)
+		entry := Mapping{Anthropic: alias, Kiro: d.ID, ContextWindowSize: d.MaxInputTokens}
+		if d.MaxInputTokens >= ThinkingContextWindowSize {
+			// An always-1M SKU: no separate -1m variant exists, so Kiro1M is the
+			// SKU itself and the `[1m]` alias is a context-window advertisement
+			// that must not turn thinking on (matching the built-in opus rows).
+			entry.Kiro1M = d.ID
+			mappings = append(mappings, Mapping{
+				Anthropic:         alias + ThinkingSuffix,
+				Kiro:              d.ID,
+				Kiro1M:            d.ID,
+				ContextWindowSize: d.MaxInputTokens,
+			})
+		}
+		mappings = append(mappings, entry)
+	}
+
+	catalog.mu.Lock()
+	catalog.mappings = mappings
+	catalog.efforts = efforts
+	catalog.mu.Unlock()
+	return added
+}
+
+// anthropicAlias converts a Kiro SKU to the Anthropic-form ID clients send,
+// which spells version separators with hyphens: "claude-opus-4.6" →
+// "claude-opus-4-6". IDs without a dot ("claude-opus-5") are already in
+// Anthropic form and pass through unchanged.
+func anthropicAlias(kiroModel string) string {
+	return strings.ReplaceAll(kiroModel, ".", "-")
+}
+
+// catalogMappings returns the discovered mappings, or nil when discovery has not
+// run or found nothing usable.
+func catalogMappings() []Mapping {
+	catalog.mu.RLock()
+	defer catalog.mu.RUnlock()
+	return catalog.mappings
+}
+
+// catalogEffortEnum returns the discovered effort enum for a Kiro SKU.
+func catalogEffortEnum(kiroModel string) ([]string, bool) {
+	catalog.mu.RLock()
+	defer catalog.mu.RUnlock()
+	enum, ok := catalog.efforts[kiroModel]
+	return enum, ok
+}

--- a/internal/models/catalog_test.go
+++ b/internal/models/catalog_test.go
@@ -1,0 +1,220 @@
+package models
+
+import (
+	"slices"
+	"testing"
+)
+
+// resetCatalog clears discovered state so cases cannot leak into each other.
+func resetCatalog(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { SetCatalog(nil) })
+	SetCatalog(nil)
+}
+
+func TestAnthropicAlias(t *testing.T) {
+	tests := []struct {
+		kiro string
+		want string
+	}{
+		{"claude-opus-4.6", "claude-opus-4-6"},
+		{"claude-sonnet-4.6", "claude-sonnet-4-6"},
+		{"claude-opus-5", "claude-opus-5"},
+		{"claude-sonnet-5", "claude-sonnet-5"},
+	}
+	for _, tt := range tests {
+		if got := anthropicAlias(tt.kiro); got != tt.want {
+			t.Errorf("anthropicAlias(%q) = %q, want %q", tt.kiro, got, tt.want)
+		}
+	}
+}
+
+func TestSetCatalog_ReportsOnlyNewModels(t *testing.T) {
+	resetCatalog(t)
+
+	added := SetCatalog([]CatalogModel{
+		{ID: "claude-opus-5", MaxInputTokens: 1_000_000, EffortEnum: []string{"low", "max"}},
+		{ID: "claude-opus-9", MaxInputTokens: 1_000_000},
+		{ID: "gpt-5.6-terra", MaxInputTokens: 272_000},
+		{ID: "auto", MaxInputTokens: 1_000_000},
+	})
+
+	want := []string{"claude-opus-9"}
+	if !slices.Equal(added, want) {
+		t.Errorf("SetCatalog added = %v, want %v", added, want)
+	}
+}
+
+func TestSetCatalog_DiscoveredModelResolves(t *testing.T) {
+	resetCatalog(t)
+	SetCatalog([]CatalogModel{
+		{ID: "claude-opus-9", MaxInputTokens: 1_000_000, EffortEnum: []string{"low", "medium", "high", "xhigh", "max"}},
+		{ID: "claude-mini-1.2", MaxInputTokens: 200_000},
+	})
+
+	tests := []struct {
+		name               string
+		model              string
+		context1M          bool
+		wantKiroModel      string
+		wantThinking       bool
+		wantContextWindow  int
+		wantAnthropicModel string
+	}{
+		{
+			name:               "1m model advertises 1m without enabling thinking",
+			model:              "claude-opus-9",
+			wantKiroModel:      "claude-opus-9",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-9[1m]",
+		},
+		{
+			name:               "1m alias is exact-matched so the suffix does not opt into thinking",
+			model:              "claude-opus-9[1m]",
+			wantKiroModel:      "claude-opus-9",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-9[1m]",
+		},
+		{
+			name:               "context1M header still enables thinking",
+			model:              "claude-opus-9",
+			context1M:          true,
+			wantKiroModel:      "claude-opus-9",
+			wantThinking:       true,
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "claude-opus-9[1m]",
+		},
+		{
+			name:               "dotted SKU resolves to the dashed anthropic alias",
+			model:              "claude-mini-1.2",
+			wantKiroModel:      "claude-mini-1.2",
+			wantContextWindow:  200_000,
+			wantAnthropicModel: "claude-mini-1-2",
+		},
+		{
+			name:               "dashed alias resolves to the dotted SKU",
+			model:              "claude-mini-1-2",
+			wantKiroModel:      "claude-mini-1.2",
+			wantContextWindow:  200_000,
+			wantAnthropicModel: "claude-mini-1-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotModel, gotThinking, gotWindow, gotAnthropic := Resolve(tt.model, tt.context1M)
+			if gotModel != tt.wantKiroModel {
+				t.Errorf("kiroModel = %q, want %q", gotModel, tt.wantKiroModel)
+			}
+			if gotThinking != tt.wantThinking {
+				t.Errorf("thinking = %v, want %v", gotThinking, tt.wantThinking)
+			}
+			if gotWindow != tt.wantContextWindow {
+				t.Errorf("contextWindowSize = %d, want %d", gotWindow, tt.wantContextWindow)
+			}
+			if gotAnthropic != tt.wantAnthropicModel {
+				t.Errorf("anthropicModel = %q, want %q", gotAnthropic, tt.wantAnthropicModel)
+			}
+		})
+	}
+}
+
+// The catalog advertises 1M input for claude-sonnet-4.6, but kirocc deliberately
+// routes bare sonnet-4.6 to the 200k window and only switches to the -1m SKU on
+// an explicit 1M opt-in. Discovery must not quietly change that.
+func TestSetCatalog_BuiltinsWin(t *testing.T) {
+	resetCatalog(t)
+	SetCatalog([]CatalogModel{
+		{ID: "claude-sonnet-4.6", MaxInputTokens: 1_000_000, EffortEnum: []string{"low", "max"}},
+	})
+
+	kiroModel, thinking, window, anthropicModel := Resolve("claude-sonnet-4-6", false)
+	if kiroModel != "claude-sonnet-4.6" || thinking || window != DefaultContextWindowSize || anthropicModel != "claude-sonnet-4-6" {
+		t.Errorf("Resolve(claude-sonnet-4-6) = (%q, %v, %d, %q), want (claude-sonnet-4.6, false, %d, claude-sonnet-4-6)",
+			kiroModel, thinking, window, anthropicModel, DefaultContextWindowSize)
+	}
+
+	// The built-in 4-value enum must still clamp xhigh, not adopt the 2-value
+	// enum from the catalog.
+	if got := ResolveEffort("claude-sonnet-4.6", "xhigh"); got != EffortMax {
+		t.Errorf("ResolveEffort(claude-sonnet-4.6, xhigh) = %q, want %q", got, EffortMax)
+	}
+}
+
+func TestSetCatalog_EnvOverrideBeatsDiscovery(t *testing.T) {
+	resetCatalog(t)
+	t.Setenv("KIROCC_MODEL_MAPPINGS", `[{"anthropic":"claude-opus-9","kiro":"claude-pinned","context_window_size":200000}]`)
+	SetCatalog([]CatalogModel{{ID: "claude-opus-9", MaxInputTokens: 1_000_000}})
+
+	kiroModel, _, window, _ := Resolve("claude-opus-9", false)
+	if kiroModel != "claude-pinned" || window != 200_000 {
+		t.Errorf("Resolve(claude-opus-9) = (%q, %d), want (claude-pinned, 200000)", kiroModel, window)
+	}
+}
+
+func TestSetCatalog_EffortFallback(t *testing.T) {
+	resetCatalog(t)
+	SetCatalog([]CatalogModel{
+		{ID: "claude-opus-9", MaxInputTokens: 1_000_000, EffortEnum: []string{EffortLow, EffortMedium, EffortHigh, EffortMax}},
+		{ID: "claude-plain-1", MaxInputTokens: 200_000},
+	})
+
+	tests := []struct {
+		name      string
+		kiroModel string
+		requested string
+		want      string
+	}{
+		{"discovered enum honoured", "claude-opus-9", "high", "high"},
+		{"discovered enum clamps missing xhigh", "claude-opus-9", "xhigh", EffortMax},
+		{"unrecognized value still dropped", "claude-opus-9", "turbo", ""},
+		{"model without effort schema drops effort", "claude-plain-1", "high", ""},
+		{"model absent from catalog drops effort", "claude-absent", "high", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveEffort(tt.kiroModel, tt.requested); got != tt.want {
+				t.Errorf("ResolveEffort(%q, %q) = %q, want %q", tt.kiroModel, tt.requested, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetCatalog_ListModelsIncludesDiscovered(t *testing.T) {
+	resetCatalog(t)
+	t.Setenv("KIROCC_MODEL_MAPPINGS", "")
+	SetCatalog([]CatalogModel{
+		{ID: "claude-opus-9", MaxInputTokens: 1_000_000},
+		{ID: "gpt-5.6-terra", MaxInputTokens: 272_000},
+	})
+
+	got := ListModels()
+	if !slices.Contains(got, "claude-opus-9") {
+		t.Errorf("ListModels() = %v, missing claude-opus-9", got)
+	}
+	if slices.Contains(got, "gpt-5.6-terra") {
+		t.Errorf("ListModels() = %v, must not include non-claude models", got)
+	}
+	seen := make(map[string]bool, len(got))
+	for _, m := range got {
+		if seen[m] {
+			t.Errorf("ListModels() returned duplicate %q", m)
+		}
+		seen[m] = true
+	}
+}
+
+func TestSetCatalog_NilResets(t *testing.T) {
+	resetCatalog(t)
+	SetCatalog([]CatalogModel{{ID: "claude-opus-9", MaxInputTokens: 1_000_000}})
+	if _, _, window, _ := Resolve("claude-opus-9", false); window != ThinkingContextWindowSize {
+		t.Fatalf("precondition failed: window = %d", window)
+	}
+
+	SetCatalog(nil)
+	kiroModel, _, window, anthropicModel := Resolve("claude-opus-9", false)
+	if kiroModel != "claude-opus-9" || window != DefaultContextWindowSize || anthropicModel != "claude-opus-9" {
+		t.Errorf("after reset Resolve = (%q, %d, %q), want passthrough (claude-opus-9, %d, claude-opus-9)",
+			kiroModel, window, anthropicModel, DefaultContextWindowSize)
+	}
+}

--- a/internal/models/catalog_test.go
+++ b/internal/models/catalog_test.go
@@ -183,24 +183,31 @@ func TestSetCatalog_EffortFallback(t *testing.T) {
 func TestSetCatalog_ListModelsIncludesDiscovered(t *testing.T) {
 	resetCatalog(t)
 	t.Setenv("KIROCC_MODEL_MAPPINGS", "")
+	// The non-claude probe must be an ID absent from modelMapOrdered: built-in
+	// non-claude entries (the gpt-5.6 family) are advertised by design, so only
+	// an unknown ID proves discovery itself skipped it.
 	SetCatalog([]CatalogModel{
 		{ID: "claude-opus-9", MaxInputTokens: 1_000_000},
-		{ID: "gpt-5.6-terra", MaxInputTokens: 272_000},
+		{ID: "gpt-9-nova", MaxInputTokens: 272_000},
 	})
 
 	got := ListModels()
-	if !slices.Contains(got, "claude-opus-9") {
-		t.Errorf("ListModels() = %v, missing claude-opus-9", got)
-	}
-	if slices.Contains(got, "gpt-5.6-terra") {
-		t.Errorf("ListModels() = %v, must not include non-claude models", got)
-	}
-	seen := make(map[string]bool, len(got))
+	ids := make([]string, 0, len(got))
 	for _, m := range got {
-		if seen[m] {
-			t.Errorf("ListModels() returned duplicate %q", m)
+		ids = append(ids, m.ID)
+	}
+	if !slices.Contains(ids, "claude-opus-9") {
+		t.Errorf("ListModels() = %v, missing claude-opus-9", ids)
+	}
+	if slices.Contains(ids, "gpt-9-nova") {
+		t.Errorf("ListModels() = %v, discovery must not add non-claude models", ids)
+	}
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			t.Errorf("ListModels() returned duplicate %q", id)
 		}
-		seen[m] = true
+		seen[id] = true
 	}
 }
 

--- a/internal/models/effort.go
+++ b/internal/models/effort.go
@@ -87,10 +87,13 @@ func ResolveEffort(kiroModel, requested string) string {
 	if !ok {
 		// Fall back to the discovered catalog so a model launched after this
 		// build still gets its effort forwarded instead of silently dropped.
-		enum, ok = catalogEffortEnum(kiroModel)
-	}
-	if !ok {
-		return ""
+		// Discovery only records the Claude-style output_config schema, so a
+		// derived capability is never a reasoning model.
+		enum, found := catalogEffortEnum(kiroModel)
+		if !found || len(enum) == 0 {
+			return ""
+		}
+		capability = effortCapability{levels: enum}
 	}
 	// Enum membership wins: accepts model-specific values like "none" that
 	// are not rankable levels.

--- a/internal/models/effort.go
+++ b/internal/models/effort.go
@@ -85,6 +85,11 @@ func ResolveEffort(kiroModel, requested string) string {
 	}
 	capability, ok := effortCapabilities[kiroModel]
 	if !ok {
+		// Fall back to the discovered catalog so a model launched after this
+		// build still gets its effort forwarded instead of silently dropped.
+		enum, ok = catalogEffortEnum(kiroModel)
+	}
+	if !ok {
 		return ""
 	}
 	// Enum membership wins: accepts model-specific values like "none" that

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -118,15 +118,19 @@ func envMappings() []Mapping {
 	return mappings
 }
 
-// effectiveMappings returns env overrides followed by built-in mappings.
+// effectiveMappings returns env overrides, then built-in mappings, then any
+// mappings discovered from Kiro's catalog. First match wins, so an explicit
+// override beats a built-in and a built-in beats discovery.
 func effectiveMappings() []Mapping {
 	overrides := envMappings()
-	if len(overrides) == 0 {
+	discovered := catalogMappings()
+	if len(overrides) == 0 && len(discovered) == 0 {
 		return modelMapOrdered
 	}
-	result := make([]Mapping, 0, len(overrides)+len(modelMapOrdered))
+	result := make([]Mapping, 0, len(overrides)+len(modelMapOrdered)+len(discovered))
 	result = append(result, overrides...)
 	result = append(result, modelMapOrdered...)
+	result = append(result, discovered...)
 	return result
 }
 


### PR DESCRIPTION
  ## What changed

  **Region override.** `-kiro-api-region` / `KIRO_API_REGION` previously only applied to `-kiro-api-key` auth. It now pins the region in `runtime.<region>.kiro.dev` for every auth mode, overriding whatever the credential resolves to. Implemented as `kiroclient.WithRegion` plus an`effectiveRegion()` helper used by both `endpointURL` and the OTel `kiro.region` attribute. Auth is untouched.

  **Automatic model discovery.** New `internal/kirocatalog` calls `AmazonCodeWhispererService.ListAvailableModels` on `management.<region>.kiro.dev` (a different host from the streaming API) and parses `modelId`, `tokenLimits.maxInputTokens`, and the effort enum nested at `additionalModelRequestFieldsSchema.properties.output_config.properties.effort.enum`. New `internal/models/catalog.go` turns that into mappings — deriving the Anthropic-form alias by replacing dots with hyphens, and emitting a `[1m]` alias for always-1M SKUs — and installs them behind the built-in table. `ResolveEffort` falls back to a discovered enum when a model is absent from `effortEnums`. Non-Claude models are ignored. Gated by `-model-discovery` (default on) / `KIROCC_MODEL_DISCOVERY`.

  ## Behaviour

  - Resolution order is `KIROCC_MODEL_MAPPINGS` → built-in table →
    discovered catalog, first match wins. Existing model behaviour is
    unchanged: the catalog advertises 1M input for `claude-sonnet-4.6`, but
    built-ins still route bare sonnet-4.6 to the 200k window and only switch
    to the `-1m` SKU on explicit opt-in.
  - The region override applies to API endpoints only. Token refresh keeps
    targeting the region that issued the credential, since a token is
    rejected outside it.
  - `-kiro-api-region` is validated against `^[a-z0-9]+(-[a-z0-9]+)*$` and a
    64-char cap, and rejected at startup otherwise. The value is
    interpolated into a hostname, so `evil.example.com` or
    `us-east-1/../x` would otherwise redirect requests — and the bearer
    token with them — to an arbitrary host.
  - Discovery never blocks startup and never fails a request: it runs in a
    background goroutine with a 20s timeout, is skipped when the credential
    has no profile ARN (the API requires one, so API-key auth cannot use
    it), and logs `WRN model discovery failed, using built-in model table`
    on any error while leaving the built-in table intact.
  - `GET /v1/models` now also lists discovered Claude models.
  - No breaking change for anyone who leaves both flags alone. Users who
    set `KIRO_API_REGION` while on DB credentials will now see it take
    effect, where it was previously ignored.

  ## Tests

  `make test -race` green across all 18 packages; `go vet` and `gofmt` clean.

  - `internal/config`: region validation table covering uppercase, path
    traversal, host injection, userinfo injection, leading hyphen and
    over-length input; `KIRO_API_REGION` and `KIROCC_MODEL_DISCOVERY`
    overrides.
  - `internal/kiroclient`: `endpointURL` precedence (base URL > pinned
    region > per-call region) and `effectiveRegion`.
  - `internal/models`: opus-5 resolution (bare, `[1m]` alias, `context-1m`
    header) and its effort enum including the invalid-value drop.
  - `internal/models/catalog_test.go` (new): alias derivation, new-SKU
    reporting, discovered-model resolution, built-ins winning over
    discovery, env overrides winning over discovery, effort fallback and
    clamping, `ListModels` inclusion/exclusion, and reset semantics.
  - `internal/kirocatalog/client_test.go` (new): request shape (path,
    `X-Amz-Target`, bearer, required `origin` and `profileArn`), parsing of
    the nested effort enum, missing-input guards, and three error paths
    (validation exception, malformed JSON, empty catalog).
  - `internal/server`: `TestE2E_Opus5_RoutesAndForwardsEffort` asserts
    upstream `modelId=claude-opus-5`, `effort=xhigh` forwarded in
    `additionalModelRequestFields`, and response model `claude-opus-5[1m]`.

  ## Manual verification

  Against the real Kiro API, from an IDC credential whose stored region is
  `ap-southeast-1` — the exact case this PR fixes.

  - `ListAvailableModels` on `management.us-east-1.kiro.dev` returned 19
    models including `claude-opus-5` with the token limits and effort enum
    encoded here.
  - `dig runtime.ap-southeast-1.kiro.dev` returns no record;
    `runtime.us-east-1.kiro.dev` and `runtime.eu-central-1.kiro.dev`
    resolve.
  - With `-kiro-api-region us-east-1`, startup logged
    `Kiro API region pinned region=us-east-1` alongside
    `credentials loaded region=ap-southeast-1`, then
    `model catalog discovered region=us-east-1 advertised=19
    new_models=[claude-sonnet-4]`.
  - `POST /v1/messages` with `model=claude-opus-5` returned 200, response
    model `claude-opus-5[1m]`, `stop_reason=end_turn`. The streaming variant
    emitted the same model in `message_start`.
  - `GET /v1/models` returned 10 ids including `claude-opus-5` (built-in)
    and `claude-sonnet-4` (discovery-only, proving the fallback layer is
    live).
  - Negative control without the flag: the same request returned 502
    upstream API error, and discovery warned and fell back to the built-in
    table.