### PR TITLE
feat: support Kiro's Auto model selection

### DIFF
--- a/internal/app/messages/effort_test.go
+++ b/internal/app/messages/effort_test.go
@@ -58,6 +58,13 @@ func TestResolveEffort(t *testing.T) {
 		{name: "gpt disabled beats explicit effort", kiroModel: "gpt-5.6-luna", effort: "high", thinkingType: anthropic.ThinkingTypeDisabled, want: "none"},
 		// Claude models never receive none: disabled just means no thinking fallback.
 		{name: "claude disabled does not map to none", kiroModel: "claude-opus-4.8", thinkingType: anthropic.ThinkingTypeDisabled, want: ""},
+
+		// Auto: backend selects the model, so effort is always dropped — even
+		// when thinking is enabled (which would otherwise try a default effort).
+		{name: "auto explicit effort dropped", kiroModel: "auto", effort: "high", want: ""},
+		{name: "auto thinking only drops effort", kiroModel: "auto", thinking: true, want: ""},
+		{name: "auto no intent drops effort", kiroModel: "auto", want: ""},
+		{name: "auto claude-auto thinking drops effort", kiroModel: "claude-auto", thinking: true, want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/models/effort.go
+++ b/internal/models/effort.go
@@ -60,7 +60,7 @@ var effortCapabilities = map[string]effortCapability{
 	"gpt-5.6-terra": {reasoning: true, levels: reasoningEffortLevels},
 	"gpt-5.6-luna":  {reasoning: true, levels: reasoningEffortLevels},
 	// Auto: backend selects the model, bypasses all effort/thinking.
-	"auto":          {levels: nil},
+	"auto": {levels: nil},
 }
 
 // IsReasoningModel reports whether the resolved Kiro model belongs to a
@@ -96,6 +96,12 @@ func ResolveEffort(kiroModel, requested string) string {
 			return ""
 		}
 		capability = effortCapability{levels: enum}
+	}
+	// A capability that reports no effort levels does not support effort at
+	// all. The `auto` SKU is one such model: the backend selects the model and
+	// its capabilities, so any effort request is dropped, never guessed.
+	if len(capability.levels) == 0 {
+		return ""
 	}
 	// Enum membership wins: accepts model-specific values like "none" that
 	// are not rankable levels.

--- a/internal/models/effort.go
+++ b/internal/models/effort.go
@@ -59,6 +59,8 @@ var effortCapabilities = map[string]effortCapability{
 	"gpt-5.6-sol":   {reasoning: true, levels: reasoningEffortLevels},
 	"gpt-5.6-terra": {reasoning: true, levels: reasoningEffortLevels},
 	"gpt-5.6-luna":  {reasoning: true, levels: reasoningEffortLevels},
+	// Auto: backend selects the model, bypasses all effort/thinking.
+	"auto":          {levels: nil},
 }
 
 // IsReasoningModel reports whether the resolved Kiro model belongs to a

--- a/internal/models/effort_test.go
+++ b/internal/models/effort_test.go
@@ -57,6 +57,13 @@ func TestResolveEffort(t *testing.T) {
 		// none must never leak into Claude models (would clamp to max).
 		{"opus-4.8 none dropped not clamped", "claude-opus-4.8", "none", ""},
 		{"sonnet-4.6 none dropped not clamped", "claude-sonnet-4.6", "none", ""},
+
+		// Auto: backend selects the model, so effort is always dropped.
+		{"auto max dropped", "auto", "max", ""},
+		{"auto high dropped", "auto", "high", ""},
+		{"auto medium dropped", "auto", "medium", ""},
+		{"auto none dropped", "auto", "none", ""},
+		{"auto empty", "auto", "", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -106,6 +106,9 @@ var modelMapOrdered = []Mapping{
 	{Anthropic: "claude-gpt-5.6-sol", Kiro: "gpt-5.6-sol", ContextWindowSize: 272_000, DisplayName: "GPT 5.6 Sol"},
 	{Anthropic: "claude-gpt-5.6-terra", Kiro: "gpt-5.6-terra", ContextWindowSize: 272_000, DisplayName: "GPT 5.6 Terra"},
 	{Anthropic: "claude-gpt-5.6-luna", Kiro: "gpt-5.6-luna", ContextWindowSize: 272_000, DisplayName: "GPT 5.6 Luna"},
+	// Auto model: passes `auto` through to the Kiro backend, bypasses
+	// thinking/effort resolution. Advertised as `claude-auto`.
+	{Anthropic: "claude-auto", Kiro: "auto", DisplayName: "Auto"},
 }
 
 const DefaultModel = "claude-sonnet-4.6"
@@ -200,6 +203,12 @@ func effectiveMappings() []Mapping {
 // Upstream `kiroModel` is never `[1m]`-suffixed — it always comes from
 // mapping tables. KIROCC_MODEL_MAPPINGS env var can override mappings.
 func Resolve(model string, context1M bool) (kiroModel string, thinking bool, contextWindowSize int, anthropicModel string) {
+	// Auto passes `auto` through to the Kiro backend and bypasses
+	// thinking/effort resolution.
+	if model == "auto" || model == "claude-auto" {
+		return "auto", false, 0, model
+	}
+
 	model = normalizeThinkingSuffix(model)
 
 	var matchedWindowSize int

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -478,6 +478,9 @@ func TestListModels_DisplayNames(t *testing.T) {
 		{id: "claude-gpt-5.6-sol", want: "GPT 5.6 Sol"},
 		{id: "claude-gpt-5.6-terra", want: "GPT 5.6 Terra"},
 		{id: "claude-gpt-5.6-luna", want: "GPT 5.6 Luna"},
+		// Auto model: advertised as claude-auto with display name "Auto".
+		{id: "claude-auto", want: "Auto"},
+		{id: "auto"},
 		// Canonical SKUs are advertised unlabelled.
 		{id: "gpt-5.6-sol"},
 		{id: "claude-opus-5"},
@@ -603,16 +606,36 @@ func TestIsReasoningModel_EnvAliasToGPT(t *testing.T) {
 }
 
 func TestResolve_EnvAliasToGPT_SuffixStillRejected(t *testing.T) {
-	// The tier-2 [1m]-strip exclusion is judged by the resolved Kiro model's
-	// intrinsic capability, so an env alias to a GPT model inherits it. Both
-	// the canonical ID and the alias must reject the suffix and fall through
-	// to the default fallback.
+	// The tier-2 [1m]-strip exclusion is judged by the resolved Kiro
+	// model's intrinsic capability, so an env alias to a GPT model
+	// inherits it. Both the canonical ID and the alias must reject the
+	// suffix and fall through to the default fallback.
 	t.Setenv("KIROCC_MODEL_MAPPINGS", `[{"anthropic":"my-gpt","kiro":"gpt-5.6-sol","context_window_size":272000}]`)
 
 	for _, model := range []string{"gpt-5.6-sol[1m]", "my-gpt[1m]"} {
 		kiroModel, _, _, _ := Resolve(model, false)
 		if kiroModel != DefaultModel {
 			t.Errorf("Resolve(%q) kiroModel = %q, want default fallback %q", model, kiroModel, DefaultModel)
+		}
+	}
+}
+
+func TestResolve_AutoModel(t *testing.T) {
+	// Auto bypasses thinking/effort resolution and passes `auto`
+	// through to the Kiro backend.
+	for _, model := range []string{"auto", "claude-auto"} {
+		kiroModel, thinking, window, anthropicModel := Resolve(model, false)
+		if kiroModel != "auto" {
+			t.Errorf("Resolve(%q) kiroModel = %q, want auto", model, kiroModel)
+		}
+		if thinking {
+			t.Errorf("Resolve(%q) thinking = %v, want false", model, thinking)
+		}
+		if window != 0 {
+			t.Errorf("Resolve(%q) window = %d, want 0", model, window)
+		}
+		if anthropicModel != model {
+			t.Errorf("Resolve(%q) anthropicModel = %q, want %q", model, anthropicModel, model)
 		}
 	}
 }


### PR DESCRIPTION
Implements d-kuro/kirocc#123: Support Kiro's Auto model selection.

- `/v1/models` advertises `claude-auto` with display name "Auto"
- `/v1/messages` accepts both `auto` and `claude-auto`
- Auto bypasses thinking/effort resolution, passing `auto` through to the Kiro backend
- Add `auto` to effort capabilities
- Added tests for Resolve and ListModels behavior

Closes #123

## Fix included on review

The initial draft added `auto` to the effort capability table with an empty level list, but `ResolveEffort` indexed `levels[len-1]` for any ranked effort request. A request for `auto` with `output_config.effort`, or with thinking enabled (which falls back to a default effort), crashed the proxy with an index-out-of-range panic instead of bypassing effort resolution.

`ResolveEffort` now drops effort for any capability that reports no levels, so `auto` requests always omit effort. Regression tests cover `ResolveEffort` and `resolveEffort` (explicit effort, thinking fallback, disabled thinking).