### PR TITLE
fix: make the request body cap configurable and diagnosable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ API keys are available for Kiro Pro, Pro+, Pro Max, and Power subscribers. On gr
 | `-kiro-api-region`    | (credential's region)     | Region for Kiro API endpoints (`runtime.<region>.kiro.dev`)         |
 | `-model-discovery`    | `true`                    | Fetch Kiro's model catalog at startup                               |
 | `-keepalive-interval` | `15s`                     | SSE idle keep-alive interval (0 = disabled)                         |
+| `-max-request-bytes`  | `33554432`                | Max accepted client request body size in bytes (0 = unlimited)      |
 | `-debug`              | `false`                   | Enable debug logging                                                |
 | `-log-file`           | (none)                    | Write logs to file with rotation (file-only by default)             |
 | `-log-max-size`       | `10`                      | Max log file size in MB before rotation                             |
@@ -142,6 +143,7 @@ Command-line options can be overridden with environment variables.
 | `KIRO_API_REGION`           | `-kiro-api-region`    |
 | `KIROCC_MODEL_DISCOVERY`    | `-model-discovery`    |
 | `KIROCC_KEEPALIVE_INTERVAL` | `-keepalive-interval` |
+| `KIROCC_MAX_REQUEST_BYTES`  | `-max-request-bytes`  |
 | `KIROCC_DEBUG`              | `-debug`              |
 | `KIROCC_LOG_FILE`           | `-log-file`           |
 | `KIROCC_LOG_MAX_SIZE`       | `-log-max-size`       |
@@ -153,6 +155,12 @@ Command-line options can be overridden with environment variables.
 | `KIROCC_OTEL_BODY_LIMIT`    | `-otel-body-limit`    |
 
 `KIRO_API_KEY` and `KIRO_API_REGION` intentionally keep Kiro's own names rather than the `KIROCC_` prefix, so a machine already configured for headless kiro-cli needs no kirocc-specific setup.
+
+#### Request body size
+
+`-max-request-bytes` defaults to 32 MiB, matching the size the Anthropic Messages API accepts. Images are what push a conversation toward it: a request carries the whole conversation, so every screenshot sent earlier is re-sent on every subsequent turn and the body only grows. Past the cap kirocc answers `413 request_too_large` naming the actual size and the limit.
+
+Retrying cannot help — the next attempt sends the same oversized body. Run `/compact` (or `/clear`) to drop the image blocks from history, or raise the limit.
 
 ### Custom API region
 

--- a/cmd/kirocc/main.go
+++ b/cmd/kirocc/main.go
@@ -123,6 +123,7 @@ func parseFlags(args []string) (config.Config, error) {
 	fs.BoolVar(&cfg.Debug, "debug", false, "enable debug logging with OTel JSON Lines output")
 	fs.BoolVar(&cfg.OTel, "otel", false, "enable OpenTelemetry tracing (OTLP HTTP exporter)")
 	fs.IntVar(&cfg.OTelBodyLimit, "otel-body-limit", config.DefaultOTelBodyLimit, "max bytes of request body to capture in OTel spans (0 = unlimited)")
+	fs.IntVar(&cfg.MaxRequestBytes, "max-request-bytes", config.DefaultMaxRequestBytes, "max accepted client request body size in bytes (0 = unlimited); also KIROCC_MAX_REQUEST_BYTES")
 	fs.DurationVar(&cfg.KeepAliveInterval, "keepalive-interval", config.DefaultKeepAliveInterval, "SSE idle keep-alive interval (0 = disabled)")
 	fs.StringVar(&cfg.LogFile.Path, "log-file", "", "write logs to file with rotation (for agent debugging)")
 	fs.IntVar(&cfg.LogFile.MaxSize, "log-max-size", logging.DefaultLogMaxSize, "max log file size in MB before rotation")
@@ -219,7 +220,10 @@ func discoverModels(ctx context.Context, authMgr *auth.AuthManager, regionOverri
 }
 
 func buildServer(authMgr *auth.AuthManager, client kiroclient.Client, cfg config.Config) *server.Server {
-	opts := []server.ServerOption{server.WithKeepAliveInterval(cfg.KeepAliveInterval)}
+	opts := []server.ServerOption{
+		server.WithKeepAliveInterval(cfg.KeepAliveInterval),
+		server.WithMaxRequestBytes(cfg.MaxRequestBytes),
+	}
 	if cfg.OTel {
 		opts = append(opts, server.WithOTel(cfg.OTelBodyLimit))
 	}

--- a/cmd/kirocc/main_test.go
+++ b/cmd/kirocc/main_test.go
@@ -92,3 +92,38 @@ func TestParseFlags_KeepAliveInterval(t *testing.T) {
 		}
 	})
 }
