### PR TITLE
Release v0.9.1

### DIFF
--- a/docs/release-notes/v0.9.1.md
+++ b/docs/release-notes/v0.9.1.md
@@ -1,0 +1,37 @@
+# Release v0.9.1
+
+## Bug Fixes
+
+### Images in Tool Results Now Reach the Model (#103)
+
+Images nested inside `tool_result` blocks were silently dropped: an image-only tool result collapsed to `"(empty result)"`, so agent tools that return images (e.g. Claude Code's `Read` on a PNG) made the model conclude the file was empty.
+
+Kiro's `ToolResultContent` only carries text or JSON, so such images are now promoted to the message-level image channel (`UserInputMessage.Images`), which the current turn already attaches. The tool result's `stdout` gains a short notice (`[N image(s) from this tool result attached to the message]`) so the model can tell which tool produced the attachment.
+
+- Top-level image blocks (images pasted directly into chat) are unchanged.
+- Non-base64 image sources (e.g. URL references) are still skipped with a warning, as the Kiro wire format only accepts inline bytes.
+- The history path is unchanged: history entries have no image field, and dropped images there were already logged.
+
+## Code Improvements
+
+- Update `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` to v0.70.0 (#99)
+
+## Contributors
+
+- @Void0312Aurora (#103)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.9.1
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.9.0...v0.9.1


### PR DESCRIPTION
## Summary

Release v0.9.1

See `docs/release-notes/v0.9.1.md` for details.