### PR TITLE
fix(models): make the 1M context window selectable from Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ claude
 
 `ANTHROPIC_AUTH_TOKEN` is required by Claude Code but not used for authentication by kirocc (credentials are read from Kiro CLI's DB). Any non-empty value works unless `-api-key` is set.
 
-`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` makes Claude Code fetch `GET /v1/models` from kirocc and list the results in the `/model` picker under "From gateway" — including the GPT 5.6 models via their `claude-gpt-5.6-*` aliases (see [Model picker integration](#model-picker-integration-discovery-aliases)).
+`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` makes Claude Code fetch `GET /v1/models` from kirocc and list the results in the `/model` picker under "From gateway" — including the "(1M context)" entries (see [1M context with Claude Code](#1m-context-with-claude-code)) and the GPT 5.6 models via their `claude-gpt-5.6-*` aliases (see [Model picker integration](#model-picker-integration-discovery-aliases)).
+
+> [!IMPORTANT]
+> For the 1M context window you must pick a "(1M context)" entry in `/model` — see [1M context with Claude Code](#1m-context-with-claude-code).
 
 ### Use with a Kiro API key
 
@@ -172,7 +175,7 @@ The override applies to the API endpoints only. Token refresh still targets the 
 
 At startup kirocc calls Kiro's `ListAvailableModels` and installs the result as a fallback layer behind the built-in mapping table. A model Kiro launches after a kirocc release therefore resolves with its real context window and effort enum instead of falling back to pass-through defaults, and shows up in `GET /v1/models`.
 
-Resolution order is `KIROCC_MODEL_MAPPINGS` → built-in table → discovered catalog, first match wins. Built-ins deliberately win: they encode behaviour a mechanically derived entry cannot reproduce, such as which `[1m]` aliases must *not* enable extended thinking and which SKU a 1M request routes to.
+Resolution order is `KIROCC_MODEL_MAPPINGS` → built-in table → discovered catalog, first match wins. Built-ins deliberately win: they encode behaviour a mechanically derived entry cannot reproduce, such as which `[1m]` aliases must _not_ enable extended thinking and which SKU a 1M request routes to.
 
 Discovery is best-effort and never blocks startup or fails a request. It is skipped when the credential has no profile ARN (which is the case for `-kiro-api-key` auth, since the API requires one), and any error leaves the built-in table in place:
 
@@ -203,6 +206,8 @@ Use the `KIROCC_MODEL_MAPPINGS` environment variable to override model name mapp
 ```bash
 export KIROCC_MODEL_MAPPINGS='[{"anthropic":"my-model","kiro":"claude-sonnet-4.5","context_window_size":200000}]'
 ```
+
+Optional fields: `kiro_1m` (the SKU a 1M request routes to; set it equal to `kiro` for an always-1M model) and `display_name` (adds the entry to `/v1/models`, so Claude Code's picker lists it — plus a `(1M context)` variant when `kiro_1m` is a separate SKU). An `anthropic` ID may carry the `[1m]` suffix in either case; it is canonicalized to `[1m]`. Because overrides win the lookup, an override that shadows a built-in ID also replaces its `[1m]` entry — the list only advertises a 1M ID when the override can actually deliver it.
 
 ## Endpoints
 
@@ -304,13 +309,14 @@ kiro-cli 2.10.0 expresses reasoning depth natively through `output_config.effort
 }
 ```
 
-Thinking is enabled by any of:
+Thinking is enabled by either of:
 
 - Model name with `[1m]` suffix (e.g., `claude-sonnet-4-6[1m]`)
-- `Anthropic-Beta` header containing `context-1m` (e.g., `context-1m-2025-01-01`)
 - `thinking.type` set to `"enabled"` or `"adaptive"` in the request
 
-Exception: the `[1m]` suffix on an **always-1M** model (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) is a first-class alias that only advertises the 1M context window — it does **not** enable thinking (see [Model mappings](#model-mappings)). Thinking on those models is still opt-in via the `context-1m` header or the `thinking` field.
+An `Anthropic-Beta` header containing `context-1m` (e.g., `context-1m-2025-08-07`) is a pure context-window signal, matching Anthropic's long-context beta semantics: it routes the request to the model's 1M SKU but does **not** enable thinking. Claude Code sends this header automatically whenever the session model carries `[1m]`, so coupling it to thinking would force thinking on for every 1M session.
+
+Exception: the `[1m]` suffix on an **always-1M** model (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) is a first-class alias that only advertises the 1M context window — it does **not** enable thinking either (see [Model mappings](#model-mappings)). Thinking on those models is opt-in via the `thinking` field.
 
 The suffix is matched case-insensitively because Claude Code may emit `[1M]`
 from internal call paths. Responses always use the canonical lowercase `[1m]`.
@@ -318,7 +324,7 @@ from internal call paths. Responses always use the canonical lowercase `[1m]`.
 The reasoning effort sent to the backend is resolved as follows:
 
 1. An explicit, recognized `output_config.effort` wins, validated/clamped to the model's allowed enum (`xhigh` on a 4-value model clamps to `max`; unrecognized strings are dropped).
-2. Otherwise, if reasoning is enabled (via `thinking.type`, the `[1m]` suffix, or the `context-1m` header) without an explicit effort, a default effort of `medium` is sent so the intent reaches the backend.
+2. Otherwise, if reasoning is enabled (via `thinking.type` or the `[1m]` suffix) without an explicit effort, a default effort of `medium` is sent so the intent reaches the backend.
 3. Otherwise the field is omitted.
 
 Per-model allowed effort levels:
@@ -421,17 +427,28 @@ Supported query forms:
 | `claude-gpt-5.6-terra`  | `gpt-5.6-terra`        | 272k           |
 | `claude-gpt-5.6-luna`   | `gpt-5.6-luna`         | 272k           |
 
-Opus 5, Opus 4.6, 4.7, 4.8, and Sonnet 5 always use 1M context (no 200k SKU exists upstream). Unlike Sonnet 4.6, `claude-opus-5` and `claude-sonnet-5` have no separate `-1m` SKU: each single SKU is always 1M. The explicit `[1m]`-suffixed aliases (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field — this matches Claude Code's 1M-context model state and keeps its context-window check happy without spuriously enabling extended thinking. On these always-1M models, thinking remains opt-in via the `context-1m` header or the `thinking` field; the `[1m]` suffix remains a thinking opt-in for models without a first-class always-1M alias.
+Opus 5, Opus 4.6, 4.7, 4.8, and Sonnet 5 always use 1M context (no 200k SKU exists upstream). Unlike Sonnet 4.6, `claude-opus-5` and `claude-sonnet-5` have no separate `-1m` SKU: each single SKU is always 1M. The explicit `[1m]`-suffixed aliases (`claude-opus-5[1m]` / `claude-opus-4-8[1m]` / `claude-opus-4-7[1m]` / `claude-opus-4-6[1m]` / `claude-sonnet-5[1m]`) are first-class entries that preserve the suffix verbatim in the response `model` field and do **not** enable extended thinking. On these always-1M models, thinking is opt-in via the `thinking` field; the `[1m]` suffix remains a thinking opt-in for models without a first-class always-1M alias.
 
 Unmatched `claude-*` models are passed through as-is. Non-claude models fall back to `claude-sonnet-4.6` (the `gpt-5.6-*` IDs and their `claude-gpt-5.6-*` discovery aliases above are explicit entries and do not fall back).
+
+#### 1M context with Claude Code
+
+Claude Code (verified against 2.1.232) decides the context window **client-side, from the session model string**: a model whose ID matches `/\[1m\]/i` gets the 1M window; everything else served through a custom `ANTHROPIC_BASE_URL` gets 200k and auto-compacts at ~160k — even when upstream actually has 1M of context. Neither the response `model` field nor anything else kirocc returns can influence this.
+
+To get the 1M window, the **session model itself** must carry the suffix:
+
+- With `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, pick a "(1M context)" entry in the `/model` picker — kirocc advertises `claude-opus-5[1m]` ("Opus 5 (1M context)"), `claude-sonnet-4-6[1m]` ("Sonnet 4.6 (1M context)"), etc. in `GET /v1/models` for exactly this purpose. Discovery results are cached in `~/.claude/cache/gateway-models.json`, so restart Claude Code after upgrading kirocc.
+- Or set the model explicitly: `claude --model 'claude-opus-5[1m]'`, `ANTHROPIC_MODEL=claude-opus-5[1m]`, or `"model"` in settings.json.
+
+A `[1m]` session model also makes Claude Code send `Anthropic-Beta: context-1m-2025-08-07` on every request; kirocc treats that header as a context-window signal only (it never enables thinking — see [Extended Thinking](#extended-thinking)).
 
 #### Response model ID
 
 The `model` field in `/v1/messages` responses (streaming `message_start`, non-streaming body, and tool-search path) is returned as the **Anthropic-form ID** (e.g. `claude-opus-4-7`), not the Kiro SKU (`claude-opus-4.7`).
 
-When the proxy routes to a **1M context window** (always-1M SKU such as `claude-opus-5` / `claude-opus-4.8` / `claude-opus-4.7` / `claude-opus-4.6`, or a model invoked with the `[1m]` suffix or `Anthropic-Beta: context-1m` header), a trailing `[1m]` is appended to the response model ID (e.g. `claude-opus-5[1m]`). Claude Code's client-side context-window logic matches `/\[1m\]/i` on the response model to pick the 1M window — without the suffix it defaults to 200k and auto-compacts at ~160k even when upstream actually has 1M of context.
+When the proxy routes to a **1M context window** (always-1M SKU such as `claude-opus-5` / `claude-opus-4.8` / `claude-opus-4.7` / `claude-opus-4.6`, or a model invoked with the `[1m]` suffix or `Anthropic-Beta: context-1m` header), a trailing `[1m]` is appended to the response model ID (e.g. `claude-opus-5[1m]`). This is informational: it reflects the routed window in Claude Code's per-model usage stats, but Claude Code's context-window logic itself only reads the session model string (see [1M context with Claude Code](#1m-context-with-claude-code)).
 
-Note: `[1m]` has different meanings on request vs. response. On the **request** `model` it is a client-supplied thinking-opt-in signal (and is stripped before upstream routing). On the **response** `model` it is purely a context-window advertisement for Claude Code and does not imply that extended thinking was enabled.
+Note: `[1m]` has different meanings on request vs. response. On the **request** `model` it is a client-supplied signal (stripped before upstream routing). On the **response** `model` it is purely a routed-window annotation and does not imply that extended thinking was enabled.
 
 ## License
 

--- a/internal/app/messages/effort.go
+++ b/internal/app/messages/effort.go
@@ -20,8 +20,8 @@ func formatContextWindow(size int) string {
 }
 
 // defaultThinkingEffort is the native effort level sent when a request enables
-// reasoning (thinking.type, the [1m] suffix, or the context-1m header) without
-// an explicit output_config.effort. kiro-cli 2.10.0 expresses all reasoning depth
+// reasoning (thinking.type or the [1m] suffix) without an explicit
+// output_config.effort. kiro-cli 2.10.0 expresses all reasoning depth
 // through effort, so this carries the "thinking on" intent to the backend. It
 // matches the medium tier the old thinking-XML path defaulted to.
 const defaultThinkingEffort = models.EffortMedium
@@ -33,8 +33,8 @@ const defaultThinkingEffort = models.EffortMedium
 //
 //  1. An explicit, recognized output_config.effort wins (validated/clamped to
 //     the model's enum; xhigh on a 4-value model clamps to max).
-//  2. Otherwise, if reasoning is enabled via thinking/[1m]/context-1m, fall back
-//     to defaultThinkingEffort so the intent still reaches the backend natively.
+//  2. Otherwise, if reasoning is enabled via thinking/[1m], fall back to
+//     defaultThinkingEffort so the intent still reaches the backend natively.
 //  3. Otherwise (and for unrecognized or unsupported effort), return "" so
 //     additionalModelRequestFields is omitted.
 //

--- a/internal/app/messages/effort_test.go
+++ b/internal/app/messages/effort_test.go
@@ -13,7 +13,7 @@ func TestResolveEffort(t *testing.T) {
 		name         string
 		kiroModel    string
 		effort       string // request output_config.effort
-		thinking     bool   // resolved thinking flag (type/[1m]/context-1m)
+		thinking     bool   // resolved thinking flag (type/[1m])
 		want         string
 		thinkingType string // request thinking.type ("" = absent)
 	}{

--- a/internal/models/catalog.go
+++ b/internal/models/catalog.go
@@ -63,12 +63,16 @@ func SetCatalog(discovered []CatalogModel) []string {
 			// An always-1M SKU: no separate -1m variant exists, so Kiro1M is the
 			// SKU itself and the `[1m]` alias is a context-window advertisement
 			// that must not turn thinking on (matching the built-in opus rows).
+			// It carries a display name so the picker labels it like a built-in
+			// 1M entry instead of showing a bare suffixed ID; there is no
+			// friendly name for a model this build predates, so the ID stands in.
 			entry.Kiro1M = d.ID
 			mappings = append(mappings, Mapping{
 				Anthropic:         alias + ThinkingSuffix,
 				Kiro:              d.ID,
 				Kiro1M:            d.ID,
 				ContextWindowSize: d.MaxInputTokens,
+				DisplayName:       alias,
 			})
 		}
 		mappings = append(mappings, entry)

--- a/internal/models/catalog_test.go
+++ b/internal/models/catalog_test.go
@@ -76,11 +76,10 @@ func TestSetCatalog_DiscoveredModelResolves(t *testing.T) {
 			wantAnthropicModel: "claude-opus-9[1m]",
 		},
 		{
-			name:               "context1M header still enables thinking",
+			name:               "context1M header advertises 1m without enabling thinking",
 			model:              "claude-opus-9",
 			context1M:          true,
 			wantKiroModel:      "claude-opus-9",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "claude-opus-9[1m]",
 		},
@@ -193,11 +192,19 @@ func TestSetCatalog_ListModelsIncludesDiscovered(t *testing.T) {
 
 	got := ListModels()
 	ids := make([]string, 0, len(got))
+	names := make(map[string]string, len(got))
 	for _, m := range got {
 		ids = append(ids, m.ID)
+		names[m.ID] = m.DisplayName
 	}
 	if !slices.Contains(ids, "claude-opus-9") {
 		t.Errorf("ListModels() = %v, missing claude-opus-9", ids)
+	}
+	// Discovered always-1M models get a [1m] alias row; it must be advertised
+	// so Claude Code's picker can select the 1M context window, and labelled so
+	// it does not show up as a bare suffixed ID next to the built-ins.
+	if want := "claude-opus-9 (1M context)"; names["claude-opus-9[1m]"] != want {
+		t.Errorf("ListModels() claude-opus-9[1m] display name = %q, want %q", names["claude-opus-9[1m]"], want)
 	}
 	if slices.Contains(ids, "gpt-9-nova") {
 		t.Errorf("ListModels() = %v, discovery must not add non-claude models", ids)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -13,15 +13,45 @@ type Mapping struct {
 	Kiro              string `json:"kiro"`
 	Kiro1M            string `json:"kiro_1m,omitempty"`
 	ContextWindowSize int    `json:"context_window_size,omitzero"` // 0 means use default
-	// DisplayName, when set, additionally advertises the Anthropic ID in
-	// /v1/models with this display_name. Used for discovery aliases: Claude
-	// Code's gateway model discovery drops IDs not starting with
-	// claude/anthropic, so non-claude upstream models need a claude- prefixed
-	// alias to appear in the model picker.
+	// DisplayName is the label for the model picker. It doubles as the opt-in
+	// for advertising the Anthropic ID in /v1/models at all: a mapping without
+	// one contributes only its Kiro SKU. See ListModels for what gets
+	// advertised. On a `[1m]` row it names the base model ("Opus 5"); the
+	// "(1M context)" part is appended by display1M.
 	DisplayName string `json:"display_name,omitempty"`
 }
 
+// hasSeparate1MSKU reports whether the mapping's 1M context window lives in a
+// distinct upstream SKU (e.g. claude-sonnet-4.6 → claude-sonnet-4.6-1m), so
+// reaching 1M means switching SKUs. Its twin is the always-1M shape
+// (Kiro1M == Kiro), which Resolve's switch tests directly against the resolved
+// SKU because the mapping may not have matched at all.
+func (m Mapping) hasSeparate1MSKU() bool {
+	return m.Kiro1M != "" && m.Kiro1M != m.Kiro
+}
+
 const ThinkingSuffix = "[1m]"
+
+// oneMLabel is appended to a picker label for the 1M-context variant of a
+// model. Kept as one constant so every advertised `[1m]` entry reads the same.
+const oneMLabel = " (1M context)"
+
+// display1M labels the 1M-context variant of the model named by base. An empty
+// base stays empty so a mapping without a DisplayName is advertised unlabelled
+// rather than as a bare " (1M context)".
+func display1M(base string) string {
+	if base == "" {
+		return ""
+	}
+	return base + oneMLabel
+}
+
+// hasThinkingSuffix reports whether a model ID carries the trailing 1M context
+// marker, in either case Claude Code emits.
+func hasThinkingSuffix(model string) bool {
+	_, ok := strings.CutSuffix(normalizeThinkingSuffix(model), ThinkingSuffix)
+	return ok
+}
 
 // normalizeThinkingSuffix canonicalizes the trailing 1M context marker while
 // leaving the model ID itself untouched. Claude Code emits both `[1m]` and
@@ -48,16 +78,19 @@ const (
 // Uses exact key matching against both Anthropic and Kiro fields (first match wins).
 // Order matters: specific entries must precede legacy aliases that share the same Kiro value.
 var modelMapOrdered = []Mapping{
-	{Anthropic: "claude-opus-5[1m]", Kiro: "claude-opus-5", Kiro1M: "claude-opus-5"},
-	{Anthropic: "claude-opus-4-8[1m]", Kiro: "claude-opus-4.8", Kiro1M: "claude-opus-4.8"},
-	{Anthropic: "claude-opus-4-7[1m]", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
-	{Anthropic: "claude-opus-4-6[1m]", Kiro: "claude-opus-4.6", Kiro1M: "claude-opus-4.6"},
-	{Anthropic: "claude-sonnet-5[1m]", Kiro: "claude-sonnet-5", Kiro1M: "claude-sonnet-5"},
+	{Anthropic: "claude-opus-5[1m]", Kiro: "claude-opus-5", Kiro1M: "claude-opus-5", DisplayName: "Opus 5"},
+	{Anthropic: "claude-opus-4-8[1m]", Kiro: "claude-opus-4.8", Kiro1M: "claude-opus-4.8", DisplayName: "Opus 4.8"},
+	{Anthropic: "claude-opus-4-7[1m]", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7", DisplayName: "Opus 4.7"},
+	{Anthropic: "claude-opus-4-6[1m]", Kiro: "claude-opus-4.6", Kiro1M: "claude-opus-4.6", DisplayName: "Opus 4.6"},
+	{Anthropic: "claude-sonnet-5[1m]", Kiro: "claude-sonnet-5", Kiro1M: "claude-sonnet-5", DisplayName: "Sonnet 5"},
 	{Anthropic: "claude-opus-5", Kiro: "claude-opus-5", Kiro1M: "claude-opus-5"},
 	{Anthropic: "claude-opus-4-8", Kiro: "claude-opus-4.8", Kiro1M: "claude-opus-4.8"},
 	{Anthropic: "claude-opus-4-7", Kiro: "claude-opus-4.7", Kiro1M: "claude-opus-4.7"},
 	{Anthropic: "claude-sonnet-5", Kiro: "claude-sonnet-5", Kiro1M: "claude-sonnet-5"},
-	{Anthropic: "claude-sonnet-4-6", Kiro: "claude-sonnet-4.6", Kiro1M: "claude-sonnet-4.6-1m"},
+	{Anthropic: "claude-sonnet-4-6", Kiro: "claude-sonnet-4.6", Kiro1M: "claude-sonnet-4.6-1m", DisplayName: "Sonnet 4.6"},
+	// No DisplayName, so this legacy row stays out of the picker (and gets no
+	// `[1m]` entry) even though it has a 1M SKU. Deliberate: give it a display
+	// name to surface it.
 	{Anthropic: "claude-sonnet-4.5", Kiro: "claude-sonnet-4.5", Kiro1M: "claude-sonnet-4.5-1m"},
 	{Anthropic: "claude-opus-4-6", Kiro: "claude-opus-4.6", Kiro1M: "claude-opus-4.6"},
 	{Anthropic: "claude-opus-4.5", Kiro: "claude-opus-4.5"},
@@ -114,6 +147,12 @@ func envMappings() []Mapping {
 		envCache.parsed = nil
 		return nil
 	}
+	// Canonicalize the suffix here, once, so every consumer compares and
+	// advertises the same spelling: lookups normalize the incoming model ID, so
+	// a row written as `custom[1M]` would otherwise be unreachable.
+	for i := range mappings {
+		mappings[i].Anthropic = normalizeThinkingSuffix(mappings[i].Anthropic)
+	}
 	envCache.parsed = mappings
 	return mappings
 }
@@ -142,11 +181,17 @@ func effectiveMappings() []Mapping {
 //  1. Exact match against `m.Anthropic` / `m.Kiro` first (no `[1m]` strip).
 //     This catches always-1M aliases like `claude-opus-4-7[1m]` that are a
 //     context-window advertisement, not a thinking opt-in — the suffix is
-//     preserved verbatim in `anthropicModel` and `thinking` stays false.
+//     preserved verbatim in `anthropicModel` and `thinking` stays false. Such a
+//     row still routes to its `Kiro1M` SKU when that is a separate one.
 //  2. If no exact match, strip a trailing `[1m]` from the input, set
 //     `thinking = true`, and retry the lookup. This is the legacy path
 //     used by aliases that don't have an explicit `[1m]` entry (e.g.
 //     `claude-sonnet-4-6[1m]` routes to the `-1m` Kiro SKU with thinking).
+//
+// `context1M` (the `context-1m` Anthropic-Beta header) routes to the 1M SKU
+// without enabling thinking: Claude Code sends the header automatically
+// whenever the session model carries `[1m]`, so coupling it to thinking would
+// force thinking on for every 1M session.
 //
 // The output `anthropicModel` gets a trailing `[1m]` when the routed
 // context window is 1M (regardless of thinking), so Claude Code's
@@ -175,7 +220,7 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 		}
 	}
 
-	// Tier 2: strip `[1m]` (treated as thinking opt-in) and retry.
+	// Tier 2: strip `[1m]` (a thinking + 1M opt-in) and retry.
 	// Reasoning-style models (GPT 5.6) are excluded — they have no 1M variant
 	// and no thinking opt-in, so e.g. `gpt-5.6-sol[1m]` falls through to the
 	// default fallback below. Judging by the resolved Kiro model's intrinsic
@@ -203,10 +248,6 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 		}
 	}
 
-	if context1M {
-		thinking = true
-	}
-
 	if !matched {
 		// reasoningExcluded blocks the claude- passthrough: a claude- prefixed
 		// discovery alias to a GPT model (`claude-gpt-5.6-sol[1m]`) must not
@@ -226,13 +267,20 @@ func Resolve(model string, context1M bool) (kiroModel string, thinking bool, con
 		anthropicModel = matchedAnthropic
 	}
 
+	// Route to the mapping's 1M SKU when any signal asked for it: the
+	// `context-1m` header (window only), the tier-2 suffix (window + thinking,
+	// which is why `thinking` implies it), or a matched row that spells the
+	// suffix in its own Anthropic ID — such a row exists to advertise 1M, so it
+	// must not answer with the 200k SKU.
+	want1M := context1M || thinking || hasThinkingSuffix(matchedAnthropic)
+
 	// A mapping with Kiro1M == Kiro means the model always uses 1M context
-	// (no separate -1m SKU exists upstream, e.g. claude-opus-4.7). Thinking
-	// stays off unless explicitly requested via suffix, header, or request field.
+	// (no separate -1m SKU exists upstream, e.g. claude-opus-4.7), so it needs
+	// no opt-in.
 	switch {
 	case matchedKiro1M == kiroModel:
 		contextWindowSize = ThinkingContextWindowSize
-	case thinking && matchedKiro1M != "":
+	case want1M && matchedKiro1M != "":
 		kiroModel = matchedKiro1M
 		contextWindowSize = ThinkingContextWindowSize
 	case matchedWindowSize > 0:
@@ -322,6 +370,14 @@ func lookupMapping(model string) (m Mapping, want1M, ok bool) {
 	return Mapping{}, false, false
 }
 
+// routes1M reports whether the model ID actually resolves to the 1M context
+// window. Used by ListModels so an advertised `[1m]` ID is never one Resolve
+// would answer with the 200k window.
+func routes1M(model string) bool {
+	_, _, contextWindowSize, _ := Resolve(model, false)
+	return contextWindowSize == ThinkingContextWindowSize
+}
+
 // ModelInfo is one entry served by /v1/models.
 type ModelInfo struct {
 	ID          string
@@ -329,11 +385,23 @@ type ModelInfo struct {
 }
 
 // ListModels returns a deduplicated list of all model IDs to advertise in
-// /v1/models: each mapping's Kiro value, plus the Anthropic ID of any mapping
-// with a DisplayName (discovery aliases). Env overrides are included.
+// /v1/models: every mapping's Kiro SKU, plus each mapping's Anthropic ID when
+// it is a `[1m]` row or carries a DisplayName. A named mapping whose 1M window
+// lives in a separate SKU also gets a `[1m]` entry, so both windows are
+// pickable — but only when that ID really resolves to 1M, so the list never
+// offers a window kirocc cannot deliver. Env overrides and discovered models
+// are included.
+//
+// The `[1m]` entries exist for Claude Code: its context-window logic runs
+// client-side on the session model string (/\[1m\]/i), so only a picker entry
+// whose ID carries the suffix makes it track the 1M window — the response
+// `model` field cannot influence it.
 func ListModels() []ModelInfo {
-	seen := make(map[string]struct{})
-	var result []ModelInfo
+	mappings := effectiveMappings()
+	// Each mapping contributes its SKU and up to two Anthropic IDs; most
+	// contribute two entries in total.
+	seen := make(map[string]struct{}, 2*len(mappings))
+	result := make([]ModelInfo, 0, 2*len(mappings))
 	add := func(id, displayName string) {
 		if id == "" {
 			return
@@ -344,9 +412,23 @@ func ListModels() []ModelInfo {
 		seen[id] = struct{}{}
 		result = append(result, ModelInfo{ID: id, DisplayName: displayName})
 	}
-	for _, m := range effectiveMappings() {
-		if m.DisplayName != "" {
+	for _, m := range mappings {
+		// Branching on the suffix keeps a double-suffixed ID unrepresentable.
+		switch {
+		case hasThinkingSuffix(m.Anthropic):
+			add(m.Anthropic, display1M(m.DisplayName))
+		case m.DisplayName != "":
 			add(m.Anthropic, m.DisplayName)
+			// Advertise the synthesized 1M ID only when it really routes to 1M.
+			// Asking Resolve instead of trusting this row keeps the promise
+			// honest when an earlier mapping shadows it — an env override on the
+			// same Anthropic ID with no 1M SKU wins the lookup, so the alias
+			// would resolve to a 200k window. hasSeparate1MSKU short-circuits
+			// first: rows that never get an alias must not pay for a lookup, and
+			// suffixing a reasoning model would log a fallback warning.
+			if alias := m.Anthropic + ThinkingSuffix; m.hasSeparate1MSKU() && routes1M(alias) {
+				add(alias, display1M(m.DisplayName))
+			}
 		}
 		add(m.Kiro, "")
 	}

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -38,11 +39,10 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-opus-5[1m]",
 		},
 		{
-			name:               "claude-opus-5 with context1M enables thinking",
+			name:               "claude-opus-5 with context1M keeps thinking off",
 			model:              "claude-opus-5",
 			context1M:          true,
 			wantKiroModel:      "claude-opus-5",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "claude-opus-5[1m]",
 		},
@@ -61,11 +61,10 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-opus-4-8[1m]",
 		},
 		{
-			name:               "claude-opus-4-8 with context1M",
+			name:               "claude-opus-4-8 with context1M keeps thinking off",
 			model:              "claude-opus-4-8",
 			context1M:          true,
 			wantKiroModel:      "claude-opus-4.8",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "claude-opus-4-8[1m]",
 		},
@@ -92,11 +91,10 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-opus-4-7[1m]",
 		},
 		{
-			name:               "claude-opus-4-7 with context1M",
+			name:               "claude-opus-4-7 with context1M keeps thinking off",
 			model:              "claude-opus-4-7",
 			context1M:          true,
 			wantKiroModel:      "claude-opus-4.7",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "claude-opus-4-7[1m]",
 		},
@@ -123,11 +121,10 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-opus-4-6[1m]",
 		},
 		{
-			name:               "claude-opus-4-6 with context1M",
+			name:               "claude-opus-4-6 with context1M keeps thinking off",
 			model:              "claude-opus-4-6",
 			context1M:          true,
 			wantKiroModel:      "claude-opus-4.6",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "claude-opus-4-6[1m]",
 		},
@@ -153,11 +150,10 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-sonnet-5[1m]",
 		},
 		{
-			name:               "claude-sonnet-5 with context1M enables thinking",
+			name:               "claude-sonnet-5 with context1M keeps thinking off",
 			model:              "claude-sonnet-5",
 			context1M:          true,
 			wantKiroModel:      "claude-sonnet-5",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "claude-sonnet-5[1m]",
 		},
@@ -192,11 +188,10 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-sonnet-4-6[1m]",
 		},
 		{
-			name:               "claude-sonnet-4-6 with context1M resolves to 1m",
+			name:               "claude-sonnet-4-6 with context1M resolves to 1m without thinking",
 			model:              "claude-sonnet-4-6",
 			context1M:          true,
 			wantKiroModel:      "claude-sonnet-4.6-1m",
-			wantThinking:       true,
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "claude-sonnet-4-6[1m]",
 		},
@@ -224,11 +219,10 @@ func TestResolve(t *testing.T) {
 			wantAnthropicModel: "claude-haiku-4.5",
 		},
 		{
-			name:               "claude-haiku-4.5 with context1M no 1m variant",
+			name:               "claude-haiku-4.5 with context1M no 1m variant keeps thinking off",
 			model:              "claude-haiku-4.5",
 			context1M:          true,
 			wantKiroModel:      "claude-haiku-4.5",
-			wantThinking:       true,
 			wantContextWindow:  DefaultContextWindowSize,
 			wantAnthropicModel: "claude-haiku-4.5",
 		},
@@ -360,6 +354,27 @@ func TestResolve(t *testing.T) {
 			wantContextWindow:  ThinkingContextWindowSize,
 			wantAnthropicModel: "custom-1m[1m]",
 		},
+		{
+			// A row that spells `[1m]` in its own ID exists to advertise 1M, so
+			// the exact-match tier must still switch to the separate 1M SKU —
+			// without turning thinking on, since the ID itself carried no opt-in
+			// beyond the window.
+			name:               "env override suffixed row routes to its separate 1m SKU",
+			envMappings:        `[{"anthropic":"custom[1m]","kiro":"claude-custom","kiro_1m":"claude-custom-1m"}]`,
+			model:              "custom[1m]",
+			wantKiroModel:      "claude-custom-1m",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "custom[1m]",
+		},
+		{
+			// Same row, requested in the case Claude Code sometimes emits.
+			name:               "env override suffixed row matches an upper-case request",
+			envMappings:        `[{"anthropic":"custom[1M]","kiro":"claude-custom","kiro_1m":"claude-custom-1m"}]`,
+			model:              "custom[1M]",
+			wantKiroModel:      "claude-custom-1m",
+			wantContextWindow:  ThinkingContextWindowSize,
+			wantAnthropicModel: "custom[1m]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -448,30 +463,115 @@ func TestListModels(t *testing.T) {
 	}
 }
 
-func TestListModels_DiscoveryAliasDisplayNames(t *testing.T) {
+// The display names drive Claude Code's model picker, and the `[1m]` IDs are
+// what make it track the 1M window (it matches /\[1m\]/i on the session model
+// string client-side).
+func TestListModels_DisplayNames(t *testing.T) {
 	t.Setenv("KIROCC_MODEL_MAPPINGS", "")
 
-	wantNames := map[string]string{
-		"claude-gpt-5.6-sol":   "GPT 5.6 Sol",
-		"claude-gpt-5.6-terra": "GPT 5.6 Terra",
-		"claude-gpt-5.6-luna":  "GPT 5.6 Luna",
-		// Canonical IDs carry no display name.
-		"gpt-5.6-sol":   "",
-		"claude-opus-5": "",
+	tests := []struct {
+		id         string
+		want       string // expected display_name ("" = advertised unlabelled)
+		wantAbsent bool
+	}{
+		// Discovery aliases for the non-claude models.
+		{id: "claude-gpt-5.6-sol", want: "GPT 5.6 Sol"},
+		{id: "claude-gpt-5.6-terra", want: "GPT 5.6 Terra"},
+		{id: "claude-gpt-5.6-luna", want: "GPT 5.6 Luna"},
+		// Canonical SKUs are advertised unlabelled.
+		{id: "gpt-5.6-sol"},
+		{id: "claude-opus-5"},
+		// Always-1M models: one labelled `[1m]` entry each.
+		{id: "claude-opus-5[1m]", want: "Opus 5 (1M context)"},
+		{id: "claude-opus-4-8[1m]", want: "Opus 4.8 (1M context)"},
+		{id: "claude-opus-4-7[1m]", want: "Opus 4.7 (1M context)"},
+		{id: "claude-opus-4-6[1m]", want: "Opus 4.6 (1M context)"},
+		{id: "claude-sonnet-5[1m]", want: "Sonnet 5 (1M context)"},
+		// Separate 1M SKU: both windows are pickable.
+		{id: "claude-sonnet-4-6", want: "Sonnet 4.6"},
+		{id: "claude-sonnet-4-6[1m]", want: "Sonnet 4.6 (1M context)"},
+		// An unnamed row stays out of the picker, `[1m]` alias included.
+		{id: "claude-sonnet-4.5[1m]", wantAbsent: true},
 	}
+
 	got := make(map[string]string)
 	for _, m := range ListModels() {
 		got[m.ID] = m.DisplayName
 	}
-	for id, want := range wantNames {
-		name, ok := got[id]
-		if !ok {
-			t.Errorf("ListModels missing %q", id)
-			continue
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			name, ok := got[tt.id]
+			switch {
+			case tt.wantAbsent:
+				if ok {
+					t.Errorf("ListModels advertises %q, want it absent", tt.id)
+				}
+			case !ok:
+				t.Errorf("ListModels missing %q", tt.id)
+			case name != tt.want:
+				t.Errorf("ListModels %q display name = %q, want %q", tt.id, name, tt.want)
+			}
+		})
+	}
+}
+
+// An env override may spell the suffix in either case, so the suffix test must
+// match case-insensitively — otherwise the row reads as unsuffixed and gets a
+// second suffix appended.
+func TestListModels_UppercaseSuffixOverrideIsNotDoubleSuffixed(t *testing.T) {
+	t.Setenv("KIROCC_MODEL_MAPPINGS",
+		`[{"anthropic":"custom[1M]","kiro":"claude-custom","kiro_1m":"claude-custom-1m","display_name":"Custom"}]`)
+
+	for _, m := range ListModels() {
+		if strings.Contains(strings.ToLower(m.ID), "[1m][1m]") {
+			t.Errorf("ListModels advertises double-suffixed ID %q", m.ID)
 		}
-		if name != want {
-			t.Errorf("ListModels %q display name = %q, want %q", id, name, want)
-		}
+	}
+}
+
+// The published ID set must agree with what Resolve can actually route.
+// /v1/models is a promise: a `[1m]` entry that resolves to the 200k window, or
+// any entry that matches no mapping at all (so Resolve falls back), offers the
+// picker a choice kirocc cannot honour.
+func TestListModels_AdvertisedIDsResolveAsAdvertised(t *testing.T) {
+	tests := []struct {
+		name        string
+		envMappings string
+	}{
+		{
+			name: "built-ins only",
+		},
+		{
+			// The override shadows the built-in claude-sonnet-4-6 row and has no
+			// 1M SKU, so the built-in's `[1m]` alias can no longer be delivered.
+			name:        "override shadows a mapping that has a 1M SKU",
+			envMappings: `[{"anthropic":"claude-sonnet-4-6","kiro":"claude-pinned"}]`,
+		},
+		{
+			// Resolve normalizes the request before comparing, so an ID
+			// advertised with an upper-case suffix would never match its own row.
+			name:        "override spells the suffix in upper case",
+			envMappings: `[{"anthropic":"custom[1M]","kiro":"claude-custom","kiro_1m":"claude-custom-1m","display_name":"Custom"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KIROCC_MODEL_MAPPINGS", tt.envMappings)
+
+			for _, m := range ListModels() {
+				if _, _, ok := lookupMapping(m.ID); !ok {
+					t.Errorf("advertised %q matches no mapping, so Resolve falls back", m.ID)
+				}
+				if !hasThinkingSuffix(m.ID) {
+					continue
+				}
+				if _, _, window, _ := Resolve(m.ID, false); window != ThinkingContextWindowSize {
+					t.Errorf("advertised %q resolves to a %d window, want %d", m.ID, window, ThinkingContextWindowSize)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Every model served through kirocc ran at a 200k context window in Claude Code, even the always-1M ones.

Claude Code decides a session's context window **client-side**, from the model string it holds — it matches `/\[1m\]/i` on it and picks 1M or 200k accordingly. Three consequences, all confirmed against the 2.1.232 binary:

- The `[1m]` suffix kirocc echoes in the response `model` field cannot influence the window at all. It only feeds per-model usage stats. The README claimed otherwise.
- The registry path that would trust a server-advertised `native_1m` capability is gated on an official `api.anthropic.com` base URL, so it never runs for a localhost proxy.
- The `context-1m` beta header is itself only sent once the session model string already carries `[1m]` — it cannot bootstrap the window.

So the only lever left is the model ID the user selects. Nothing kirocc returned in a response could ever flip the window.

## Change

`/v1/models` now advertises Anthropic-form `[1m]` IDs with `"<name> (1M context)"` display names, so selecting one in `/model` gives Claude Code a session model string that carries the suffix. Mappings whose 1M window lives in a separate SKU get both entries, so both windows stay pickable; unnamed rows stay out of the picker as before.

While making the advertised set meaningful, three ways it could disagree with what `Resolve` actually routes were fixed:

- A synthesized 1M ID is advertised only when it **really** resolves to 1M (asked of `Resolve`, not derived from the row), so a `KIROCC_MODEL_MAPPINGS` override that shadows a built-in cannot leave behind a 1M entry the proxy would answer at 200k.
- A mapping whose own `anthropic` ID carries `[1m]` now routes to its `kiro_1m` SKU. No built-in row has that shape (all are always-1M), so this only fixes hand-written override rows.
- The `[1m]` suffix in override IDs is canonicalized at parse time, so a row written `custom[1M]` is advertised and matched in the same normal form instead of being unreachable.

Separately, the `context-1m` header is decoupled from extended thinking. Claude Code sends that header automatically for **every** 1M session, so coupling it forced thinking on whenever 1M was in use. It is now a context-window signal only, matching Anthropic's long-context beta semantics; the `[1m]` suffix and the `thinking` field remain the thinking opt-ins.

Discovered always-1M models also get a display name on their `[1m]` row, so they are labelled like built-ins instead of appearing as bare suffixed IDs.

## Usage

With `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, pick a `(1M context)` entry in `/model`, or start with `claude --model 'claude-opus-5[1m]'` / `ANTHROPIC_MODEL`. Claude Code caches gateway models per base URL, so a restart is needed to see the new entries.

## Tests

- New invariant test over the published ID set: every advertised ID must match a mapping (so `Resolve` never falls back), and every `[1m]` ID must resolve to the 1M window. Covered with built-ins only, with a shadowing override, and with an upper-case suffix override — the last two fail without this change.
- Table-driven display-name coverage for the advertised entries, `Resolve` cases for suffixed override rows in both spellings, and the `context1M` cases updated to assert thinking stays off.
- `make test` (`-race`), `make lint` (0 issues), `make build` all clean.