+
+func TestParseFlags_MaxRequestBytes(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg, err := parseFlags(nil)
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.MaxRequestBytes != config.DefaultMaxRequestBytes {
+			t.Fatalf("MaxRequestBytes = %v, want %v", cfg.MaxRequestBytes, config.DefaultMaxRequestBytes)
+		}
+		if cfg.MaxRequestBytes != 32<<20 {
+			t.Fatalf("MaxRequestBytes = %v, want %v", cfg.MaxRequestBytes, 32<<20)
+		}
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		cfg, err := parseFlags([]string{"-max-request-bytes", "1048576"})
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.MaxRequestBytes != 1048576 {
+			t.Fatalf("MaxRequestBytes = %v, want 1048576", cfg.MaxRequestBytes)
+		}
+	})
+
+	t.Run("zero means unlimited", func(t *testing.T) {
+		cfg, err := parseFlags([]string{"-max-request-bytes", "0"})
+		if err != nil {
+			t.Fatalf("parseFlags: %v", err)
+		}
+		if cfg.MaxRequestBytes != 0 {
+			t.Fatalf("MaxRequestBytes = %v, want 0", cfg.MaxRequestBytes)
+		}
+	})
+}

--- a/internal/app/messages/handler.go
+++ b/internal/app/messages/handler.go
@@ -21,10 +21,10 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	traceID, short := logging.TraceIDs(ctx)
 
-	req, err := parseAndValidateRequest(ctx, w, r)
+	req, bodyBytes, err := s.parseAndValidateRequest(ctx, w, r)
 	if err != nil {
-		slog.WarnContext(ctx, "invalid request", "trace_id", short, "err", err)
-		httpx.WriteError(w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
+		slog.WarnContext(ctx, "invalid request", "trace_id", short, "body_bytes", bodyBytes, "err", err)
+		writeRequestError(w, err)
 		return
 	}
 
@@ -54,7 +54,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 		thinking = true
 	}
 
-	s.logRequest(ctx, short, ccSessionID, kiroModel, contextWindowSize, req, thinking)
+	s.logRequest(ctx, short, ccSessionID, kiroModel, contextWindowSize, req, thinking, bodyBytes)
 
 	effort := resolveEffort(ctx, kiroModel, req, thinking)
 
@@ -99,7 +99,7 @@ func (s *Service) HandleMessages(w http.ResponseWriter, r *http.Request) {
 }
 
 // logRequest emits the "--> POST /v1/messages" info log summarizing the call.
