### PR TITLE
feat(homebrew): publish formula with brew services support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,37 @@ homebrew_casks:
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/kirocc"]
           end
 
+brews:
+  - name: kirocc
+    repository:
+      owner: d-kuro
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/d-kuro/kirocc"
+    description: "Local proxy server that relays Anthropic Messages API requests to the Kiro backend"
+    license: "Apache-2.0"
+    url_template: "https://github.com/d-kuro/kirocc/releases/download/{{.Tag}}/{{.ArtifactName}}"
+    targets:
+      - darwin_arm64
+      - darwin_amd64
+    service: |
+      run [opt_bin/"kirocc"]
+      keep_alive true
+      log_path var/"log/kirocc.log"
+      error_log_path var/"log/kirocc.log"
+      working_dir Dir.home
+    extra_install: |
+      if OS.mac?
+        quiet_system "/usr/bin/xattr", "-d", "com.apple.quarantine", bin/"kirocc"
+      end
+    caveats: |
+      kirocc is a local proxy that needs Kiro CLI installed and logged in.
+    test: |
+      output = shell_output("#{bin}/kirocc -h 2>&1")
+      assert_match "listen port", output
+      assert_match "kiro-api-key", output
+
 release:
   draft: false
   prerelease: auto

--- a/README.md
+++ b/README.md
@@ -36,8 +36,27 @@ Just set `ANTHROPIC_BASE_URL` from any Anthropic API client (e.g., Claude Code) 
 ### Homebrew
 
 ```bash
-brew install d-kuro/tap/kirocc
+brew install d-kuro/tap/kirocc --trust
 ```
+
+`d-kuro/tap` ships both a **cask** and a **formula**. The formula (`brew services`
+capable) is what you want if you intend to run kirocc as a background service; the
+cask is useful for one-off manual runs.
+
+#### Run as a service (recommended)
+
+The Homebrew formula installs a launchd-managed service so kirocc starts at login
+and stays running:
+
+```bash
+brew services start d-kuro/tap/kirocc   # start now and at login
+brew services list                      # verify it shows "Started"
+brew services stop d-kuro/tap/kirocc    # stop it
+```
+
+Within the service, kirocc resolves its default credential database relative to your
+home directory, so no extra configuration is needed for it to find the existing Kiro CLI
+login.
 
 ### go install
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Just set `ANTHROPIC_BASE_URL` from any Anthropic API client (e.g., Claude Code) 
 brew install d-kuro/tap/kirocc --trust
 ```
 
-`d-kuro/tap` ships both a **cask** and a **formula**. The formula (`brew services`
-capable) is what you want if you intend to run kirocc as a background service; the
-cask is useful for one-off manual runs.
+`d-kuro/tap` ships both a **cask** and a **formula**. `brew install` resolves to the
+formula, which installs the binary to `$(brew --prefix)/bin` so `kirocc` works as a
+plain command. The formula also supports `brew services` for background use.
 
 #### Run as a service (recommended)
 


### PR DESCRIPTION
## Summary

Add a Homebrew **formula** (alongside the existing cask) so `kirocc` can run as a managed background service via `brew services`.

Closes #106.

## Motivation

kirocc is a long-lived local proxy that clients point `ANTHROPIC_BASE_URL` at. Users reasonably expect to be able to keep it running without a persistent terminal session. The existing cask doesn't support `brew services`; a formula does.

## Changes

### `.goreleaser.yaml` — new `brews:` formula block

Publishes `Formula/kirocc.rb` to `d-kuro/homebrew-tap` alongside the existing `Casks/kirocc.rb`. The formula:

- installs the binary to `bin/kirocc`
- strips the macOS quarantine attribute on install (same workaround as the cask — upstream binaries are ad-hoc signed, not notarized)
- declares an interactive, long-lived service:

  ```ruby
  service do
    run [opt_bin/"kirocc"]
    keep_alive true
    log_path var/"log/kirocc.log"
    error_log_path var/"log/kirocc.log"
    working_dir Dir.home
  end
  ```

  `working_dir Dir.home` ensures the default credential DB path (`~/Library/Application Support/kiro-cli/data.sqlite3`) resolves correctly when running as a launchd service.

- adds a `brew test` block (validates `--help` output)
- adds a caveat noting the Kiro CLI login prerequisite

**Note on deprecation:** GoReleaser's `brews` key has been soft-deprecated since v2.10 in favour of `homebrew_casks`. It still works today (v2.18) and only emits a warning. The `homebrew_casks` block is left untouched. Once GoReleaser v3 ships (or a `brew services`-capable cask path becomes available), this can be revisited.

### `README.md` — updated Homebrew install section

- adds `--trust` to the `brew tap` step (required for third-party taps)
- documents `brew services start/stop/list`
- notes that the formula resolves the credential DB path relative to the user's home directory

## Testing

Validated config structure against goreleaser's current `brews` template (`internal/pipe/brew/templates/formula.rb`). Reference formula used in validation: [`kylerjensen/homebrew-tap@b0ddec3 Formula/kirocc.rb`](https://github.com/kylerjensen/homebrew-tap/blob/b0ddec3/Formula/kirocc.rb) — end-to-end tested on macOS arm64 (service starts, Gatekeeper does not block).
