### PR TITLE
feat: upgrade to Go 1.27 and drop GOEXPERIMENT=jsonv2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
     types: [ opened, synchronize ]
     paths-ignore: [ '**.md' ]
 
-env:
-  GOEXPERIMENT: jsonv2
-
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: write
 
-env:
-  GOEXPERIMENT: jsonv2
-
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,6 @@ builds:
     binary: kirocc
     env:
       - CGO_ENABLED=0
-      - GOEXPERIMENT=jsonv2
     flags:
       - -trimpath
     goos:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 ## Project Overview
 
 **Project type:** CLI tool — local proxy server (Anthropic Messages API → Kiro backend)
-**Primary language:** Go (requires `GOEXPERIMENT=jsonv2`)
+**Primary language:** Go
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-export GOEXPERIMENT := jsonv2
 
 BIN := dist/kirocc
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Just set `ANTHROPIC_BASE_URL` from any Anthropic API client (e.g., Claude Code) 
 
 ## Prerequisites
 
-- Go 1.26+
+- Go 1.27+
 - One of the following:
   - [Kiro CLI](https://kiro.dev) installed and logged in, **or**
   - A Kiro API key (`KIRO_API_KEY`) — available for [Kiro Pro, Pro+, Pro Max, and Power](https://kiro.dev/docs/cli/authentication/) subscribers
@@ -127,7 +127,7 @@ API keys are available for Kiro Pro, Pro+, Pro Max, and Power subscribers. On gr
 | ------- | ----------------------------------------------------- |
 | macOS   | `~/Library/Application Support/kiro-cli/data.sqlite3` |
 | Linux   | `~/.local/share/kiro-cli/data.sqlite3`                |
-| Windows | `%LOCALAPPDATA%\kiro-cli\data.sqlite3`               |
+| Windows | `%LOCALAPPDATA%\kiro-cli\data.sqlite3`                |
 
 ### Environment variables
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/d-kuro/kirocc
 
-go 1.26.1
+go 1.27.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/app/messages/errors.go
+++ b/internal/app/messages/errors.go
@@ -82,8 +82,7 @@ func classifyUpstreamError(isException bool, invalidReason, upstreamMessage stri
 func logUpstreamError(ctx context.Context, short string, err error, extra ...any) {
 	attrs := []any{"trace_id", short, "err", err}
 	attrs = append(attrs, extra...)
-	var ue *kiroclient.UpstreamError
-	if errors.As(err, &ue) {
+	if ue, ok := errors.AsType[*kiroclient.UpstreamError](err); ok {
 		attrs = append(attrs,
 			"status", ue.Status,
 			"content_type", ue.ContentType,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,18 +3,12 @@ pre-commit:
   commands:
     golangci-lint:
       glob: "*.go"
-      env:
-        GOEXPERIMENT: jsonv2
       run: golangci-lint run --fix ./...
     golangci-lint-fmt:
       glob: "*.go"
-      env:
-        GOEXPERIMENT: jsonv2
       run: golangci-lint fmt ./...
     go-fix:
       glob: "*.go"
-      env:
-        GOEXPERIMENT: jsonv2
       run: go fix ./...
     oxfmt:
       glob: "*.md"


### PR DESCRIPTION
## Summary

- Bump the minimum Go version to 1.27.0 in `go.mod`
- Remove `GOEXPERIMENT=jsonv2` from the Makefile, goreleaser config, lefthook hooks, and CI/release workflows — `encoding/json/v2` and `encoding/json/jsontext` are part of the standard library in Go 1.27, so the opt-in flag is no longer needed (it flipped to an opt-out `nojsonv2`)
- Update README prerequisites (Go 1.27+) and CLAUDE.md accordingly

## Testing

- `go mod tidy` — no changes
- `go build` and `go test -race ./...` with the Go 1.27.0 toolchain — all 19 packages pass
- `golangci-lint run` — 0 issues