### PR TITLE
Release v0.9.0

### DIFF
--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,0 +1,41 @@
+# Release v0.9.0
+
+## New Features
+
+### Kiro API Region Override for All Auth Modes (#100)
+
+`-kiro-api-region` / `KIRO_API_REGION` previously only applied to `-kiro-api-key` auth. It now pins the region in `runtime.<region>.kiro.dev` for every auth mode, overriding whatever the credential resolves to.
+
+- The override applies to API endpoints only. Token refresh keeps targeting the region that issued the credential.
+- The region value is validated at startup (`^[a-z0-9]+(-[a-z0-9]+)*$`, max 64 chars) to prevent host injection.
+- Users who set `KIRO_API_REGION` while on IDC/social credentials will now see it take effect, where it was previously ignored.
+
+### Automatic Model Discovery (#100)
+
+kirocc now discovers available Claude models from the Kiro management API (`ListAvailableModels`) at startup and installs them behind the built-in model table.
+
+- Resolution order: `KIROCC_MODEL_MAPPINGS` → built-in table → discovered catalog, first match wins. Existing model behaviour is unchanged.
+- Discovery never blocks startup and never fails a request: it runs in a background goroutine with a 20s timeout and falls back to the built-in table on any error.
+- Discovery requires a profile ARN, so it is skipped for API-key auth.
+- `GET /v1/models` now also lists discovered Claude models.
+- Gated by `-model-discovery` (default on) / `KIROCC_MODEL_DISCOVERY`.
+
+## Contributors
+
+- @Artoria-OwO (#100)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.9.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.8.0...v0.9.0


### PR DESCRIPTION
## Summary

Release v0.9.0

See `docs/release-notes/v0.9.0.md` for details.