-func (s *Service) logRequest(ctx context.Context, short, ccSessionID, kiroModel string, contextWindowSize int, req *anthropic.Request, thinking bool) {
+func (s *Service) logRequest(ctx context.Context, short, ccSessionID, kiroModel string, contextWindowSize int, req *anthropic.Request, thinking bool, bodyBytes int64) {
 	var thinkingLog any = false
 	if thinking {
 		if effort := req.Effort(); effort != "" {
@@ -115,6 +115,7 @@ func (s *Service) logRequest(ctx context.Context, short, ccSessionID, kiroModel 
 		"thinking", thinkingLog,
 		"stream", req.Stream,
 		"context_window", formatContextWindow(contextWindowSize),
+		"body_bytes", bodyBytes,
 	)
 }
 

--- a/internal/app/messages/request.go
+++ b/internal/app/messages/request.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,11 +18,78 @@ import (
 	"github.com/d-kuro/kirocc/internal/tokencount"
 )
 
+// requestTooLargeError reports a client body that exceeded the configured cap.
+// It is distinct from a malformed-JSON error so callers can answer 413 instead
+// of 400: "too big" is actionable (drop images, /compact), "malformed" is not,
+// and a client that cannot tell them apart retries the same oversized body
+// forever.
+type requestTooLargeError struct {
+	// size is the body size in bytes: exact when Content-Length was present or
+	// the body was drained to EOF, otherwise a lower bound.
+	size int64
+	// exact reports whether size is the full body size rather than a lower bound.
+	exact bool
+	limit int64
+}
+
+func (e *requestTooLargeError) Error() string {
+	if e.exact {
+		return fmt.Sprintf("request body too large: %d bytes exceeds the %d byte limit; "+
+			"remove images from the conversation, run /compact, or raise -max-request-bytes",
+			e.size, e.limit)
+	}
+	return fmt.Sprintf("request body too large: exceeded the %d byte limit (read %d bytes before aborting); "+
+		"remove images from the conversation, run /compact, or raise -max-request-bytes",
+		e.limit, e.size)
+}
+
+// countingReader tracks how many bytes were read from the underlying body, so
+// the size is known both for the "--> POST /v1/messages" log line and for the
+// too-large error when Content-Length was absent.
+type countingReader struct {
+	r io.ReadCloser
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+func (c *countingReader) Close() error { return c.r.Close() }
+
+// maxDrainBytes bounds how much of a rejected body is read and discarded before
+// answering. It is not a tuning knob; it exists so the error is deliverable.
+// Many HTTP clients write the whole request before reading any of the response
+// (Python's urllib among them). Answering an oversized request without reading
+// it leaves unread bytes on the connection, and closing then reaches the client
+// as a connection reset rather than the 413 — a transport failure in place of
+// the diagnosable error this path exists to produce. Reading the rest first lets
+// the client finish writing and see the answer; nginx solves the same problem
+// the same way, with lingering_close. Bounded so a hostile body cannot make
+// kirocc read forever.
+const maxDrainBytes = 64 << 20
+
+// drainRejected discards up to maxDrainBytes of a rejected request body,
+// reporting how much it discarded and whether it reached EOF. It must be given
+// the reader beneath the cap: a MaxBytesReader that has already tripped returns
+// its error forever and would discard nothing.
+func drainRejected(body io.Reader) (discarded int64, atEOF bool) {
+	// One byte past the bound distinguishes "drained it all" from "there was
+	// more", which is what decides whether the reported size is exact.
+	n, err := io.CopyN(io.Discard, body, maxDrainBytes+1)
+	if err == nil {
+		return n, false
+	}
+	return n, errors.Is(err, io.EOF)
+}
+
 // HandleCountTokens serves POST /v1/messages/count_tokens.
 func (s *Service) HandleCountTokens(w http.ResponseWriter, r *http.Request) {
-	req, err := parseAndValidateRequest(r.Context(), w, r)
+	req, _, err := s.parseAndValidateRequest(r.Context(), w, r)
 	if err != nil {
-		httpx.WriteError(w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
+		writeRequestError(w, err)
 		return
 	}
 
@@ -79,26 +147,73 @@ func (s *Service) HandleCountTokens(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("\n"))
 }
 
-// parseAndValidateRequest decodes and validates an Anthropic request from the HTTP body.
-func parseAndValidateRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) (*anthropic.Request, error) {
-	r.Body = http.MaxBytesReader(w, r.Body, 4<<20)
+// writeRequestError answers a parseAndValidateRequest failure, mapping an
+// oversized body to 413 request_too_large and everything else to 400.
+func writeRequestError(w http.ResponseWriter, err error) {
+	var tooLarge *requestTooLargeError
+	if errors.As(err, &tooLarge) {
+		httpx.WriteError(w, http.StatusRequestEntityTooLarge, httpx.ErrTypeRequestTooLarge, err.Error())
+		return
+	}
+	httpx.WriteError(w, http.StatusBadRequest, errTypeInvalidRequest, err.Error())
+}
+
+// parseAndValidateRequest decodes and validates an Anthropic request from the
+// HTTP body, returning the number of body bytes read alongside it. A body over
+// s.maxRequestBytes yields a *requestTooLargeError; a zero limit means unlimited.
+func (s *Service) parseAndValidateRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) (*anthropic.Request, int64, error) {
+	limit := int64(s.maxRequestBytes)
+	// Content-Length is advisory, but when the client sends one — Claude Code
+	// always does — an oversized body can be rejected before reading a byte of
+	// it, and the reported size is the real one rather than a lower bound.
+	if limit > 0 && r.ContentLength > limit {
+		drainRejected(r.Body)
+		return nil, r.ContentLength, &requestTooLargeError{size: r.ContentLength, exact: true, limit: limit}
+	}
+	// The counter sits *under* the cap, so it sees every byte consumed from the
+	// body: MaxBytesReader reads one byte past its limit to detect the overflow
+	// but does not hand that byte back, and counting above the cap would lose
+	// it. It also makes the drain below self-accounting, leaving counter.n the
+	// single source of truth for the size.
+	counter := &countingReader{r: r.Body}
+	var body io.ReadCloser = counter
+	if limit > 0 {
+		body = http.MaxBytesReader(w, counter, limit)
+	}
+	r.Body = body
+
+	toError := func(err error) error {
+		// MaxBytesReader's error survives the jsontext decoder's wrapping, so
+		// errors.As is the primary signal; the byte count is the fallback for a
+		// reader that reports the truncation differently.
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) || (limit > 0 && counter.n >= limit) {
+			// Draining yields the true total when it reaches the end, so a body
+			// sent without a Content-Length still gets its real size reported.
+			// It reads through the counter, so counter.n covers the drain too.
+			_, atEOF := drainRejected(counter)
+			return &requestTooLargeError{size: counter.n, exact: atEOF, limit: limit}
+		}
+		return fmt.Errorf("invalid request: %w", err)
+	}
+
 	var req anthropic.Request
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
 		raw, err := io.ReadAll(r.Body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid request: %w", err)
+			return nil, counter.n, toError(err)
 		}
 		slog.DebugContext(ctx, "client request body", "request_body", jsontext.Value(raw))
 		if err := json.UnmarshalDecode(jsontext.NewDecoder(bytes.NewReader(raw)), &req); err != nil {
-			return nil, fmt.Errorf("invalid request: %w", err)
+			return nil, counter.n, toError(err)
 		}
 	} else {
 		if err := json.UnmarshalRead(r.Body, &req); err != nil {
-			return nil, fmt.Errorf("invalid request: %w", err)
+			return nil, counter.n, toError(err)
 		}
 	}
 	if len(req.Messages) == 0 {
-		return nil, fmt.Errorf("messages must not be empty")
+		return nil, counter.n, fmt.Errorf("messages must not be empty")
 	}
-	return &req, nil
+	return &req, counter.n, nil
 }

--- a/internal/app/messages/request_test.go
+++ b/internal/app/messages/request_test.go
@@ -1,0 +1,257 @@
+package messages
+
+import (
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// validMessageBody is a minimal Anthropic request that parseAndValidateRequest accepts.
+const validMessageBody = `{"model":"claude-sonnet-4.6","messages":[{"role":"user","content":"hi"}]}`
+
+func TestParseAndValidateRequest_ContentLengthFastPath(t *testing.T) {
+	const limit = 100
+	body := strings.Repeat("a", limit+50)
+	s := New(nil, nil, WithMaxRequestBytes(limit))
+
+	// httptest.NewRequest sets ContentLength from a *strings.Reader automatically.
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	_, n, err := s.parseAndValidateRequest(context.Background(), w, r)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var tooLarge *requestTooLargeError
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("error = %v (%T), want *requestTooLargeError", err, err)
+	}
+	if !tooLarge.exact {
+		t.Errorf("exact = false, want true (Content-Length path)")
+	}
+	if tooLarge.size != int64(len(body)) {
+		t.Errorf("size = %d, want %d", tooLarge.size, len(body))
+	}
+	if tooLarge.limit != limit {
+		t.Errorf("limit = %d, want %d", tooLarge.limit, limit)
+	}
+	if n != int64(len(body)) {
+		t.Errorf("returned byte count = %d, want %d", n, len(body))
+	}
+
+	msg := tooLarge.Error()
+	if !strings.Contains(msg, fmt.Sprint(len(body))) {
+		t.Errorf("message %q should contain the observed size %d", msg, len(body))
+	}
+	if !strings.Contains(msg, fmt.Sprint(limit)) {
+		t.Errorf("message %q should contain the limit %d", msg, limit)
+	}
+}
+
+// TestParseAndValidateRequest_ChunkedPath proves the errors.As(err, &maxErr)
+// detection through the jsontext decoder works when Content-Length is
+// unknown (e.g. chunked transfer encoding), not just the fast Content-Length
+// path above.
+//
+// The body must be well-formed-looking JSON (not garbage) so the decoder
+// keeps pulling bytes instead of failing fast on a syntax error before ever
+// reaching the byte that trips MaxBytesReader.
+func TestParseAndValidateRequest_ChunkedPath(t *testing.T) {
+	const limit = 200
+	pad := strings.Repeat("a", 1000)
+	body := `{"model":"claude-sonnet-4.6","messages":[{"role":"user","content":"` + pad + `"}]}`
+	s := New(nil, nil, WithMaxRequestBytes(limit))
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	r.ContentLength = -1 // simulate chunked / unknown-length body
+	w := httptest.NewRecorder()
+
+	_, _, err := s.parseAndValidateRequest(context.Background(), w, r)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var tooLarge *requestTooLargeError
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("error = %v (%T), want *requestTooLargeError", err, err)
+	}
+	// Draining the rejected body reaches EOF here, so the size is the real
+	// total even though Content-Length was absent.
+	if !tooLarge.exact {
+		t.Errorf("exact = false, want true (drain reached EOF)")
+	}
+	if got, want := tooLarge.size, int64(len(body)); got != want {
+		t.Errorf("size = %d, want %d", got, want)
+	}
+	if tooLarge.limit != limit {
+		t.Errorf("limit = %d, want %d", tooLarge.limit, limit)
+	}
+}
+
+// TestParseAndValidateRequest_DrainsRejectedBody covers what makes the 413
+// deliverable: a rejected body is read to the end rather than left on the
+// connection. A client that writes its whole request before reading the
+// response — Python's urllib does — otherwise gets a connection reset instead
+// of the error. Asserted on both rejection paths, since the fast
+// Content-Length path answers before touching the body at all.
+func TestParseAndValidateRequest_DrainsRejectedBody(t *testing.T) {
+	pad := strings.Repeat("a", 1000)
+	body := `{"model":"claude-sonnet-4.6","messages":[{"role":"user","content":"` + pad + `"}]}`
+
+	tests := []struct {
+		name          string
+		contentLength int64
+	}{
+		{"content-length fast path", int64(len(body))},
+		{"unknown length", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(nil, nil, WithMaxRequestBytes(200))
+			// Held directly, because r.Body is wrapped in a MaxBytesReader that
+			// keeps returning its error once tripped no matter what remains
+			// beneath it — only the source shows whether the body was drained.
+			src := strings.NewReader(body)
+			r := httptest.NewRequest(http.MethodPost, "/v1/messages", src)
+			r.ContentLength = tt.contentLength
+			w := httptest.NewRecorder()
+
+			if _, _, err := s.parseAndValidateRequest(context.Background(), w, r); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if left := src.Len(); left != 0 {
+				t.Errorf("body not drained: %d bytes left unread, want 0", left)
+			}
+		})
+	}
+}
+
+// TestDrainRejected_BoundedForHostileBody confirms the drain cannot be used to
+// make kirocc read forever: an endless body stops at maxDrainBytes and reports
+// the size as a lower bound rather than the truth.
+func TestDrainRejected_BoundedForHostileBody(t *testing.T) {
+	endless := endlessReader{}
+	discarded, atEOF := drainRejected(endless)
+	if atEOF {
+		t.Error("atEOF = true, want false for an endless body")
+	}
+	if discarded != maxDrainBytes+1 {
+		t.Errorf("discarded = %d, want %d", discarded, int64(maxDrainBytes)+1)
+	}
+}
+
+// endlessReader yields bytes forever, standing in for a body that never ends.
+type endlessReader struct{}
+
+func (endlessReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+func TestParseAndValidateRequest_UnderLimit(t *testing.T) {
+	s := New(nil, nil, WithMaxRequestBytes(1<<20))
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(validMessageBody))
+	w := httptest.NewRecorder()
+
+	req, n, err := s.parseAndValidateRequest(context.Background(), w, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req == nil {
+		t.Fatal("expected a non-nil request")
+	}
+	if n != int64(len(validMessageBody)) {
+		t.Errorf("returned byte count = %d, want %d", n, len(validMessageBody))
+	}
+}
+
+// TestParseAndValidateRequest_Unlimited verifies that a zero limit (unlimited)
+// does not reject a body over the default 32 MiB cap for size. It may still
+// fail for another reason (malformed JSON), so the assertion is specifically
+// that any error is not *requestTooLargeError.
+func TestParseAndValidateRequest_Unlimited(t *testing.T) {
+	const size = 33 << 20 // 33 MiB, just over the default 32 MiB default cap
+	body := strings.Repeat("a", size)
+	s := New(nil, nil, WithMaxRequestBytes(0))
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	_, _, err := s.parseAndValidateRequest(context.Background(), w, r)
+	if err == nil {
+		// The body is not valid JSON for an anthropic.Request, so some error is
+		// expected; but if the decoder is ever relaxed this is still a pass.
+		return
+	}
+	var tooLarge *requestTooLargeError
+	if errors.As(err, &tooLarge) {
+		t.Fatalf("unlimited (limit=0) rejected body for size: %v", err)
+	}
+}
+
+func TestParseAndValidateRequest_MalformedJSON(t *testing.T) {
+	s := New(nil, nil, WithMaxRequestBytes(1<<20))
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+
+	_, _, err := s.parseAndValidateRequest(context.Background(), w, r)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	var tooLarge *requestTooLargeError
+	if errors.As(err, &tooLarge) {
+		t.Fatalf("malformed JSON under the limit should not be *requestTooLargeError, got %v", err)
+	}
+}
+
+func TestWriteRequestError(t *testing.T) {
+	t.Run("request too large maps to 413", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		writeRequestError(rec, &requestTooLargeError{size: 200, exact: true, limit: 100})
+
+		if rec.Code != http.StatusRequestEntityTooLarge {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+		}
+		var payload struct {
+			Error struct {
+				Type string `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(rec.Body.String())), &payload); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if payload.Error.Type != "request_too_large" {
+			t.Errorf("error.type = %q, want %q", payload.Error.Type, "request_too_large")
+		}
+	})
+
+	t.Run("other error maps to 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		writeRequestError(rec, errors.New("boom"))
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+		var payload struct {
+			Error struct {
+				Type string `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(rec.Body.String())), &payload); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if payload.Error.Type != "invalid_request_error" {
+			t.Errorf("error.type = %q, want %q", payload.Error.Type, "invalid_request_error")
+		}
+	})
+}

