### PR TITLE
fix(respconv): flush held-back text at ToolSearch round boundaries

### DIFF
--- a/internal/respconv/streaming.go
+++ b/internal/respconv/streaming.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/d-kuro/kirocc/internal/anthropic"
 	"github.com/d-kuro/kirocc/internal/kiroproto"
@@ -419,7 +420,21 @@ func (s *SSEWriter) SetToolNameMap(m map[string]string) {
 
 // ResetAccumulator replaces the internal accumulator with a fresh one,
 // preserving the SSEWriter's block index and started state for continuation.
+// Flushes any text/thinking bytes the outgoing accumulator was still holding
+// back for cross-chunk boundary matching (a partial <thinking> tag or stop
+// sequence prefix) — otherwise those bytes are silently dropped at the round
+// boundary instead of carrying over to the next round's stream.
 func (s *SSEWriter) ResetAccumulator(contextWindowSize int, stopSequences []string, maxTokens int, preCountedInputTokens int) {
+	textDelta, thinkingDelta := s.acc.FinalizeStream()
+	if thinkingDelta != "" {
+		s.writeThinkingDelta(EventDelta{ThinkingDelta: thinkingDelta})
+	}
+	if textDelta != "" {
+		s.fireVisibleOutput()
+		s.switchBlock(anthropic.BlockTypeText)
+		s.writeDelta("text_delta", "text", textDelta)
+	}
+
 	filterNames := s.acc.dropToolNames
 	nameMap := s.acc.toolNameMap
 	s.acc = newAccumulator(contextWindowSize, stopSequences, maxTokens, preCountedInputTokens)
@@ -475,7 +490,20 @@ func (s *SSEWriter) captureWriterError() {
 
 // writeDelta writes a content_block_delta SSE event with a single string field.
 func (s *SSEWriter) writeDelta(deltaType, fieldName, value string) {
-	escaped, _ := json.Marshal(value)
+	escaped, err := json.Marshal(value)
+	if err != nil {
+		// json/v2 rejects invalid UTF-8 outright instead of escaping it, which
+		// would otherwise leave `escaped` empty and emit a malformed SSE line
+		// (`"text":`) that breaks the client's JSON parse for the whole event.
+		// Replace the invalid bytes rather than emit or silently drop them.
+		slog.WarnContext(s.ctx, "SSE delta value has invalid UTF-8, replacing", "event", deltaType, "err", err)
+		value = strings.ToValidUTF8(value, "�")
+		escaped, err = json.Marshal(value)
+		if err != nil {
+			slog.ErrorContext(s.ctx, "SSE delta JSON marshal failed after sanitizing", "event", deltaType, "err", err)
+			return
+		}
+	}
 	s.writeRawSSE("content_block_delta",
 		`{"type":"content_block_delta","index":%d,"delta":{"type":"%s","%s":%s}}`,
 		s.blockIndex, deltaType, fieldName, escaped)

--- a/internal/respconv/streaming_test.go
+++ b/internal/respconv/streaming_test.go
@@ -8,8 +8,37 @@ import (
 	"strings"
 	"testing"
 
+	"encoding/json/v2"
+
 	"github.com/d-kuro/kirocc/internal/kiroproto"
 )
+
+// concatTextDeltas extracts every content_block_delta text_delta from an SSE
+// body in order and returns the concatenated text.
+func concatTextDeltas(t *testing.T, sseBody string) string {
+	t.Helper()
+	var out strings.Builder
+	for _, line := range strings.Split(sseBody, "\n") {
+		data, ok := strings.CutPrefix(strings.TrimSpace(line), "data: ")
+		if !ok {
+			continue
+		}
+		var ev struct {
+			Type  string `json:"type"`
+			Delta struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"delta"`
+		}
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			continue
+		}
+		if ev.Type == "content_block_delta" && ev.Delta.Type == "text_delta" {
+			out.WriteString(ev.Delta.Text)
+		}
+	}
+	return out.String()
+}
 
 func TestSSEWriter_TextOnly(t *testing.T) {
 	w := httptest.NewRecorder()
@@ -500,5 +529,59 @@ func TestSSEWriter_MaxTokensRedactedOnly_StopsImmediately(t *testing.T) {
 	}
 	if !strings.Contains(body, "message_stop") {
 		t.Fatalf("missing message_stop: %s", body)
+	}
+}
+
+// TestSSEWriter_ResetAccumulator_FlushesHoldback is a regression test for a
+// byte-loss bug at ToolSearch round boundaries: a partial <thinking> tag or
+// stop-sequence prefix held back by the accumulator for cross-chunk boundary
+// matching was silently discarded when ResetAccumulator swapped in a fresh
+// accumulator for the next round, instead of being flushed first.
+func TestSSEWriter_ResetAccumulator_FlushesHoldback(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)
+
+	// "<" is a valid prefix of "<thinking>", so parseThinkingTags buffers it
+	// instead of emitting it, waiting to see whether a full tag follows.
+	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "5 < 6 and 7 <"})
+
+	// Simulate the ToolSearch orchestrator starting a new round: the held-back
+	// "<" must be flushed now, since a fresh accumulator has no memory of it.
+	sw.ResetAccumulator(200000, nil, 0, 0)
+
+	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "done"})
+	_ = sw.Finish()
+
+	got := concatTextDeltas(t, w.Body.String())
+	want := "5 < 6 and 7 <done"
+	if got != want {
+		t.Fatalf("concatenated text deltas = %q, want %q (round-boundary byte loss)", got, want)
+	}
+}
+
+// TestSSEWriter_WriteDelta_InvalidUTF8 is a regression test for a swallowed
+// json.Marshal error: encoding/json/v2 rejects invalid UTF-8 outright, and
+// discarding that error left `escaped` empty, emitting a malformed SSE line
+// (`"text":`) that breaks the client's JSON parse for the whole event.
+func TestSSEWriter_WriteDelta_InvalidUTF8(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := NewSSEWriter(context.Background(), w, "claude-sonnet-4.6", 200000, nil, 0, 0)
+
+	sw.HandleEvent(kiroproto.Event{Type: "assistantResponseEvent", Content: "abc\xffdef"})
+	_ = sw.Finish()
+
+	body := w.Body.String()
+	if strings.Contains(body, `"text":}`) || strings.Contains(body, `"text":,`) {
+		t.Fatalf("emitted malformed SSE delta for invalid UTF-8: %s", body)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		data, ok := strings.CutPrefix(strings.TrimSpace(line), "data: ")
+		if !ok || data == "" {
+			continue
+		}
+		var v any
+		if err := json.Unmarshal([]byte(data), &v); err != nil {
+			t.Fatalf("SSE data line is not valid JSON: %q: %v", data, err)
+		}
 	}
 }


### PR DESCRIPTION
Fixes two bugs in the streamed-text pipeline found while investigating a
report of dropped repeated letters:

- ResetAccumulator silently discarded text a prior ToolSearch/advisor round was still holding back at a round boundary (a partial <thinking> tag or stop-sequence prefix). Fixed by flushing the outgoing accumulator before replacing it.
- writeDelta swallowed a json.Marshal error; encoding/json/v2 rejects invalid UTF-8 outright, so a marshal failure emitted a malformed SSE delta line that would break a client's JSON parse for that event. Now replaces invalid bytes and retries instead of emitting broken output.

Closes #129
Closes #130

## Test plan
- Added TestSSEWriter_ResetAccumulator_FlushesHoldback and
  TestSSEWriter_WriteDelta_InvalidUTF8, both of which fail on the pre-fix
  code and pass after.
- go build ./..., go vet ./..., gofmt -l clean.
- go test -race ./... — all packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)