### PR TITLE
Release v0.11.0

### DIFF
--- a/docs/release-notes/v0.11.0.md
+++ b/docs/release-notes/v0.11.0.md
@@ -1,0 +1,35 @@
+# Release v0.11.0
+
+## New Features
+
+### Go 1.27 Upgrade (#114)
+
+kirocc now requires Go 1.27. The `encoding/json/v2` and `encoding/json/jsontext` packages became part of the standard library in Go 1.27, so building kirocc no longer requires `GOEXPERIMENT=jsonv2`. The flag has been removed from the Makefile, goreleaser config, lefthook hooks, and CI workflows.
+
+If you build from source, plain `go build ./cmd/kirocc` now works with Go 1.27+ — no environment variables needed.
+
+## Bug Fixes
+
+### Windows Default Database Path (#110)
+
+Windows previously fell through to the Linux default (`~/.local/share/kiro-cli/data.sqlite3`), while Kiro CLI stores its database under `%LOCALAPPDATA%\kiro-cli`. Database-backed authentication failed with SQLite error 14 unless `-db` or `KIROCC_DB_PATH` was set manually. The default now resolves to LocalAppData on Windows; macOS and Linux defaults are unchanged.
+
+## Contributors
+
+- @wilsonwangdev (#110)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.11.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.10.0...v0.11.0


### PR DESCRIPTION
## Summary

Release v0.11.0

See `docs/release-notes/v0.11.0.md` for details.