### PR TITLE
Release v0.11.1

### DIFF
--- a/docs/release-notes/v0.11.1.md
+++ b/docs/release-notes/v0.11.1.md
@@ -1,0 +1,35 @@
+# Release v0.11.1
+
+## Bug Fixes
+
+### Streamed Text No Longer Loses Characters at Frame Seams (#116)
+
+Streamed responses silently lost characters whenever a frame boundary split a repeated byte (`password` → `pasword`, `succeeded` → `succded`). In prose this read as a model typo; in generated code it produced identifiers that failed at runtime.
+
+The root cause was in the response conversion pipeline: `ComputeDelta` assumed the Kiro backend streams cumulative text and used a KMP overlap fallback to deduplicate, but the backend actually streams incremental frames (measured 761/761 incremental; all AWS first-party clients do a plain append). The overlap fallback deleted bytes that had never been duplicated. The delta computation has been removed entirely — frames are now concatenated verbatim on both the text and reasoning streams, matching the first-party parsers.
+
+Reported in #112 with an exceptionally thorough investigation by @jwuser00.
+
+### Dependency Update (#111)
+
+- Update `modernc.org/sqlite` to v1.57.0
+
+## Contributors
+
+- @jwuser00 (#112)
+
+## Upgrade Instructions
+
+### Homebrew
+
+```bash
+brew upgrade kirocc
+```
+
+### go install
+
+```bash
+go install github.com/d-kuro/kirocc/cmd/kirocc@v0.11.1
+```
+
+**Full Changelog**: https://github.com/d-kuro/kirocc/compare/v0.11.0...v0.11.1


### PR DESCRIPTION
## Summary

Release v0.11.1

See `docs/release-notes/v0.11.1.md` for details.