--- a/internal/app/messages/service.go
+++ b/internal/app/messages/service.go
@@ -19,6 +19,7 @@ type Service struct {
 	client            kiroclient.Client
 	captureEnabled    bool
 	keepAliveInterval time.Duration
+	maxRequestBytes   int
 }
 
 // Option configures a Service.
@@ -35,6 +36,12 @@ func WithCapture(enabled bool) Option {
 // A zero duration disables the heartbeat.
 func WithKeepAliveInterval(interval time.Duration) Option {
 	return func(s *Service) { s.keepAliveInterval = interval }
+}
+
+// WithMaxRequestBytes caps the client request body the service will read.
+// Zero means unlimited.
+func WithMaxRequestBytes(n int) Option {
+	return func(s *Service) { s.maxRequestBytes = n }
 }
 
 // New constructs a message service.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,12 @@ import (
 const (
 	// DefaultOTelBodyLimit is the default max bytes of request body to capture in OTel spans.
 	DefaultOTelBodyLimit = 32 * 1024
+	// DefaultMaxRequestBytes is the default max accepted client request body
+	// size. It matches the 32 MB the Anthropic Messages API accepts, which is
+	// what clients budget against: an image-heavy conversation resends every
+	// prior image block on every turn, so a lower proxy-side cap wedges a
+	// session that upstream would have served.
+	DefaultMaxRequestBytes = 32 << 20
 	// DefaultKeepAliveInterval is the default idle time between SSE keep-alive comments.
 	DefaultKeepAliveInterval = 15 * time.Second
 )
@@ -39,10 +45,13 @@ type Config struct {
 	// ModelDiscovery enables fetching Kiro's model catalog at startup so newly
 	// launched models resolve without a kirocc release. Built-in mappings always
 	// win; discovery only fills gaps.
-	ModelDiscovery    bool
-	Debug             bool
-	OTel              bool
-	OTelBodyLimit     int
+	ModelDiscovery bool
+	Debug          bool
+	OTel           bool
+	OTelBodyLimit  int
+	// MaxRequestBytes caps the client request body kirocc will read. 0 means
+	// unlimited.
+	MaxRequestBytes   int
 	KeepAliveInterval time.Duration
 	LogFile           logging.LogFileConfig
 }
@@ -99,6 +108,9 @@ func ApplyEnvOverrides(cfg *Config) error {
 	if err := applyInt("KIROCC_OTEL_BODY_LIMIT", &cfg.OTelBodyLimit); err != nil {
 		return err
 	}
+	if err := applyInt("KIROCC_MAX_REQUEST_BYTES", &cfg.MaxRequestBytes); err != nil {
+		return err
+	}
 	if err := applyDuration("KIROCC_KEEPALIVE_INTERVAL", &cfg.KeepAliveInterval); err != nil {
 		return err
 	}
@@ -133,6 +145,9 @@ func (c *Config) Validate() error {
 	}
 	if c.OTelBodyLimit < 0 {
 		return fmt.Errorf("otel-body-limit must be >= 0, got %d", c.OTelBodyLimit)
+	}
+	if c.MaxRequestBytes < 0 {
+		return fmt.Errorf("max-request-bytes must be >= 0, got %d", c.MaxRequestBytes)
 	}
 	if c.KeepAliveInterval != 0 && c.KeepAliveInterval < time.Second {
 		return fmt.Errorf("keepalive-interval must be 0 or >= 1s, got %s", c.KeepAliveInterval)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,12 +257,52 @@ func TestConfig_Validate(t *testing.T) {
 		{"region with userinfo injection", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "a@evil.com"}, true},
 		{"region with leading hyphen", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: "-us-east-1"}, true},
 		{"region too long", Config{Host: "127.0.0.1", Port: 3456, KiroAPIRegion: strings.Repeat("a", maxRegionLen+1)}, true},
+		{"max-request-bytes zero", Config{Host: "127.0.0.1", Port: 3456, MaxRequestBytes: 0}, false},
+		{"max-request-bytes positive", Config{Host: "127.0.0.1", Port: 3456, MaxRequestBytes: 1024}, false},
+		{"max-request-bytes negative", Config{Host: "127.0.0.1", Port: 3456, MaxRequestBytes: -1}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.cfg.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApplyEnvOverrides_MaxRequestBytes(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		initial      int
+		want         int
+		wantApplyErr bool
+		wantValidErr bool
+	}{
+		{name: "override", value: "1048576", initial: DefaultMaxRequestBytes, want: 1048576},
+		{name: "disabled", value: "0", initial: DefaultMaxRequestBytes, want: 0},
+		{name: "negative", value: "-1", initial: DefaultMaxRequestBytes, want: -1, wantValidErr: true},
+		{name: "invalid", value: "not-a-number", initial: DefaultMaxRequestBytes, want: DefaultMaxRequestBytes, wantApplyErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KIROCC_MAX_REQUEST_BYTES", tt.value)
+			cfg := Config{Host: "127.0.0.1", Port: 3456, MaxRequestBytes: tt.initial}
+
+			err := ApplyEnvOverrides(&cfg)
+			if (err != nil) != tt.wantApplyErr {
+				t.Fatalf("ApplyEnvOverrides() err = %v, wantApplyErr = %v", err, tt.wantApplyErr)
+			}
+			if tt.wantApplyErr {
+				return
+			}
+			if cfg.MaxRequestBytes != tt.want {
+				t.Fatalf("MaxRequestBytes = %v, want %v", cfg.MaxRequestBytes, tt.want)
+			}
+			if err := cfg.Validate(); (err != nil) != tt.wantValidErr {
+				t.Fatalf("Validate() err = %v, wantValidErr = %v", err, tt.wantValidErr)
 			}
 		})
 	}

--- a/internal/httpx/error.go
+++ b/internal/httpx/error.go
@@ -8,10 +8,11 @@ import (
 
 // Anthropic-compatible error type constants.
 const (
-	ErrTypeInvalidRequest = "invalid_request_error"
-	ErrTypeAPI            = "api_error"
-	ErrTypeAuthentication = "authentication_error"
-	ErrTypeStream         = "stream_error"
+	ErrTypeInvalidRequest  = "invalid_request_error"
+	ErrTypeRequestTooLarge = "request_too_large"
+	ErrTypeAPI             = "api_error"
+	ErrTypeAuthentication  = "authentication_error"
+	ErrTypeStream          = "stream_error"
 )
 
 // WriteError writes an Anthropic-compatible JSON error response.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,12 @@ func WithKeepAliveInterval(interval time.Duration) ServerOption {
 	return func(s *Server) { s.keepAliveInterval = interval }
 }
 
+// WithMaxRequestBytes caps the client request body the messages service reads.
+// Zero means unlimited.
+func WithMaxRequestBytes(n int) ServerOption {
+	return func(s *Server) { s.maxRequestBytes = n }
+}
+
 // Server is the HTTP server for the kirocc proxy.
 type Server struct {
 	apiKey            string
@@ -38,6 +44,7 @@ type Server struct {
 	otelBodyLimit     int
 	captureEnabled    bool
 	keepAliveInterval time.Duration
+	maxRequestBytes   int
 	mux               *http.ServeMux
 	messages          *messagesapp.Service
 }
@@ -54,6 +61,7 @@ func New(authMgr messagesapp.TokenGetter, apiKey string, client kiroclient.Clien
 	s.messages = messagesapp.New(authMgr, client,
 		messagesapp.WithCapture(s.captureEnabled),
 		messagesapp.WithKeepAliveInterval(s.keepAliveInterval),
+		messagesapp.WithMaxRequestBytes(s.maxRequestBytes),
 	)
 	s.registerRoutes()
 	return s

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json/v2"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -558,6 +559,90 @@ func TestGetModels_GPTModelsListedOnce(t *testing.T) {
 		if counts[id] != 1 {
 			t.Errorf("model %q listed %d times, want exactly 1", id, counts[id])
 		}
+	}
+}
+
+func TestPostMessages_RequestTooLarge(t *testing.T) {
+	const limit = 200
+	mgr := &mockAuthManager{
+		creds: &auth.Credentials{
+			AccessToken: "test-token",
+			ProfileARN:  "arn:test",
+			Region:      "us-east-1",
+		},
+	}
+	s := New(mgr, "", &mockKiroClient{}, WithMaxRequestBytes(limit))
+	srv := newTCP4TestServer(t, s.Handler())
+	defer srv.Close()
+
+	pad := strings.Repeat("a", 1000)
+	oversized := `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"` + pad + `"}]}`
+
+	// Deliberately no X-Claude-Code-Session-Id header: the size check must run
+	// before the session-header check so an oversized request is diagnosable
+	// without the client having to get anything else right first.
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/messages", strings.NewReader(oversized))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d, body = %s", resp.StatusCode, http.StatusRequestEntityTooLarge, body)
+	}
+
+	var payload struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.UnmarshalRead(resp.Body, &payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if payload.Error.Type != "request_too_large" {
+		t.Errorf("error.type = %q, want %q", payload.Error.Type, "request_too_large")
+	}
+	if !strings.Contains(payload.Error.Message, fmt.Sprint(len(oversized))) {
+		t.Errorf("message %q should name the observed size %d", payload.Error.Message, len(oversized))
+	}
+	if !strings.Contains(payload.Error.Message, fmt.Sprint(limit)) {
+		t.Errorf("message %q should name the configured limit %d", payload.Error.Message, limit)
+	}
+}
+
+func TestPostMessages_UnderLimit_NotRequestTooLarge(t *testing.T) {
+	const limit = 1 << 20 // 1 MiB, well over the small test body below
+	mgr := &mockAuthManager{
+		creds: &auth.Credentials{
+			AccessToken: "test-token",
+			ProfileARN:  "arn:test",
+			Region:      "us-east-1",
+		},
+	}
+	client := &mockKiroClient{
+		handler: func(ctx context.Context, token string, payload *kiroproto.Payload, region string) (*kiroclient.Response, error) {
+			p, _ := json.Marshal(map[string]string{"content": "ok"})
+			body := buildEventStream("assistantResponseEvent", p)
+			return &kiroclient.Response{StatusCode: 200, Body: body, Header: http.Header{}}, nil
+		},
+	}
+	s := New(mgr, "", client, WithMaxRequestBytes(limit))
+	srv := newTCP4TestServer(t, s.Handler())
+	defer srv.Close()
+
+	resp := postMessages(t, srv.URL, `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"stream":false}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want != %d, body = %s", resp.StatusCode, http.StatusRequestEntityTooLarge, body)
 	}
 }
 


### PR DESCRIPTION
## Summary

The client request-body cap in `parseAndValidateRequest` is hardcoded at `4<<20`, undocumented, and one eighth of the 32 MB the Anthropic Messages API accepts. This makes it configurable (defaulting to 32 MiB), returns a diagnosable 413 instead of a leaked decoder string, and logs the body size per request.

Scoped to that one concern — no unrelated changes.

## The failure

Images cross it. A request carries the whole conversation, so every screenshot sent earlier is re-sent on every subsequent turn and the body only grows. Past roughly 8–9 screenshots a Claude Code session is **permanently wedged**: every retry sends the same oversized body. I hit this twice in one day, killing two consecutive sessions (6 failed requests).

The error made it hard to diagnose. `MaxBytesReader` trips mid-decode, so the client gets the decoder's internal string as a 400:

```
API Error: 400 invalid request: jsontext: read error: http: request body too large
```

No size in it, and nothing to distinguish "too big" (actionable — drop images, `/compact`) from "malformed" (not). The failure also precedes field extraction, so the log line carries no `session_id` or `model`, and there is no matching `--> POST` line:

```
14:58:13 WRN invalid request trace_id=9d75363a err="invalid request: jsontext: read error: http: request body too large"
15:03:08 WRN invalid request trace_id=893d82a6 err="..."   # retry
15:04:14 WRN invalid request trace_id=fc429598 err="..."   # retry
15:11:45 WRN invalid request trace_id=07ae2e90 err="..."   # next session, same wall
```

Measured from the two dead transcripts — text was 0.14 MiB of the 4.33 MiB request; images were 96%:

| request | payload | image blocks | outcome |
|---|---|---|---|
| last good | 3.48 MiB | 9 | 200 |
| next one | 4.33 MiB | 11 | 400 ×2 |

## Changes

1. **`-max-request-bytes` / `KIROCC_MAX_REQUEST_BYTES`**, default `32<<20`, `0` = unlimited. Wired through `internal/config` following the existing `OTelBodyLimit` / `KIROCC_OTEL_BODY_LIMIT` pattern, then `server.WithMaxRequestBytes` → `messagesapp.WithMaxRequestBytes` following `WithKeepAliveInterval`.

2. **HTTP 413 `request_too_large`**, naming the actual size and the limit, and pointing at `/compact`. `Content-Length` is checked first, so an oversized body is rejected without reading it. Malformed JSON still returns 400 — the two are now distinguishable, which is what lets a client stop retrying.

3. **`body_bytes` on `--> POST /v1/messages`**. This would have made the failure self-diagnosing: the growth curve toward the cap is visible one request before the cliff.

Plus a short README note (options table, env-var table, and a paragraph explaining that retrying cannot work).

## On the default of 32 MiB

Raising a limit deserves scrutiny, so to be explicit: 32 MB is [Anthropic's own documented Messages API limit](https://docs.anthropic.com/en/docs/vision), which is what clients budget against — this aligns kirocc with upstream rather than inventing a number. The listener is loopback-bound by default and serves a single trusted client, so the DoS threat model the 4 MiB guard implies barely applies; and the cap stays configurable, so anyone who wants it lower (or off) can set it.

## Why rejected bodies are drained

The one non-obvious part of the diff, and worth explaining because it is easy to read as unnecessary.

Answering a 413 without reading the body leaves unread bytes on the connection. Many HTTP clients write the entire request before reading any of the response — Python's `urllib` does — and for those the close arrives as a **connection reset instead of the 413**, trading a diagnosable error for a transport failure. That would defeat the point of change 2.

Verified against a running proxy with a 1 MiB cap and a 2 MiB body:

| client | without drain | with drain |
|---|---|---|
| curl | 413 | 413 |
| node / undici | 413 | 413 |
| python urllib | `ECONNRESET` | 413 |

So the rejected body is drained before answering, bounded at 64 MiB so a hostile body cannot make kirocc read forever. nginx solves the same problem the same way, with `lingering_close`.

The drain also improves the reported size: reading to EOF yields the true total, so a body sent without a `Content-Length` (chunked) still reports its real size rather than a lower bound.

## Tests

Added, following the existing patterns in `internal/config` and `internal/server`:

- `internal/config`: `KIROCC_MAX_REQUEST_BYTES` env override (valid / `0` / negative / non-numeric) and `Validate()` rows.
- `cmd/kirocc`: `-max-request-bytes` default, explicit value, and `0`.
- `internal/app/messages`: the `Content-Length` fast path, the unknown-length path (which pins that `errors.As(err, &maxErr)` survives the `jsontext` decoder's wrapping), under-limit, unlimited, malformed-JSON-is-not-413, that both rejection paths drain the body, and that the drain stays bounded on an endless body.
- `internal/server`: an oversized POST to `/v1/messages` gets 413 with both sizes named — asserted **without** an `X-Claude-Code-Session-Id` header, pinning that the size check runs before the session-header check, which is what makes an oversized request diagnosable without the client having to get anything else right first.

## Verification

- `go test -race ./...` passes; `go vet`, `golangci-lint run` (0 issues), `go mod tidy` and `go fix` all clean.
- Against a patched binary on a spare port (boundary confirmed by binary search): 33,554,432 bytes accepted, +1 → 413. `KIROCC_MAX_REQUEST_BYTES=0` accepted a 48 MiB body. `body_bytes: 90` on a successful request matched the request file exactly.

## Note on behaviour change

Oversized requests now return **413** rather than 400, and the error type is `request_too_large` rather than `invalid_request_error`. This matches what the Anthropic API returns for this condition, so it moves toward upstream fidelity, but it is a visible change for anything matching on the old status or message.
