### PR TITLE
Release v0.10.0

### DIFF
--- a/docs/release-notes/v0.10.0.md
+++ b/docs/release-notes/v0.10.0.md
@@ -1,0 +1,49 @@
+# Release v0.10.0
+
+## New Features
+
+### Advisor Server-Side Tool Emulation (Experimental) (#104)
+
+kirocc now emulates Anthropic's `advisor_20260301` server-side tool in-proxy. When the executor model calls the advisor tool, kirocc issues a separate upstream request to the configured advisor model carrying the conversation so far, and returns the guidance as an `advisor_tool_result` block — one client request, N upstream calls, matching the real API's lifecycle.
+
+- Advisor tokens are reported in `usage.iterations[]` as `advisor_message` entries; credits fold into round totals.
+- `max_uses` accounting (default 2), strict advisor model resolution with no silent fallback, and preflight errors surfaced as `advisor_tool_result_error` instead of HTTP errors.
+- The tool-search inner loop was generalized into a shared server-tool orchestrator handling both tools.
+- `ExpandServerToolResults` rewrites packed assistant server-tool rounds into the user/assistant alternation Kiro requires, so advice survives replay from client-supplied history (also fixes the same hole for tool-search results).
+
+> **Warning — Experimental.** Anthropic does not publish the system prompt used to run the advisor model server-side. The instruction kirocc sends to the advisor model is an original implementation written for this proxy, not a reproduction of Anthropic's. Advisor behavior may therefore differ from the real Anthropic API, and the prompt may change as we learn more.
+
+Known limitations:
+
+- `advisor_redacted_result` (`encrypted_content`) is accept-and-replay only; kirocc never produces it.
+- The `caching` option on the tool definition is validated but honored only on a best-effort basis.
+- Empty advisor responses can still occur nondeterministically on some large conversations even after one retry; they degrade to `advisor_tool_result_error: unavailable` rather than failing the request.
+
+## Bug Fixes
+
+### 1M Context Window Selectable from Claude Code (#108)
+
+Every model served through kirocc previously ran at a 200k context window in Claude Code, even the always-1M ones. Claude Code decides a session's context window client-side from the model string it holds (matching `[1m]`), so nothing kirocc returned in a response could flip the window.
+
+- `GET /v1/models` now advertises Anthropic-form `[1m]` IDs with `"<name> (1M context)"` display names, so selecting one in `/model` gives Claude Code a session model string that carries the suffix. Mappings whose 1M window lives in a separate SKU get both entries.
+- A synthesized 1M ID is advertised only when it really resolves to 1M, so a `KIROCC_MODEL_MAPPINGS` override that shadows a built-in cannot leave behind a 1M entry the proxy would answer at 200k.
+- The `[1m]` suffix in override IDs is canonicalized at parse time, so a row written `custom[1M]` is advertised and matched in the same normal form.
+- The `context-1m` beta header is decoupled from extended thinking: it is now a context-window signal only. Claude Code sends that header automatically for every 1M session, so coupling it forced thinking on whenever 1M was in use.
+
+Usage: with `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, pick a `(1M context)` entry in `/model`, or start with `claude --model 'claude-opus-5[1m]'`. Claude Code caches gateway models per base URL, so a restart is needed to see the new entries.
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.10.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.9.1...v0.10.0


### PR DESCRIPTION
## Summary

Release v0.10.0

See `docs/release-notes/v0.10.0.md` for details.