### PR TITLE
fix(config): use LocalAppData for Windows database

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,11 @@ API keys are available for Kiro Pro, Pro+, Pro Max, and Power subscribers. On gr
 
 #### Default DB path
 
-| OS    | Path                                                  |
-| ----- | ----------------------------------------------------- |
-| macOS | `~/Library/Application Support/kiro-cli/data.sqlite3` |
-| Linux | `~/.local/share/kiro-cli/data.sqlite3`                |
+| OS      | Path                                                  |
+| ------- | ----------------------------------------------------- |
+| macOS   | `~/Library/Application Support/kiro-cli/data.sqlite3` |
+| Linux   | `~/.local/share/kiro-cli/data.sqlite3`                |
+| Windows | `%LOCALAPPDATA%\kiro-cli\data.sqlite3`               |
 
 ### Environment variables
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,18 +58,28 @@ const maxRegionLen = 64
 
 // DefaultDBPath returns the default kiro-cli SQLite database location.
 func DefaultDBPath() string {
+	if runtime.GOOS == "windows" {
+		localAppData, err := os.UserCacheDir()
+		if err != nil {
+			return ""
+		}
+		return DefaultDBPathFor(runtime.GOOS, "", localAppData)
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
-	return DefaultDBPathFor(runtime.GOOS, home)
+	return DefaultDBPathFor(runtime.GOOS, home, "")
 }
 
-// DefaultDBPathFor returns the default database location for the given OS and home directory.
-func DefaultDBPathFor(goos, home string) string {
+// DefaultDBPathFor returns the default database location for the given OS and user directories.
+func DefaultDBPathFor(goos, home, localAppData string) string {
 	switch goos {
 	case "darwin":
 		return filepath.Join(home, "Library", "Application Support", "kiro-cli", "data.sqlite3")
+	case "windows":
+		return filepath.Join(localAppData, "kiro-cli", "data.sqlite3")
 	default:
 		return filepath.Join(home, ".local", "share", "kiro-cli", "data.sqlite3")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -129,29 +130,50 @@ func TestApplyEnvOverrides_KeepAliveInterval(t *testing.T) {
 
 func TestDefaultDBPathFor(t *testing.T) {
 	tests := []struct {
-		name string
-		goos string
-		home string
-		want string
+		name         string
+		goos         string
+		home         string
+		localAppData string
+		want         string
 	}{
 		{
 			name: "darwin",
 			goos: "darwin",
 			home: "/Users/dkuro",
-			want: "/Users/dkuro/Library/Application Support/kiro-cli/data.sqlite3",
+			want: filepath.Join(
+				"/Users/dkuro", "Library", "Application Support", "kiro-cli", "data.sqlite3",
+			),
 		},
 		{
 			name: "linux",
 			goos: "linux",
 			home: "/home/dkuro",
-			want: "/home/dkuro/.local/share/kiro-cli/data.sqlite3",
+			want: filepath.Join(
+				"/home/dkuro", ".local", "share", "kiro-cli", "data.sqlite3",
+			),
+		},
+		{
+			name:         "windows",
+			goos:         "windows",
+			home:         `C:\Users\dkuro`,
+			localAppData: `D:\Profiles\dkuro\AppData\Local`,
+			want: filepath.Join(
+				`D:\Profiles\dkuro\AppData\Local`, "kiro-cli", "data.sqlite3",
+			),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultDBPathFor(tt.goos, tt.home); got != tt.want {
-				t.Fatalf("DefaultDBPathFor(%q, %q) = %q, want %q", tt.goos, tt.home, got, tt.want)
+			if got := DefaultDBPathFor(tt.goos, tt.home, tt.localAppData); got != tt.want {
+				t.Fatalf(
+					"DefaultDBPathFor(%q, %q, %q) = %q, want %q",
+					tt.goos,
+					tt.home,
+					tt.localAppData,
+					got,
+					tt.want,
+				)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- use Windows LocalAppData for the default Kiro CLI SQLite database path
- add regression coverage for Windows while preserving macOS and Linux defaults
- document the Windows default database location

## Problem

Windows currently falls through to the Linux default (`~/.local/share/kiro-cli/data.sqlite3`). Kiro CLI stores its database under `%LOCALAPPDATA%\kiro-cli`, so database-backed authentication fails with SQLite error 14 unless `-db` or `KIROCC_DB_PATH` is set manually.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./internal/config`
- `GOEXPERIMENT=jsonv2 go run ./cmd/kirocc -h` on Windows; verified the default resolves under LocalAppData