### PR TITLE
fix(reqconv): promote tool_result images to message images

### DIFF
--- a/internal/reqconv/content_scan.go
+++ b/internal/reqconv/content_scan.go
@@ -1,6 +1,7 @@
 package reqconv
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -11,6 +12,14 @@ import (
 // scanCurrentMessage walks message content once and extracts tool_results and
 // images. Replaces the former pattern of calling ExtractToolResults and
 // ExtractImages separately, which scanned the block list twice.
+//
+// Images nested inside tool_result blocks are promoted to the returned images
+// slice so they reach the model. Kiro's ToolResultContent only carries Text or
+// JSON (see kiroproto.ToolResultContent), so an image cannot be attached to the
+// tool result itself; UserInputMessage.Images is the only image channel for the
+// current turn. Without promotion, a tool that returns an image (for example
+// Read on a PNG) yields no text, so stdout becomes "(empty result)" and the
+// image is silently lost.
 func scanCurrentMessage(content anthropic.MessageContent) (toolResults []kiroproto.ToolResult, images []kiroproto.Image) {
 	if content.IsString() {
 		return nil, nil
@@ -25,6 +34,14 @@ func scanCurrentMessage(content anthropic.MessageContent) (toolResults []kiropro
 				exitStatus = "1"
 			}
 			text := extractToolResultContentText(b)
+			// Promote any images carried by this tool_result to the turn-level
+			// image list, and describe them in stdout so the text and the
+			// attached images stay correlated for the model.
+			promoted := extractToolResultImages(b)
+			if len(promoted) > 0 {
+				images = append(images, promoted...)
+				text = appendImageNotice(text, len(promoted))
+			}
 			if text == "" {
 				text = "(empty result)"
 			}
@@ -38,19 +55,60 @@ func scanCurrentMessage(content anthropic.MessageContent) (toolResults []kiropro
 				}}},
 			})
 		case b.Type == anthropic.BlockTypeImage && b.Source != nil:
-			if b.Source.Type != "base64" {
-				slog.Warn("skipping non-base64 image source type", "type", b.Source.Type)
-				continue
+			if img, ok := convertImageBlock(b); ok {
+				images = append(images, img)
 			}
-			format := b.Source.MediaType
-			if idx := strings.LastIndex(format, "/"); idx >= 0 {
-				format = format[idx+1:]
-			}
-			images = append(images, kiroproto.Image{
-				Format: format,
-				Source: kiroproto.ImageSource{Bytes: b.Source.Data},
-			})
 		}
 	}
 	return toolResults, images
+}
+
+// convertImageBlock converts a base64 Anthropic image block to a Kiro image.
+// Non-base64 sources (for example URL references) are skipped with a warning
+// because the Kiro wire format only accepts inline bytes.
+func convertImageBlock(b anthropic.ContentBlock) (kiroproto.Image, bool) {
+	if b.Source == nil {
+		return kiroproto.Image{}, false
+	}
+	if b.Source.Type != "base64" {
+		slog.Warn("skipping non-base64 image source type", "type", b.Source.Type)
+		return kiroproto.Image{}, false
+	}
+	format := b.Source.MediaType
+	if idx := strings.LastIndex(format, "/"); idx >= 0 {
+		format = format[idx+1:]
+	}
+	return kiroproto.Image{
+		Format: format,
+		Source: kiroproto.ImageSource{Bytes: b.Source.Data},
+	}, true
+}
+
+// extractToolResultImages collects image blocks nested in a tool_result's
+// content. A tool_result whose content is a plain string carries no images.
+func extractToolResultImages(b anthropic.ContentBlock) []kiroproto.Image {
+	if b.Content.IsString() {
+		return nil
+	}
+	var images []kiroproto.Image
+	for _, cb := range b.Content.Blocks {
+		if cb.Type != anthropic.BlockTypeImage || cb.Source == nil {
+			continue
+		}
+		if img, ok := convertImageBlock(cb); ok {
+			images = append(images, img)
+		}
+	}
+	return images
+}
+
+// appendImageNotice records in the tool result's stdout that images were moved
+// to the message-level image list, so the model can tell which tool produced
+// them instead of seeing an unexplained attachment.
+func appendImageNotice(text string, n int) string {
+	notice := fmt.Sprintf("[%d image(s) from this tool result attached to the message]", n)
+	if text == "" {
+		return notice
+	}
+	return text + "\n" + notice
 }

--- a/internal/reqconv/content_scan_images_test.go
+++ b/internal/reqconv/content_scan_images_test.go
@@ -1,0 +1,136 @@
+package reqconv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/d-kuro/kirocc/internal/anthropic"
+)
+
+// Images nested in a tool_result must be promoted to the message-level image
+// list. Kiro's ToolResultContent carries only Text or JSON, so without
+// promotion an image-only tool result (e.g. the Read tool on a PNG) collapses
+// to "(empty result)" and the image never reaches the model.
+func TestScanCurrentMessagePromotesToolResultImages(t *testing.T) {
+	content := anthropic.MessageContent{
+		Blocks: []anthropic.ContentBlock{{
+			Type:      anthropic.BlockTypeToolResult,
+			ToolUseID: "toolu_read_png",
+			Content: anthropic.MessageContent{
+				Blocks: []anthropic.ContentBlock{{
+					Type: anthropic.BlockTypeImage,
+					Source: &anthropic.ImageSource{
+						Type:      "base64",
+						MediaType: "image/png",
+						Data:      "iVBORw0KGgo=",
+					},
+				}},
+			},
+		}},
+	}
+
+	toolResults, images := scanCurrentMessage(content)
+
+	if len(toolResults) != 1 {
+		t.Fatalf("expected 1 tool result, got %d", len(toolResults))
+	}
+	if len(images) != 1 {
+		t.Fatalf("expected 1 promoted image, got %d", len(images))
+	}
+	if images[0].Format != "png" {
+		t.Errorf("expected format png, got %q", images[0].Format)
+	}
+	if images[0].Source.Bytes != "iVBORw0KGgo=" {
+		t.Errorf("image bytes not carried through, got %q", images[0].Source.Bytes)
+	}
+
+	stdout, _ := toolResults[0].Content[0].JSON["stdout"].(string)
+	if stdout == "(empty result)" {
+		t.Error("stdout is still \"(empty result)\"; the image was not accounted for")
+	}
+	if !strings.Contains(stdout, "1 image(s)") {
+		t.Errorf("stdout should note the attached image, got %q", stdout)
+	}
+}
+
+// A tool_result mixing text and an image keeps its text and appends the notice.
+func TestScanCurrentMessageToolResultTextPlusImage(t *testing.T) {
+	content := anthropic.MessageContent{
+		Blocks: []anthropic.ContentBlock{{
+			Type:      anthropic.BlockTypeToolResult,
+			ToolUseID: "toolu_mixed",
+			Content: anthropic.MessageContent{
+				Blocks: []anthropic.ContentBlock{
+					{Type: anthropic.BlockTypeText, Text: "rendered ortho_front.png"},
+					{Type: anthropic.BlockTypeImage, Source: &anthropic.ImageSource{
+						Type: "base64", MediaType: "image/jpeg", Data: "/9j/4AAQ",
+					}},
+				},
+			},
+		}},
+	}
+
+	toolResults, images := scanCurrentMessage(content)
+
+	if len(images) != 1 || images[0].Format != "jpeg" {
+		t.Fatalf("expected one jpeg image, got %+v", images)
+	}
+	stdout, _ := toolResults[0].Content[0].JSON["stdout"].(string)
+	if !strings.Contains(stdout, "rendered ortho_front.png") {
+		t.Errorf("original text lost, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "1 image(s)") {
+		t.Errorf("missing image notice, got %q", stdout)
+	}
+}
+
+// Non-base64 image sources cannot be sent inline and must be skipped rather
+// than emitted with empty bytes.
+func TestScanCurrentMessageSkipsNonBase64ToolResultImage(t *testing.T) {
+	content := anthropic.MessageContent{
+		Blocks: []anthropic.ContentBlock{{
+			Type:      anthropic.BlockTypeToolResult,
+			ToolUseID: "toolu_url",
+			Content: anthropic.MessageContent{
+				Blocks: []anthropic.ContentBlock{{
+					Type: anthropic.BlockTypeImage,
+					Source: &anthropic.ImageSource{
+						Type: "url", MediaType: "image/png", Data: "https://example.com/a.png",
+					},
+				}},
+			},
+		}},
+	}
+
+	toolResults, images := scanCurrentMessage(content)
+
+	if len(images) != 0 {
+		t.Errorf("expected no images for url source, got %d", len(images))
+	}
+	stdout, _ := toolResults[0].Content[0].JSON["stdout"].(string)
+	if stdout != "(empty result)" {
+		t.Errorf("expected \"(empty result)\" when nothing usable was found, got %q", stdout)
+	}
+}
+
+// Regression guard: a top-level image block (the paste-into-chat path) must
+// keep working exactly as before.
+func TestScanCurrentMessageTopLevelImageUnchanged(t *testing.T) {
+	content := anthropic.MessageContent{
+		Blocks: []anthropic.ContentBlock{{
+			Type: anthropic.BlockTypeImage,
+			Source: &anthropic.ImageSource{
+				Type: "base64", MediaType: "image/webp", Data: "UklGRg==",
+			},
+		}},
+	}
+
+	toolResults, images := scanCurrentMessage(content)
+
+	if len(toolResults) != 0 {
+		t.Errorf("expected no tool results, got %d", len(toolResults))
+	}
+	if len(images) != 1 || images[0].Format != "webp" {
+		t.Fatalf("expected one webp image, got %+v", images)
+	}
+}


### PR DESCRIPTION
Fixes #102.

Images nested in `tool_result` blocks never reached the model. `extractToolResultContentText` handles only text and `tool_references`, so an image-only tool result yielded `""` and the caller substituted `"(empty result)"` — the bytes were discarded with no warning.

`ToolResultContent` carries only `Text` or `JSON`, so the image cannot ride on the tool result itself. This promotes such images to `UserInputMessage.Images`, the image channel for the current turn that `buildCurrentMessage` already attaches, and appends a short note to `stdout` so the model can tell which tool produced them.

The top-level image path is unchanged; its inline conversion is factored into `convertImageBlock` so both paths apply the same base64 check and media-type split.

The history path is deliberately untouched — `buildHistory` already logs dropped images and that limitation is real, since the history entry type has no image field.

### Tests

Four cases in `content_scan_images_test.go`: image-only tool result, mixed text+image, non-base64 source (skipped), and a regression guard for top-level blocks. They fail before the change (`expected 1 promoted image, got 0`) and pass after.

Verified end-to-end against a live Kiro backend with `KIRO_API_KEY` auth: the reproduction from #102 returns `Red` on the patched build and "the file appears empty" on an unpatched one, same fixture and upstream.

Two notes on what I could not check locally: `go test -race` needs cgo and I had no C toolchain on this machine, so I ran the suite without `-race` (the change adds no goroutines, channels, or shared state); and `golangci-lint` was not installed, so lint is unverified beyond `go vet`, `go fix`, and `go mod tidy`, which are all clean. Social-login auth is untested — the change is not auth-dependent, but I only exercised the API-key path.

### Open question

Whether to annotate `stdout` at all, and the wording if so, is a judgement call I'd defer to you. Dropping the note keeps the tool result byte-identical to today's output at the cost of the model not knowing which tool the attachment came from.
